### PR TITLE
Remove suspicious unwraps added in 799027d

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -464,8 +464,11 @@ impl Event for client::wl_pointer::Event {
                     warn!("could not enter surface: stale surface");
                     return;
                 };
+                let Some((surface, role, scale, window)) = query.get() else {
+                    warn!("could not enter surface: stale surface");
+                    return;
+                };
 
-                let (surface, role, scale, window) = query.get().unwrap();
                 cmd.insert(target, (*scale,));
 
                 let surface_is_popup = matches!(role, SurfaceRole::Popup(_));

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -736,8 +736,10 @@ impl<C: XConnection> ServerState<C> {
             debug!("not reconfiguring unknown window {:?}", event.window());
             return;
         };
-
-        let mut win = data.get::<&mut WindowData>().unwrap();
+        let Some(mut win) = data.get::<&mut WindowData>() else {
+            debug!("not reconfiguring unknown window {:?}", event.window());
+            return;
+        };
 
         let dims = WindowDims {
             x: event.x(),


### PR DESCRIPTION
Found this regression after crashing xwls about 2 seconds after opening Chaterino7 due to creating a stale surface. The offending `unwrap` is hit since the query `get` call is what finds the stale surface, rather than the construction of the query in `query_one`.

I took a rough look over the rest of that commit, and found a few additional blocks structured the same way and refactored them to also account for the split in query construction and query execution failures.

Doing double `let else` is a smidge unergonomic, but the query has to be held for the duration of the things it gets, so probably not a better way.