### PR TITLE
do not panic if focus_window fails

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -817,7 +817,7 @@ impl super::XConnection for Arc<xcb::Connection> {
             revert_to: x::InputFocus::None,
             time: x::CURRENT_TIME,
         }) {
-            log::warn!("SetInputFocus {:?}: {:?}", window, e);
+            log::debug!("SetInputFocus failed ({:?}: {:?})", window, e);
             return;
         }
         if let Err(e) = self.send_and_check_request(&x::ChangeProperty {
@@ -827,7 +827,7 @@ impl super::XConnection for Arc<xcb::Connection> {
             r#type: x::ATOM_WINDOW,
             data: &[window],
         }) {
-            log::warn!("ChangeProperty {:?}: {:?}", window, e);
+            log::debug!("ChangeProperty failed ({:?}: {:?})", window, e);
         }
     }
 

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -812,19 +812,23 @@ impl super::XConnection for Arc<xcb::Connection> {
     }
 
     fn focus_window(&mut self, window: x::Window, atoms: Self::ExtraData) {
-        unwrap_or_skip_bad_window!(self.send_and_check_request(&x::SetInputFocus {
+        if let Err(e) = self.send_and_check_request(&x::SetInputFocus {
             focus: window,
             revert_to: x::InputFocus::None,
             time: x::CURRENT_TIME,
-        }));
-
-        unwrap_or_skip_bad_window!(self.send_and_check_request(&x::ChangeProperty {
+        }) {
+            log::warn!("SetInputFocus {:?}: {:?}", window, e);
+            return;
+        }
+        if let Err(e) = self.send_and_check_request(&x::ChangeProperty {
             mode: x::PropMode::Replace,
             window: self.root_window(),
             property: atoms.active_win,
             r#type: x::ATOM_WINDOW,
             data: &[window],
-        }));
+        }) {
+            log::warn!("ChangeProperty {:?}: {:?}", window, e);
+        }
     }
 
     fn close_window(&mut self, window: x::Window, atoms: Self::ExtraData) {


### PR DESCRIPTION
mousing the connected devices on steamvr status window causes a bunch of short-lived trash to spawn and likely due to a race condition, focus_window panics:
```
thread 'main' panicked at src/xstate/mod.rs:822:9:
X11 protocol error: Protocol(X(Match(RequestError { response_type: 0, error_code: 8, sequence: 480, bad_value: 46137356, minor_opcode: 0, major_opcode: 42, pad: 1 }), Some("x::SetInputFocus")))
```