### PR TITLE
Refactor flake for overridability, conditional service install, version formatting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
               ${lib.optionalString withSystemd ''
                 install -Dm0644 resources/xwayland-satellite.service -t $out/lib/systemd/user
                 substituteInPlace $out/lib/systemd/user/xwayland-satellite.service \
-                  --replace '/usr/local/bin/xwayland-satellite' "$out/bin/xwayland-satellite"
+                  --replace-fail '/usr/local/bin/xwayland-satellite' "$out/bin/xwayland-satellite"
               ''}
               wrapProgram $out/bin/xwayland-satellite \
                 --prefix PATH : "${lib.makeBinPath [ pkgs.xwayland ]}"

--- a/flake.nix
+++ b/flake.nix
@@ -82,15 +82,7 @@
             };
           };
 
-        xwayland-satellite = pkgs.callPackage buildXwaylandSatellite {
-          lib = pkgs.lib;
-          rustPlatform = pkgs.rustPlatform;
-          pkg-config = pkgs.pkg-config;
-          makeBinaryWrapper = pkgs.makeBinaryWrapper;
-          libxcb = pkgs.xorg.libxcb;
-          xcb-util-cursor = pkgs.xcb-util-cursor;
-          xwayland = pkgs.xwayland;
-        };
+        xwayland-satellite = pkgs.callPackage buildXwaylandSatellite { };
       in
       {
         devShell = (pkgs.mkShell.override { stdenv = pkgs.clangStdenv; }) {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
               xorg.libxcb
               xorg.xcbutilcursor
             ];
-
+           buildNoDefaultFeatures = true;
             buildFeatures = lib.optionals withSystemd [ "systemd" ];
 
             postInstall = ''

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           , pkg-config
           , makeWrapper
           , libxcb
-          , xcbutilcursor
+          , xcb-util-cursor
           , xwayland
           , withSystemd ? true
           }:
@@ -52,7 +52,7 @@
 
             buildInputs = [
               libxcb
-              xcbutilcursor
+              xcb-util-cursor
             ];
 
             buildNoDefaultFeatures = true;
@@ -85,7 +85,7 @@
           pkg-config = pkgs.pkg-config;
           makeWrapper = pkgs.makeWrapper;
           libxcb = pkgs.xorg.libxcb;
-          xcbutilcursor = pkgs.xorg.xcbutilcursor;
+          xcb-util-cursor = pkgs.xcb-util-cursor;
           xwayland = pkgs.xwayland;
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,6 @@
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs { inherit system overlays; };
-        lib = pkgs.lib;
 
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         cargoPackageVersion = cargoToml.package.version;
@@ -24,13 +23,14 @@
         version = "${cargoPackageVersion}-${commitHash}";
 
         buildXwaylandSatellite =
-          { withSystemd ? true
+          { lib
           , rustPlatform
           , pkg-config
           , makeWrapper
           , libxcb
           , xcbutilcursor
           , xwayland
+          , withSystemd ? true
           }:
 
           rustPlatform.buildRustPackage rec {
@@ -80,6 +80,7 @@
           };
 
         xwayland-satellite = pkgs.callPackage buildXwaylandSatellite {
+          lib = pkgs.lib;
           rustPlatform = pkgs.rustPlatform;
           pkg-config = pkgs.pkg-config;
           makeWrapper = pkgs.makeWrapper;

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         commitHash = self.shortRev or self.dirtyShortRev or "unknown";
 
-        version = "${cargoPackageVersion}-unstable-${commitHash}";
+        version = "${cargoPackageVersion}-${commitHash}";
 
         buildXwaylandSatellite = { withSystemd ? true, ... } @ args:
           pkgs.rustPlatform.buildRustPackage (rec {

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           { lib
           , rustPlatform
           , pkg-config
-          , makeWrapper
+          , makeBinaryWrapper
           , libxcb
           , xcb-util-cursor
           , xwayland
@@ -47,7 +47,7 @@
             nativeBuildInputs = [
               rustPlatform.bindgenHook
               pkg-config
-              makeWrapper
+              makeBinaryWrapper
             ];
 
             buildInputs = [
@@ -83,7 +83,7 @@
           lib = pkgs.lib;
           rustPlatform = pkgs.rustPlatform;
           pkg-config = pkgs.pkg-config;
-          makeWrapper = pkgs.makeWrapper;
+          makeBinaryWrapper = pkgs.makeBinaryWrapper;
           libxcb = pkgs.xorg.libxcb;
           xcb-util-cursor = pkgs.xcb-util-cursor;
           xwayland = pkgs.xwayland;

--- a/flake.nix
+++ b/flake.nix
@@ -56,15 +56,18 @@
             ];
 
             buildNoDefaultFeatures = true;
-
             buildFeatures = lib.optionals withSystemd [ "systemd" ];
 
-            postInstall = ''
-              ${lib.optionalString withSystemd ''
-                install -Dm0644 resources/xwayland-satellite.service -t $out/lib/systemd/user
-                substituteInPlace $out/lib/systemd/user/xwayland-satellite.service \
-                  --replace-fail '/usr/local/bin/xwayland-satellite' "$out/bin/xwayland-satellite"
-              ''}
+            postPatch = ''
+              substituteInPlace resources/xwayland-satellite.service \
+                --replace-fail '/usr/local/bin' "$out/bin"
+            '';
+
+            postInstall = lib.optionalString withSystemd ''
+              install -Dm0644 resources/xwayland-satellite.service -t $out/lib/systemd/user
+            '';
+
+            postFixup = ''
               wrapProgram $out/bin/xwayland-satellite \
                 --prefix PATH : "${lib.makeBinPath [ xwayland ]}"
             '';


### PR DESCRIPTION
This updates the flake to make the package overridable and install the service conditionally based on the `withSystemd` option. It introduces dynamic version formatting as `cargoPackageVersion-unstable-shortCommitHash` and cleans up unnecessary variables and inputs.