### PR TITLE
Remove paste dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,7 +832,6 @@ dependencies = [
  "libc",
  "log",
  "macros",
- "paste",
  "pretty_env_logger",
  "rustix",
  "sd-notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ crate-type = ["lib"]
 
 [dependencies]
 bitflags = "2.5.0"
-paste = "1.0.14"
 rustix = { workspace = true, features = ["event"] }
 wayland-client.workspace = true
 wayland-protocols = { workspace = true, features = ["client", "server", "staging", "unstable"] }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -308,7 +308,7 @@ macro_rules! handle_event_enum {
         $(#[$meta:meta])*
         $pub:vis enum $name:ident {
             $( $variant:ident($ty:ty) ),+
-        }
+        } => $name_event:ident
     ) => {
         enum_try_from! {
             $(#[$meta])*
@@ -317,19 +317,15 @@ macro_rules! handle_event_enum {
             }
         }
 
-        paste::paste! {
-            enum_try_from! {
-                #[derive(Debug)]
-                $pub enum [<$name Event>] {
-                    $( $variant(<$ty as HandleEvent>::Event) ),+
-                }
+        enum_try_from! {
+            #[derive(Debug)]
+            $pub enum $name_event {
+                $( $variant(<$ty as HandleEvent>::Event) ),+
             }
         }
 
         impl HandleEvent for $name {
-            paste::paste! {
-                type Event = [<$name Event>];
-            }
+            type Event = $name_event;
 
             fn handle_event<C: XConnection>(&mut self, event: Self::Event, state: &mut ServerState<C>) {
                 match self {
@@ -370,7 +366,7 @@ pub(crate) enum Object {
     TabletPadGroup(TabletPadGroup),
     TabletPadRing(TabletPadRing),
     TabletPadStrip(TabletPadStrip)
-}
+} => ObjectEvent
 
 }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1,6 +1,5 @@
 use super::{ServerState, WindowDims};
 use crate::xstate::{SetState, WmName};
-use paste::paste;
 use rustix::event::{poll, PollFd, PollFlags};
 use std::collections::HashMap;
 use std::io::Write;
@@ -71,7 +70,7 @@ macro_rules! with_optional {
             $(
                 $field:ident: $type:ty
             ),+$(,)?
-        }
+        } => $name_optional:ident
     ) => {
         $( #[$attr] )?
         struct $name$(<$($lifetimes),+>)? {
@@ -80,23 +79,19 @@ macro_rules! with_optional {
             ),+
         }
 
-        paste! {
-            #[derive(Default)]
-            struct [< $name Optional >] {
-                $(
-                    $field: Option<$type>
-                ),+
-            }
+        #[derive(Default)]
+        struct $name_optional {
+            $(
+                $field: Option<$type>
+            ),+
         }
 
-        paste! {
-            impl From<[<$name Optional>]> for $name {
-                fn from(opt: [<$name Optional>]) -> Self {
-                    Self {
-                        $(
-                            $field: opt.$field.expect(concat!("uninitialized field ", stringify!($field)))
-                        ),+
-                    }
+        impl From<$name_optional> for $name {
+            fn from(opt: $name_optional) -> Self {
+                Self {
+                    $(
+                        $field: opt.$field.expect(concat!("uninitialized field ", stringify!($field)))
+                    ),+
                 }
             }
         }
@@ -111,7 +106,7 @@ struct Compositor {
     shell: TestObject<XwaylandShellV1>,
     seat: TestObject<WlSeat>,
     tablet_man: TestObject<ZwpTabletManagerV2>
-}
+} => CompositorOptional
 
 }
 


### PR DESCRIPTION
[RustSec Advisory - `paste` is unmaintained](https://rustsec.org/advisories/RUSTSEC-2024-0436.html)

Was not a large part of the total infrastructure, so I just wrote out the types paste would create myself as macro parameters. The macro syntax seems fine (macro syntax design is not something I would call myself *good* at though).