### PR TITLE
Systemd notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "sd-notify"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4646d6f919800cd25c50edb49438a1381e2cd4833c027e75e8897981c50b8b5e"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +862,7 @@ dependencies = [
  "paste",
  "pretty_env_logger",
  "rustix",
+ "sd-notify",
  "slotmap",
  "smithay-client-toolkit",
  "testwl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ slotmap = "1.0.7"
 xcb-util-cursor = "0.3.2"
 smithay-client-toolkit = { version = "0.19.1", default-features = false }
 
+sd-notify = { version = "0.4.2", optional = true }
+
+[features]
+default = []
+systemd = ["dep:sd-notify"]
+
 [dev-dependencies]
 rustix = { workspace = true, features = ["fs"] }
 testwl = { path = "testwl" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,9 @@ pub fn main(data: impl RunData) -> Option<()> {
             data.xwayland_ready(display);
             server_state.set_x_connection(xstate.connection.clone());
             server_state.atoms = Some(xstate.atoms.clone());
+
+            #[cfg(feature = "systemd")]
+            let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
         }
 
         if let Some(xstate) = &mut xstate {


### PR DESCRIPTION
Currently when `xwayland-satellite` is run from a systemd service, there is no method to notify that initialisation has been completed for services that depend on it. Service types such as `simple` and `exec` will consider the service started right after forking (and `execve`) and dependent services may be started prematurely.

This PR adds a `systemd` feature that notifies systemd (with the `notify` type) when the setup is complete the dependent services may be started.