### PR TITLE
Cursor shape

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,16 @@ log = "0.4.21"
 env_logger = "0.11.3"
 pretty_env_logger = "0.5.0"
 slotmap = "1.0.7"
-xcb-util-cursor = "0.3.2"
 smithay-client-toolkit = { version = "0.19.1", default-features = false }
 
 sd-notify = { version = "0.4.2", optional = true }
+xcb-util-cursor = { version = "0.3.2", optional = true }
 macros = { version = "0.1.0", path = "macros" }
 
 [features]
-default = []
+default = ["client-cursors"]
 systemd = ["dep:sd-notify"]
+client-cursors = ["dep:xcb-util-cursor"]
 
 [dev-dependencies]
 rustix = { workspace = true, features = ["fs"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.37"
-syn = "2.0.79"
+syn = { version = "2.0.79", features = ["full"] }

--- a/src/clientside/cursor_shape.rs
+++ b/src/clientside/cursor_shape.rs
@@ -1,0 +1,34 @@
+use crate::clientside::Globals;
+use log::warn;
+use smithay_client_toolkit::globals::GlobalData;
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
+use wayland_protocols::wp::cursor_shape::v1::client::{
+    wp_cursor_shape_device_v1::WpCursorShapeDeviceV1,
+    wp_cursor_shape_manager_v1::WpCursorShapeManagerV1,
+};
+
+impl Dispatch<WpCursorShapeManagerV1, GlobalData> for Globals {
+    fn event(
+        _: &mut Self,
+        _: &WpCursorShapeManagerV1,
+        event: <WpCursorShapeManagerV1 as Proxy>::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        warn!("unhandled cursor shape manager event: {event:?}");
+    }
+}
+
+impl Dispatch<WpCursorShapeDeviceV1, GlobalData> for Globals {
+    fn event(
+        _: &mut Self,
+        _: &WpCursorShapeDeviceV1,
+        event: <WpCursorShapeDeviceV1 as Proxy>::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        warn!("unhandled cursor shape device event: {event:?}");
+    }
+}

--- a/src/clientside/mod.rs
+++ b/src/clientside/mod.rs
@@ -1,3 +1,4 @@
+mod cursor_shape;
 mod data_device;
 pub mod xdg_activation;
 
@@ -67,6 +68,7 @@ pub struct Globals {
     events: Vec<(ObjectKey, ObjectEvent)>,
     queued_events: Vec<mpsc::Receiver<(ObjectKey, ObjectEvent)>>,
     pub new_globals: Vec<Global>,
+    pub pointer: Option<wayland_client::protocol::wl_pointer::WlPointer>,
     pub selection: Option<wayland_client::protocol::wl_data_device::WlDataDevice>,
     pub selection_requests: Vec<(
         String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod clientside;
 mod server;
+mod utils;
 pub mod xstate;
 
 use crate::server::{PendingSurfaceState, ServerState};

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -383,6 +383,7 @@ impl HandleEvent for Pointer {
                 surface_x,
                 surface_y,
             } => 'enter: {
+                state.last_pointer_enter_serial = Some(serial);
                 let Some(surface_data): Option<&SurfaceData> = surface
                     .data::<ObjectKey>()
                     .copied()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,45 @@
+use wayland_protocols::wp::cursor_shape::v1::client::wp_cursor_shape_device_v1::Shape;
+
+pub fn cursor_name_to_shape(cursor: &str) -> Option<Shape> {
+    // x11 names loosely based on GDK and Chromium
+    match cursor {
+        "default" | "left_ptr" => Some(Shape::Default),
+        "context-menu" => Some(Shape::ContextMenu),
+        "help" | "question_arrow" => Some(Shape::Help),
+        "pointer" | "hand" => Some(Shape::Pointer),
+        "progress" | "left_ptr_watch" => Some(Shape::Progress),
+        "wait" | "watch" => Some(Shape::Wait),
+        "cell" | "plus" => Some(Shape::Cell),
+        "crosshair" | "cross" => Some(Shape::Crosshair),
+        "text" | "xterm" => Some(Shape::Text),
+        "vertical-text" => Some(Shape::VerticalText),
+        "alias" | "dnd-link" => Some(Shape::Alias),
+        "copy" | "dnd-copy" => Some(Shape::Copy),
+        "move" | "dnd-move" => Some(Shape::Move),
+        "no-drop" | "dnd-none" => Some(Shape::NoDrop),
+        "not-allowed" | "crossed_circle" => Some(Shape::NotAllowed),
+        "grab" | "hand1" => Some(Shape::Grab),
+        "grabbing" | "hand2" => Some(Shape::Grabbing),
+        "all-scroll" | "fleur" => Some(Shape::AllScroll),
+        "col-resize" => Some(Shape::ColResize),
+        "row-resize" => Some(Shape::RowResize),
+        "n-resize" | "top_side" => Some(Shape::NResize),
+        "e-resize" | "right_side" => Some(Shape::EResize),
+        "s-resize" | "bottom_side" => Some(Shape::SResize),
+        "w-resize" | "left_side" => Some(Shape::WResize),
+        "ne-resize" | "top_right_corner" => Some(Shape::NeResize),
+        "nw-resize" | "top_left_corner" => Some(Shape::NwResize),
+        "sw-resize" | "bottom_right_corner" => Some(Shape::SwResize),
+        "se-resize" | "bottom_left_corner" => Some(Shape::SeResize),
+        "ew-resize" | "sb_h_double_arrow" => Some(Shape::EwResize),
+        "ns-resize" | "sb_v_double_arrow" => Some(Shape::NsResize),
+        "nesw-resize" | "fd_double_arrow" => Some(Shape::NeswResize),
+        "nwse-resize" | "bd_double_arrow" => Some(Shape::NwseResize),
+        "zoom-in" => Some(Shape::ZoomIn),
+        "zoom-out" => Some(Shape::ZoomOut),
+        // TODO: Add when the updated protocol is available
+        // "dnd-ask" => Some(Shape::DndAsk),
+        // "all-resize" => Some(Shape::AllResize),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Mostly draft because disabling disabling the `client-cursors` feature causes weird behavior and crashes, we probably have to create our own fake cursor theme which we can then identify serials of.

It needs some testing (mainly with `client-cursors` enabled), I've made some very specific heuristics tailored to gtk for detecting default and hidden cursors, and also if there are any missing cursor name (they should print out as warnings).