### PR TITLE
Add optional systemd support to flake package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,8 +45,13 @@
               xorg.libxcb
 
               makeWrapper
+
+              systemd
             ];
+
             buildInputs = [ pkgs.xwayland ];
+
+            cargoBuildOptions = opts: opts ++ [ "--features" "systemd" ];
 
             postInstall = ''
               wrapProgram $out/bin/xwayland-satellite \

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,39 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
+        lib = pkgs.lib;
+
         naersk' = pkgs.callPackage naersk {
           cargo = pkgs.rust-bin.stable.latest.default;
           rustc = pkgs.rust-bin.stable.latest.default;
         };
-      in {
+
+        buildXwaylandSatellite = { withSystemd ? false }: naersk'.buildPackage {
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            rustPlatform.bindgenHook
+            rust-bin.stable.latest.default
+            pkg-config
+
+            xcb-util-cursor
+            xorg.libxcb
+
+            makeWrapper
+          ] ++ lib.optional withSystemd pkgs.systemd;
+
+          buildInputs = [ pkgs.xwayland ];
+
+          cargoBuildOptions = opts: opts ++ lib.optional withSystemd "--features systemd";
+
+          postInstall = ''
+            wrapProgram $out/bin/xwayland-satellite \
+              --prefix PATH : ${pkgs.xwayland}/bin
+          '';
+        };
+
+      in
+      {
         devShell = (pkgs.mkShell.override { stdenv = pkgs.clangStdenv; }) {
           buildInputs = with pkgs; [
             rustPlatform.bindgenHook
@@ -33,31 +61,9 @@
         };
 
         packages = rec {
-          xwayland-satellite = naersk'.buildPackage {
-            src = ./.;
+          xwayland-satellite-nosd = buildXwaylandSatellite { withSystemd = false; };
 
-            nativeBuildInputs = with pkgs; [
-              rustPlatform.bindgenHook
-              rust-bin.stable.latest.default
-              pkg-config
-
-              xcb-util-cursor
-              xorg.libxcb
-
-              makeWrapper
-
-              systemd
-            ];
-
-            buildInputs = [ pkgs.xwayland ];
-
-            cargoBuildOptions = opts: opts ++ [ "--features" "systemd" ];
-
-            postInstall = ''
-              wrapProgram $out/bin/xwayland-satellite \
-                --prefix PATH : ${pkgs.xwayland}/bin
-            '';
-          };
+          xwayland-satellite = buildXwaylandSatellite { withSystemd = true; };
 
           default = xwayland-satellite;
         };


### PR DESCRIPTION
I've made systemd support optional in the flake package and enabled it by default as NixOS relies on it. Therefore, I've added an `xwayland-satellite-nosd` derivation in case anyone uses this flake with a Nix setup on distributions with different init systems.