### PR TITLE
Set popup constraint adjustment to slide

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -26,6 +26,7 @@ use wayland_protocols::xdg::decoration::zv1::client::zxdg_decoration_manager_v1:
 use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1::{
     self, ZxdgToplevelDecorationV1,
 };
+use wayland_protocols::xdg::shell::client::xdg_positioner::ConstraintAdjustment;
 use wayland_protocols::{
     wp::{
         linux_dmabuf::zv1::{client as c_dmabuf, server as s_dmabuf},
@@ -1193,6 +1194,9 @@ impl<C: XConnection> ServerState<C> {
                 0,
                 parent_window.attrs.dims.width as _,
                 parent_window.attrs.dims.height as _,
+            );
+            positioner.set_constraint_adjustment(
+                ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY,
             );
             let popup = xdg_surface.get_popup(
                 Some(&parent_surface.xdg().unwrap().surface),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -711,6 +711,11 @@ impl TestFixture {
             );
             assert_eq!(pos.anchor, xdg_positioner::Anchor::TopLeft);
             assert_eq!(pos.gravity, xdg_positioner::Gravity::BottomRight);
+            assert_eq!(
+                pos.constraint_adjustment,
+                xdg_positioner::ConstraintAdjustment::SlideX
+                    | xdg_positioner::ConstraintAdjustment::SlideY,
+            );
         }
 
         self.testwl.configure_popup(popup_id);

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1293,6 +1293,7 @@ pub struct PositionerState {
     pub offset: Vec2,
     pub anchor: xdg_positioner::Anchor,
     pub gravity: xdg_positioner::Gravity,
+    pub constraint_adjustment: xdg_positioner::ConstraintAdjustment,
 }
 
 impl Default for PositionerState {
@@ -1303,6 +1304,7 @@ impl Default for PositionerState {
             offset: Vec2 { x: 0, y: 0 },
             anchor: xdg_positioner::Anchor::None,
             gravity: xdg_positioner::Gravity::None,
+            constraint_adjustment: xdg_positioner::ConstraintAdjustment::None,
         }
     }
 }
@@ -1352,6 +1354,11 @@ impl Dispatch<XdgPositioner, ()> for State {
             }
             xdg_positioner::Request::SetGravity { gravity } => {
                 data.get_mut().gravity = gravity.into_result().unwrap();
+            }
+            xdg_positioner::Request::SetConstraintAdjustment {
+                constraint_adjustment,
+            } => {
+                data.get_mut().constraint_adjustment = constraint_adjustment.into_result().unwrap();
             }
             xdg_positioner::Request::Destroy => {
                 data.remove();


### PR DESCRIPTION
Like @ehopperdietzel requested, I don't have a strong opinion on this but since afaik x11 doesn't have an equivalent for this (it barely has the concept of popups), it seems like a reasonable default.
Tested it a bit on gtk4 and ~~it works as expected~~ actually the part of the popup that overflows above the window doesn't get mouse events... it's not directly related to this but makes this pretty pointless, I'll try to investigate it