### PR TITLE
Fix most Broken Pipe IO aborts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  UBUNTU_DOCKERFILE: .github/workflows/ubuntu.dockerfile
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  check-should-build-container:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          sparse-checkout: .github
+      - id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: ${{ env.UBUNTU_DOCKERFILE }}
+      - id: name
+        run: echo "container_path=${{ env.REGISTRY }}/${GITHUB_REPOSITORY@L}" >> "$GITHUB_OUTPUT"
+    outputs:
+      should-build: ${{ steps.changed.outputs.any_changed }}
+      container-path: ${{ steps.name.outputs.container_path }}
+
+  ubuntu-build:
+    runs-on: ubuntu-latest
+    needs: check-should-build-container
+    if: ${{ needs.check-should-build-container.outputs.should-build == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          file: ${{ env.UBUNTU_DOCKERFILE }}
+          push: true
+          tags: ${{ needs.check-should-build-container.outputs.container-path }}-ubuntu:latest
+          labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build:
+    needs: [ubuntu-build, check-should-build-container]
+    if: ${{ always() && (needs.ubuntu-build.result == 'success' || needs.ubuntu-build.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.check-should-build-container.outputs.container-path }}-ubuntu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --release --verbose
+    - name: Run tests
+      run: cargo test --verbose
+    - name: Format check
+      run: cargo fmt --check
+    - name: Clippy
+      run: cargo clippy

--- a/.github/workflows/ubuntu.dockerfile
+++ b/.github/workflows/ubuntu.dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+ENV CARGO_HOME=/cargo RUSTUP_HOME=/rustup
+RUN apt-get update \
+	&& apt-get install -y xwayland libxcb1 clang libxcb-cursor0 libxcb-cursor-dev curl pkg-config libegl1 \
+	&& rm -r /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+	&& . "/cargo/env" \
+	&& rustup toolchain install stable \
+	&& rustup default stable
+RUN mkdir /run/xwls-test
+ENV PATH="/cargo/bin:$PATH" XDG_RUNTIME_DIR="/run/xwls-test"


### PR DESCRIPTION
Makes sure the xwayland_satellite main thread ends so that the file descriptors don't continue to be used after Fixture drops them