### PR TITLE
Fix panic on empty WM_CLASS

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -569,7 +569,7 @@ impl XState {
                 0
             };
             let mut data = data[class_start..].to_vec();
-            if data.last().copied().unwrap() != 0 {
+            if data.last().copied() != Some(0) {
                 data.push(0);
             }
             let class = CString::from_vec_with_nul(data).unwrap();


### PR DESCRIPTION
This was triggered by running openbox.

I could add a test, I tested it with:
```rs
#[test]
fn empty_window_class() {
    let mut f = Fixture::new();
    let mut conn = Connection::new(&f.display);
    let toplevel = conn.new_window(conn.root, 0, 0, 20, 20, false);
    f.map_as_toplevel(&mut conn, toplevel);

    conn.set_property(toplevel, x::ATOM_STRING, x::ATOM_WM_CLASS, b"");
    f.wait_and_dispatch();
}
```
But I feel like it's kinda pointless to test a single edge case on a single property, I feel like it should be more comprehensive e.g. testing empty, really long, non-utf8 etc. across all supported atoms