### PR TITLE
clipboard-sync behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ smithay-client-toolkit = { version = "0.19.1", default-features = false }
 [dev-dependencies]
 rustix = { workspace = true, features = ["fs"] }
 testwl = { path = "testwl" }
+
+[features]
+default = ["clipboard-sync"]
+clipboard-sync = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use xcb::x;
 
 pub trait XConnection: Sized + 'static {
     type ExtraData: FromServerState<Self>;
+    #[cfg(feature = "clipboard-sync")]
     type MimeTypeData: MimeTypeData;
 
     fn root_window(&self) -> x::Window;
@@ -30,6 +31,7 @@ pub trait FromServerState<C: XConnection> {
     fn create(state: &ServerState<C>) -> Self;
 }
 
+#[cfg(feature = "clipboard-sync")]
 pub trait MimeTypeData {
     fn name(&self) -> &str;
     fn data(&self) -> &[u8];
@@ -167,6 +169,7 @@ pub fn main(data: impl RunData) -> Option<()> {
         server_state.run();
         display.flush_clients().unwrap();
 
+        #[cfg(feature = "clipboard-sync")]
         if let Some(xstate) = &mut xstate {
             if let Some(sel) = server_state.new_selection() {
                 xstate.set_clipboard(sel);

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -1094,9 +1094,12 @@ where
                 .global_list
                 .registry()
                 .bind::<client::wl_seat::WlSeat, _, _>(data.name, server.version(), &state.qh, key);
+
+            #[cfg(feature = "clipboard-sync")]
             if let Some(c) = &mut state.clipboard_data {
                 c.device = Some(c.manager.get_data_device(&state.qh, &client));
             }
+
             GenericObject { server, client }.into()
         });
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -4,24 +4,29 @@ mod event;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "clipboard-sync")]
+use {
+    crate::MimeTypeData,
+    smithay_client_toolkit::data_device_manager::{
+        data_device::DataDevice, data_offer::SelectionOffer, data_source::CopyPasteSource,
+        DataDeviceManagerState,
+    },
+    std::rc::Rc,
+};
+
 use self::event::*;
 use super::FromServerState;
 use crate::clientside::*;
 use crate::xstate::{Atoms, WindowDims, WmHints, WmName, WmNormalHints};
-use crate::{MimeTypeData, XConnection};
+use crate::XConnection;
 use log::{debug, warn};
 use rustix::event::{poll, PollFd, PollFlags};
 use slotmap::{new_key_type, HopSlotMap, SparseSecondaryMap};
-use smithay_client_toolkit::data_device_manager::{
-    data_device::DataDevice, data_offer::SelectionOffer, data_source::CopyPasteSource,
-    DataDeviceManagerState,
-};
 use std::collections::HashMap;
 use std::io::Read;
 use std::io::Write;
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::net::UnixStream;
-use std::rc::Rc;
 use wayland_client::{globals::Global, protocol as client, Proxy};
 use wayland_protocols::{
     wp::{
@@ -430,6 +435,7 @@ pub struct ServerState<C: XConnection> {
     connection: Option<C>,
 
     xdg_wm_base: XdgWmBase,
+    #[cfg(feature = "clipboard-sync")]
     clipboard_data: Option<ClipboardData<C::MimeTypeData>>,
     last_kb_serial: Option<u32>,
 }
@@ -443,16 +449,18 @@ impl<C: XConnection> ServerState<C> {
             .global_list
             .bind::<XdgWmBase, _, _>(&qh, 2..=6, ())
             .expect("Could not bind XdgWmBase");
-        let manager = DataDeviceManagerState::bind(&clientside.global_list, &qh)
+
+        #[cfg(feature = "clipboard-sync")]
+        let clipboard_data = DataDeviceManagerState::bind(&clientside.global_list, &qh)
             .inspect_err(|e| {
                 warn!("Could not bind data device manager ({e:?}). Clipboard will not work.")
             })
+            .map(|manager| ClipboardData {
+                manager,
+                device: None,
+                source: None::<CopyPasteData<C::MimeTypeData>>,
+            })
             .ok();
-        let clipboard_data = manager.map(|manager| ClipboardData {
-            manager,
-            device: None,
-            source: None::<CopyPasteData<C::MimeTypeData>>,
-        });
 
         dh.create_global::<Self, XwaylandShellV1, _>(1, ());
         clientside
@@ -472,6 +480,7 @@ impl<C: XConnection> ServerState<C> {
             objects: Default::default(),
             associated_windows: Default::default(),
             xdg_wm_base,
+            #[cfg(feature = "clipboard-sync")]
             clipboard_data,
             last_kb_serial: None,
         }
@@ -654,6 +663,7 @@ impl<C: XConnection> ServerState<C> {
         let _ = self.windows.remove(&window);
     }
 
+    #[cfg(feature = "clipboard-sync")]
     pub(crate) fn set_copy_paste_source(&mut self, mime_types: Rc<Vec<C::MimeTypeData>>) {
         if let Some(d) = &mut self.clipboard_data {
             let src = d
@@ -709,10 +719,12 @@ impl<C: XConnection> ServerState<C> {
             }
         }
 
+        #[cfg(feature = "clipboard-sync")]
         self.handle_clipboard_events();
         self.clientside.queue.flush().unwrap();
     }
 
+    #[cfg(feature = "clipboard-sync")]
     pub fn new_selection(&mut self) -> Option<ForeignSelection> {
         self.clipboard_data.as_mut().and_then(|c| {
             c.source.take().and_then(|s| match s {
@@ -725,6 +737,7 @@ impl<C: XConnection> ServerState<C> {
         })
     }
 
+    #[cfg(feature = "clipboard-sync")]
     fn handle_clipboard_events(&mut self) {
         let globals = &mut self.clientside.globals;
 
@@ -914,17 +927,20 @@ pub struct PendingSurfaceState {
     pub height: i32,
 }
 
+#[cfg(feature = "clipboard-sync")]
 struct ClipboardData<M: MimeTypeData> {
     manager: DataDeviceManagerState,
     device: Option<DataDevice>,
     source: Option<CopyPasteData<M>>,
 }
 
+#[cfg(feature = "clipboard-sync")]
 pub struct ForeignSelection {
     pub mime_types: Box<[String]>,
     inner: SelectionOffer,
 }
 
+#[cfg(feature = "clipboard-sync")]
 impl ForeignSelection {
     pub(crate) fn receive(
         &self,
@@ -939,12 +955,14 @@ impl ForeignSelection {
     }
 }
 
+#[cfg(feature = "clipboard-sync")]
 impl Drop for ForeignSelection {
     fn drop(&mut self) {
         self.inner.destroy();
     }
 }
 
+#[cfg(feature = "clipboard-sync")]
 enum CopyPasteData<M: MimeTypeData> {
     X11 {
         inner: CopyPasteSource,

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "clipboard-sync")]
 mod selection;
+#[cfg(feature = "clipboard-sync")]
 use selection::{SelectionData, SelectionTarget};
 
 use crate::server::WindowAttributes;
@@ -107,6 +109,7 @@ pub struct XState {
     pub atoms: Atoms,
     root: x::Window,
     wm_window: x::Window,
+    #[cfg(feature = "clipboard-sync")]
     selection_data: SelectionData,
 }
 
@@ -158,6 +161,7 @@ impl XState {
             wm_window,
             root,
             atoms,
+            #[cfg(feature = "clipboard-sync")]
             selection_data: Default::default(),
         };
         r.create_ewmh_window();
@@ -217,6 +221,7 @@ impl XState {
             })
             .unwrap();
 
+        #[cfg(feature = "clipboard-sync")]
         self.set_clipboard_owner(x::CURRENT_TIME);
     }
 
@@ -238,6 +243,7 @@ impl XState {
         while let Some(event) = self.connection.poll_for_event().unwrap() {
             trace!("x11 event: {event:?}");
 
+            #[cfg(feature = "clipboard-sync")]
             if self.handle_selection_event(&event, server_state) {
                 continue;
             }
@@ -774,6 +780,7 @@ impl TryFrom<u32> for SetState {
 
 impl super::XConnection for Arc<xcb::Connection> {
     type ExtraData = Atoms;
+    #[cfg(feature = "clipboard-sync")]
     type MimeTypeData = SelectionTarget;
 
     fn root_window(&self) -> x::Window {


### PR DESCRIPTION
this is so that people who don't want implicit clipboard sync can just disable it.