### PR TITLE
nix: Set `meta.mainProgram` attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
               description = "Xwayland outside your Wayland";
               homepage = "https://github.com/Supreeeme/xwayland-satellite";
               license = licenses.mpl20;
+              mainProgram = "xwayland-satellite";
               platforms = platforms.linux;
             };
           };


### PR DESCRIPTION
Setting the `meta.mainProgram` attribute allows `lib.getExe` function to (reliably) return a path to the actual xwayland-satellite binary. If the attribute isn't set the function infers the binary name from the package name (which is correct in this case) but it generates a warning as the binary could have a different name than the actual package.