### PR TITLE
Xdg toplevel icon

### DIFF
--- a/src/clientside/mod.rs
+++ b/src/clientside/mod.rs
@@ -1,4 +1,5 @@
 mod data_device;
+mod shm;
 pub mod xdg_activation;
 
 use crate::server::{ObjectEvent, ObjectKey};
@@ -19,6 +20,8 @@ use wayland_protocols::wp::relative_pointer::zv1::client::{
     zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
     zwp_relative_pointer_v1::ZwpRelativePointerV1,
 };
+use wayland_protocols::xdg::toplevel_icon::v1::client::xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1;
+use wayland_protocols::xdg::toplevel_icon::v1::client::xdg_toplevel_icon_v1::XdgToplevelIconV1;
 use wayland_protocols::{
     wp::{
         linux_dmabuf::zv1::client::{
@@ -140,6 +143,8 @@ delegate_noop!(Globals: ZxdgOutputManagerV1);
 delegate_noop!(Globals: ZwpPointerConstraintsV1);
 delegate_noop!(Globals: ZwpTabletManagerV2);
 delegate_noop!(Globals: XdgActivationV1);
+delegate_noop!(Globals: ignore XdgToplevelIconManagerV1);
+delegate_noop!(Globals: XdgToplevelIconV1);
 
 impl Dispatch<WlRegistry, GlobalListContents> for Globals {
     fn event(

--- a/src/clientside/shm.rs
+++ b/src/clientside/shm.rs
@@ -1,0 +1,14 @@
+use smithay_client_toolkit::{
+    delegate_shm,
+    shm::{Shm, ShmHandler},
+};
+
+use super::Globals;
+
+delegate_shm!(Globals);
+impl ShmHandler for Globals {
+    fn shm_state(&mut self) -> &mut Shm {
+        // &self.shm
+        todo!()
+    }
+}


### PR DESCRIPTION
This is turning out a lot involved than I thought, I'll probably take a bit a of break after this.
The shm stuff is also necessary for `sctk-adwaita`, I'm not yet sure if it's fine to use `WlShm` both through the `Shm` in sctk and outside of it or if it'll panic at runtime.
TODO: Figure out where `Shm` should be and delegate it, deal with the case where `width != height` because it's disallowed by the protocol, add tests, avoid unnecessary copying the icon data, better handling of slot pool size.
Also `PropertyResolver` returning `Option` is better than before but still could be improved, if we get an invalid value we probably want to keep the ignore it and log the error, currently we it's treated as if the property was removed. I think it should return a `Result` instead and then we can wrap the option with it, so it'll return `XResult<Result<Option<T>>>`.