### PR TITLE
Fix `copy_from_wayland` breaking on Nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ all = "deny"
 name = "xwayland-satellite"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.83.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -2,9 +2,10 @@
 name = "testwl"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.87.0"
 
 [dependencies]
-wayland-protocols = { workspace = true, features = ["server", "unstable"] }
+wayland-protocols = { workspace = true, features = ["server", "staging", "unstable"] }
 wayland-server.workspace = true
 wl_drm = { path = "../wl_drm" }
 rustix = { workspace = true, features = ["pipe"] }

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map, HashMap, HashSet};
 use std::io::Read;
-use std::io::Write;
+use std::io::{Write, PipeWriter};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -997,7 +997,7 @@ impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
                     .position(|data| data.mime_type == mime_type)
                     .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
 
-                let mut stream = UnixStream::from(fd);
+                let mut stream = PipeWriter::from(fd);
                 stream.write_all(&data[pos].data).unwrap();
             }
             wl_data_offer::Request::Destroy => {}


### PR DESCRIPTION
Due to [Nightly changes with how `UnixStream` will handle `SIGPIPE`](https://github.com/rust-lang/rust/issues/139956), attempting to [write to a non-socket `UnixStream` will fail](https://github.com/rust-lang/rust/pull/140005#issuecomment-2853932531), a change which appears to be being stabilized.

This resolves the integrations which crash on Nightly by switching to a `PipeWriter`, a fairly new addition to the standard library, which does not have the non-socket restriction.

I think this bumps MSRV for testwl from 1.83.0 to 1.87.0, but testwl doesn't pass `cargo check`, not sure why, not sure how integrations still work, but whatever.