### PR TITLE
Recognize drag and drop window type

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -639,7 +639,13 @@ impl XState {
                 x if x == self.window_atoms.normal || x == self.window_atoms.dialog => {
                     is_popup = override_redirect;
                 }
-                x if x == self.window_atoms.menu || x == self.window_atoms.tooltip => {
+                x if [
+                    self.window_atoms.menu,
+                    self.window_atoms.tooltip,
+                    self.window_atoms.drag_n_drop,
+                ]
+                .contains(&x) =>
+                {
                     is_popup = true;
                 }
                 _ => {
@@ -923,6 +929,7 @@ xcb::atoms_struct! {
         ty => b"_NET_WM_WINDOW_TYPE" only_if_exists = false,
         normal => b"_NET_WM_WINDOW_TYPE_NORMAL" only_if_exists = false,
         dialog => b"_NET_WM_WINDOW_TYPE_DIALOG" only_if_exists = false,
+        drag_n_drop => b"_NET_WM_WINDOW_TYPE_DND" only_if_exists = false,
         splash => b"_NET_WM_WINDOW_TYPE_SPLASH" only_if_exists = false,
         menu => b"_NET_WM_WINDOW_TYPE_MENU" only_if_exists = false,
         utility => b"_NET_WM_WINDOW_TYPE_UTILITY" only_if_exists = false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -320,6 +320,7 @@ xcb::atoms_struct! {
         win_type_normal => b"_NET_WM_WINDOW_TYPE_NORMAL",
         win_type_menu => b"_NET_WM_WINDOW_TYPE_MENU",
         win_type_tooltip => b"_NET_WM_WINDOW_TYPE_TOOLTIP",
+        win_type_dnd => b"_NET_WM_WINDOW_TYPE_DND",
         motif_wm_hints => b"_MOTIF_WM_HINTS" only_if_exists = false,
         mime1 => b"text/plain" only_if_exists = false,
         mime2 => b"blah/blah" only_if_exists = false,
@@ -1726,6 +1727,28 @@ fn popup_heuristics() {
         &[connection.atoms.win_type_tooltip],
     );
     f.map_as_popup(&mut connection, chromium_tooltip);
+}
+
+#[test]
+#[ignore]
+fn discord_drag_n_drop() {
+    let mut f = Fixture::new();
+    let mut connection = Connection::new(&f.display);
+
+    let discord_dnd = connection.new_window(connection.root, 20, 138, 48, 48, true);
+    connection.set_property(
+        discord_dnd,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_dnd],
+    );
+    connection.set_property::<u32>(
+        discord_dnd,
+        x::ATOM_WM_SIZE_HINTS,
+        x::ATOM_WM_HINTS,
+        &[516, 20, 137, 0, 0, 0, 0, 0, 0],
+    );
+    f.map_as_popup(&mut connection, discord_dnd);
 }
 
 #[test]


### PR DESCRIPTION
Recognize `_NET_WM_WINDOW_TYPE_DND` used by discord as a popup, fixing #166.

I tried to add an integration test for it, but found it was failing despite `guess_is_popup()` returning true for the test window. Ultimately I gave up trying to get the test to work correctly in service of submitting something, and marked the test `#[ignore]`.