### PR TITLE
Accept and pass -listenfd on to Xwayland

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ fn parse_args() -> RealData {
 
             data.listenfds.push(fd);
             i += 2;
+        } else if arg == "--test-listenfd-support" {
+            std::process::exit(0);
         } else {
             panic!("Unrecognized argument: {arg}");
         }

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -294,6 +294,14 @@ impl XState {
                 data: b"xwayland-satellite",
             })
             .unwrap();
+
+        self.connection
+            .send_and_check_request(&x::SetSelectionOwner {
+                owner: self.wm_window,
+                selection: self.atoms.wm_s0,
+                time: x::CURRENT_TIME,
+            })
+            .unwrap();
     }
 
     pub fn handle_events(&mut self, server_state: &mut super::RealServerState) {
@@ -886,6 +894,7 @@ xcb::atoms_struct! {
         wm_delete_window => b"WM_DELETE_WINDOW" only_if_exists = false,
         wm_transient_for => b"WM_TRANSIENT_FOR" only_if_exists = false,
         wm_state => b"WM_STATE" only_if_exists = false,
+        wm_s0 => b"WM_S0" only_if_exists = false,
         wm_check => b"_NET_SUPPORTING_WM_CHECK" only_if_exists = false,
         net_wm_name => b"_NET_WM_NAME" only_if_exists = false,
         wm_pid => b"_NET_WM_PID" only_if_exists = false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,7 +3,7 @@ use rustix::process::{Pid, Signal, WaitOptions};
 use std::collections::HashMap;
 use std::io::Write;
 use std::mem::ManuallyDrop;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::{AsRawFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -70,6 +70,10 @@ impl xwls::RunData for TestData {
 
     fn display(&self) -> Option<&str> {
         None
+    }
+
+    fn listenfds(&mut self) -> Vec<OwnedFd> {
+        Vec::new()
     }
 
     fn server(&self) -> Option<UnixStream> {


### PR DESCRIPTION
Implements the part of #102 necessary for compositor-driven on-demand activation. I've got a proof-of-concept working in niri using this, but I'll leave it as a draft until I flesh out the niri part some more.