### PR TITLE
Destory popups in FILO order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ all = "deny"
 [package]
 name = "xwayland-satellite"
 version = "0.5.1"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2024"
 
 [lib]
 crate-type = ["lib"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 
 use quote::{format_ident, quote};
 use syn::{
-    braced, bracketed, parse::Parse, parse_macro_input, parse_quote, punctuated::Punctuated, Token,
+    Token, braced, bracketed, parse::Parse, parse_macro_input, parse_quote, punctuated::Punctuated,
 };
 
 enum FieldOrClosure {

--- a/src/clientside/mod.rs
+++ b/src/clientside/mod.rs
@@ -3,7 +3,7 @@ pub mod xdg_activation;
 
 use crate::server::{ObjectEvent, ObjectKey};
 use std::os::unix::net::UnixStream;
-use std::sync::{mpsc, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock, mpsc};
 use wayland_client::protocol::{
     wl_buffer::WlBuffer, wl_callback::WlCallback, wl_compositor::WlCompositor,
     wl_keyboard::WlKeyboard, wl_output::WlOutput, wl_pointer::WlPointer, wl_region::WlRegion,
@@ -11,9 +11,8 @@ use wayland_client::protocol::{
     wl_surface::WlSurface, wl_touch::WlTouch,
 };
 use wayland_client::{
-    delegate_noop, event_created_child,
-    globals::{registry_queue_init, Global, GlobalList, GlobalListContents},
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop, event_created_child,
+    globals::{Global, GlobalList, GlobalListContents, registry_queue_init},
 };
 use wayland_protocols::wp::relative_pointer::zv1::client::{
     zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
@@ -35,13 +34,13 @@ use wayland_protocols::{
         },
         tablet::zv2::client::{
             zwp_tablet_manager_v2::ZwpTabletManagerV2,
-            zwp_tablet_pad_group_v2::{ZwpTabletPadGroupV2, EVT_RING_OPCODE, EVT_STRIP_OPCODE},
+            zwp_tablet_pad_group_v2::{EVT_RING_OPCODE, EVT_STRIP_OPCODE, ZwpTabletPadGroupV2},
             zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2,
             zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2,
-            zwp_tablet_pad_v2::{ZwpTabletPadV2, EVT_GROUP_OPCODE},
+            zwp_tablet_pad_v2::{EVT_GROUP_OPCODE, ZwpTabletPadV2},
             zwp_tablet_seat_v2::{
-                ZwpTabletSeatV2, EVT_PAD_ADDED_OPCODE, EVT_TABLET_ADDED_OPCODE,
-                EVT_TOOL_ADDED_OPCODE,
+                EVT_PAD_ADDED_OPCODE, EVT_TABLET_ADDED_OPCODE, EVT_TOOL_ADDED_OPCODE,
+                ZwpTabletSeatV2,
             },
             zwp_tablet_tool_v2::ZwpTabletToolV2,
             zwp_tablet_v2::ZwpTabletV2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod xstate;
 use crate::server::{PendingSurfaceState, ServerState};
 use crate::xstate::{RealConnection, XState};
 use log::{error, info};
-use rustix::event::{poll, PollFd, PollFlags};
+use rustix::event::{PollFd, PollFlags, poll};
 use smithay_client_toolkit::data_device_manager::WritePipe;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd};

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -117,8 +117,7 @@ impl<C: XConnection> Dispatch<WlSurface, ObjectKey> for ServerState<C> {
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         let surface: &SurfaceData = state.objects[*key].as_ref();
-        let configured =
-            surface.role.is_none() || surface.xdg().is_none() || surface.xdg().unwrap().configured;
+        let configured = surface.role.is_none() || surface.xdg().configured;
 
         match request {
             Request::<WlSurface>::Attach { buffer, x, y } => {

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -40,6 +40,7 @@ use wayland_protocols::{
     },
 };
 use wayland_server::{
+    Dispatch, DisplayHandle, GlobalDispatch, Resource,
     protocol::{
         wl_buffer::WlBuffer,
         wl_callback::WlCallback,
@@ -54,7 +55,6 @@ use wayland_server::{
         wl_surface::WlSurface,
         wl_touch::WlTouch,
     },
-    Dispatch, DisplayHandle, GlobalDispatch, Resource,
 };
 
 macro_rules! only_destroy_request_impl {

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -4,7 +4,7 @@ use log::{debug, trace, warn};
 use macros::simple_event_shunt;
 use std::collections::HashSet;
 use std::os::fd::AsFd;
-use wayland_client::{protocol as client, Proxy};
+use wayland_client::{Proxy, protocol as client};
 use wayland_protocols::{
     wp::{
         pointer_constraints::zv1::{

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -168,7 +168,7 @@ impl SurfaceData {
             unreachable!();
         };
 
-        let xdg = self.xdg_mut().unwrap();
+        let xdg = self.xdg_mut();
         xdg.surface.ack_configure(serial);
         xdg.configured = true;
 
@@ -226,7 +226,7 @@ impl SurfaceData {
                 states,
             } => {
                 debug!("configuring toplevel {width}x{height}, {states:?}");
-                if let Some(SurfaceRole::Toplevel(Some(toplevel))) = &mut self.role {
+                if let Some(SurfaceRole::Toplevel(toplevel)) = &mut self.role {
                     let prev_fs = toplevel.fullscreen;
                     toplevel.fullscreen =
                         states.contains(&(u32::from(xdg_toplevel::State::Fullscreen) as u8));
@@ -240,7 +240,7 @@ impl SurfaceData {
                     }
                 };
 
-                self.xdg_mut().unwrap().pending = Some(PendingSurfaceState {
+                self.xdg_mut().pending = Some(PendingSurfaceState {
                     width,
                     height,
                     ..Default::default()
@@ -263,7 +263,7 @@ impl SurfaceData {
                 height,
             } => {
                 trace!("popup configure: {x}x{y}, {width}x{height}");
-                self.xdg_mut().unwrap().pending = Some(PendingSurfaceState {
+                self.xdg_mut().pending = Some(PendingSurfaceState {
                     x,
                     y,
                     width,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1,13 +1,14 @@
 use super::{ServerState, WindowDims};
 use crate::xstate::{SetState, WmName};
-use rustix::event::{poll, PollFd, PollFlags};
+use rustix::event::{PollFd, PollFlags, poll};
 use std::collections::HashMap;
 use std::io::Write;
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 use wayland_client::{
-    backend::{protocol::Message, Backend, ObjectData, ObjectId, WaylandError},
+    Connection, Proxy, WEnum,
+    backend::{Backend, ObjectData, ObjectId, WaylandError, protocol::Message},
     protocol::{
         wl_buffer::WlBuffer,
         wl_compositor::WlCompositor,
@@ -21,7 +22,6 @@ use wayland_client::{
         wl_shm_pool::WlShmPool,
         wl_surface::WlSurface,
     },
-    Connection, Proxy, WEnum,
 };
 
 use wayland_protocols::{
@@ -32,14 +32,14 @@ use wayland_protocols::{
         tablet::zv2::client::{
             zwp_tablet_manager_v2::{self, ZwpTabletManagerV2},
             zwp_tablet_pad_group_v2::{
-                self, ZwpTabletPadGroupV2, EVT_RING_OPCODE, EVT_STRIP_OPCODE,
+                self, EVT_RING_OPCODE, EVT_STRIP_OPCODE, ZwpTabletPadGroupV2,
             },
             zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2,
             zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2,
-            zwp_tablet_pad_v2::{self, ZwpTabletPadV2, EVT_GROUP_OPCODE},
+            zwp_tablet_pad_v2::{self, EVT_GROUP_OPCODE, ZwpTabletPadV2},
             zwp_tablet_seat_v2::{
-                self, ZwpTabletSeatV2, EVT_PAD_ADDED_OPCODE, EVT_TABLET_ADDED_OPCODE,
-                EVT_TOOL_ADDED_OPCODE,
+                self, EVT_PAD_ADDED_OPCODE, EVT_TABLET_ADDED_OPCODE, EVT_TOOL_ADDED_OPCODE,
+                ZwpTabletSeatV2,
             },
             zwp_tablet_tool_v2::{self, ZwpTabletToolV2},
             zwp_tablet_v2::{self, ZwpTabletV2},
@@ -57,7 +57,7 @@ use wayland_protocols::{
         xwayland_shell_v1::XwaylandShellV1, xwayland_surface_v1::XwaylandSurfaceV1,
     },
 };
-use wayland_server::{protocol as s_proto, Display, Resource};
+use wayland_server::{Display, Resource, protocol as s_proto};
 use wl_drm::client::wl_drm::WlDrm;
 use xcb::x::{self, Window};
 
@@ -1039,40 +1039,46 @@ fn fullscreen() {
     f.run();
 
     let data = f.testwl.get_surface_data(id).unwrap();
-    assert!(data
-        .toplevel()
-        .states
-        .contains(&xdg_toplevel::State::Fullscreen));
+    assert!(
+        data.toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Fullscreen)
+    );
 
     f.satellite.set_fullscreen(win, SetState::Remove);
     f.run();
     f.run();
 
     let data = f.testwl.get_surface_data(id).unwrap();
-    assert!(!data
-        .toplevel()
-        .states
-        .contains(&xdg_toplevel::State::Fullscreen));
+    assert!(
+        !data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Fullscreen)
+    );
 
     f.satellite.set_fullscreen(win, SetState::Toggle);
     f.run();
     f.run();
 
     let data = f.testwl.get_surface_data(id).unwrap();
-    assert!(data
-        .toplevel()
-        .states
-        .contains(&xdg_toplevel::State::Fullscreen));
+    assert!(
+        data.toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Fullscreen)
+    );
 
     f.satellite.set_fullscreen(win, SetState::Toggle);
     f.run();
     f.run();
 
     let data = f.testwl.get_surface_data(id).unwrap();
-    assert!(!data
-        .toplevel()
-        .states
-        .contains(&xdg_toplevel::State::Fullscreen));
+    assert!(
+        !data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Fullscreen)
+    );
 }
 
 #[test]

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -2,14 +2,14 @@ mod selection;
 use selection::{Selection, SelectionData};
 use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1;
 
-use crate::{server::WindowAttributes, XConnection};
+use crate::{XConnection, server::WindowAttributes};
 use bitflags::bitflags;
 use log::{debug, trace, warn};
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::rc::Rc;
-use xcb::{x, Xid, XidNew};
+use xcb::{Xid, XidNew, x};
 use xcb_util_cursor::{Cursor, CursorContext};
 
 // Sometimes we'll get events on windows that have already been destroyed
@@ -336,9 +336,10 @@ impl XState {
                 }
                 xcb::Event::X(x::Event::MapRequest(e)) => {
                     debug!("requested to map {:?}", e.window());
-                    unwrap_or_skip_bad_window_cont!(self
-                        .connection
-                        .send_and_check_request(&x::MapWindow { window: e.window() }));
+                    unwrap_or_skip_bad_window_cont!(
+                        self.connection
+                            .send_and_check_request(&x::MapWindow { window: e.window() })
+                    );
                 }
                 xcb::Event::X(x::Event::MapNotify(e)) => {
                     unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
@@ -1174,9 +1175,10 @@ impl XConnection for RealConnection {
     }
 
     fn unmap_window(&mut self, window: x::Window) {
-        unwrap_or_skip_bad_window!(self
-            .connection
-            .send_and_check_request(&x::UnmapWindow { window }));
+        unwrap_or_skip_bad_window!(
+            self.connection
+                .send_and_check_request(&x::UnmapWindow { window })
+        );
     }
 
     fn raise_to_top(&mut self, window: x::Window) {

--- a/src/xstate/selection.rs
+++ b/src/xstate/selection.rs
@@ -1,4 +1,4 @@
-use super::{get_atom_name, XState};
+use super::{XState, get_atom_name};
 use crate::server::ForeignSelection;
 use crate::{RealServerState, X11Selection};
 use log::{debug, error, warn};
@@ -385,7 +385,10 @@ impl XState {
                         let Some(target) = mimes.iter().find(|t| t.atom == other) else {
                             if log::log_enabled!(log::Level::Debug) {
                                 let name = get_atom_name(&self.connection, other);
-                                debug!("refusing selection request because given atom could not be found ({})", name);
+                                debug!(
+                                    "refusing selection request because given atom could not be found ({})",
+                                    name
+                                );
                             }
                             refuse();
                             return true;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,12 +1,12 @@
-use rustix::event::{poll, PollFd, PollFlags};
+use rustix::event::{PollFd, PollFlags, poll};
 use rustix::process::{Pid, Signal, WaitOptions};
 use std::io::Write;
 use std::mem::ManuallyDrop;
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex, Once,
+    atomic::{AtomicBool, Ordering},
 };
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -14,7 +14,7 @@ use wayland_protocols::xdg::{
     decoration::zv1::server::zxdg_toplevel_decoration_v1, shell::server::xdg_toplevel,
 };
 use wayland_server::Resource;
-use xcb::{x, Xid};
+use xcb::{Xid, x};
 use xwayland_satellite as xwls;
 use xwayland_satellite::xstate::{WmSizeHintsFlags, WmState};
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1576,3 +1576,19 @@ fn xdg_decorations() {
         Some(zxdg_toplevel_decoration_v1::Mode::ServerSide)
     );
 }
+
+#[test]
+fn filo_popup_destruction_order() {
+    let mut f = Fixture::new();
+    let mut connection = Connection::new(&f.display);
+
+    let window = connection.new_window(connection.root, 0, 0, 20, 20, false);
+    f.map_as_toplevel(&mut connection, window);
+    let popup = connection.new_window(window, 0, 0, 20, 20, false);
+    f.map_as_popup(&mut connection, popup, 0, 0, 20, 20);
+    let nested_popup = connection.new_window(popup, 0, 0, 20, 20, false);
+    f.map_as_popup(&mut connection, nested_popup, 0, 0, 20, 20);
+
+    connection.destroy_window(popup);
+    f.wait_and_dispatch();
+}

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "testwl"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 wayland-protocols = { workspace = true, features = ["server", "unstable"] }

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map};
 use std::io::Read;
 use std::io::Write;
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
@@ -45,9 +45,10 @@ use wayland_protocols::{
     },
 };
 use wayland_server::{
+    Client, Dispatch, Display, DisplayHandle, GlobalDispatch, Resource, WEnum,
     backend::{
-        protocol::{Interface, ProtocolError},
         GlobalHandler, ObjectData,
+        protocol::{Interface, ProtocolError},
     },
     protocol::{
         self as proto,
@@ -66,7 +67,6 @@ use wayland_server::{
         wl_shm_pool::WlShmPool,
         wl_surface::WlSurface,
     },
-    Client, Dispatch, Display, DisplayHandle, GlobalDispatch, Resource, WEnum,
 };
 use wl_drm::server::wl_drm::WlDrm;
 
@@ -90,21 +90,21 @@ pub struct SurfaceData {
 impl SurfaceData {
     pub fn xdg(&self) -> &XdgSurfaceData {
         match self.role.as_ref().expect("Surface missing role") {
-            SurfaceRole::Toplevel(ref t) => &t.xdg,
-            SurfaceRole::Popup(ref p) => &p.xdg,
+            SurfaceRole::Toplevel(t) => &t.xdg,
+            SurfaceRole::Popup(p) => &p.xdg,
             SurfaceRole::Cursor => panic!("cursor surface doesn't have an XdgSurface"),
         }
     }
 
     pub fn toplevel(&self) -> &Toplevel {
         match self.role.as_ref().expect("Surface missing role") {
-            SurfaceRole::Toplevel(ref t) => t,
+            SurfaceRole::Toplevel(t) => t,
             other => panic!("Surface role was not toplevel: {other:?}"),
         }
     }
     pub fn popup(&self) -> &Popup {
         match self.role.as_ref().expect("Surface missing role") {
-            SurfaceRole::Popup(ref p) => p,
+            SurfaceRole::Popup(p) => p,
             other => panic!("Surface role was not popup: {other:?}"),
         }
     }

--- a/wl_drm/Cargo.toml
+++ b/wl_drm/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "wl_drm"
 version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2024"
 
 [dependencies]
 wayland-client.workspace = true


### PR DESCRIPTION
Fixes vscode issue described here: https://github.com/Supreeeme/xwayland-satellite/issues/31#issuecomment-2777257710

The logic in `Request::<WlSurface>::Destroy` is messy, I've had to wrestle with the borrow checker to get it to work (I upgraded to edition 2024 because I thought the I encountered a borrow checker limitation that was lifted but apparently not, it should probably be a separate PR).
A lot of tests are consistently failing, I have a feeling it's due to an existing race condition that is now a lot more likely because surface destruction now takes a more time.

Also I think storing the keys of children is overkill, using a count should be enough like in testwl. I think this simplifies the borrowing a bit.

Edit: turns out this was also the wrong place for it, the role is destroyed beforehand when the window is unmapped.