### PR TITLE
Fix `copy_from_wayland` breaking in Nightly + CI tweaks (continues #198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   UBUNTU_DOCKERFILE: .github/workflows/ubuntu.dockerfile
+  ROOT_CARGO_TOML: Cargo.toml
 
 permissions:
   contents: read
@@ -23,19 +24,19 @@ jobs:
       pull-requests: read
       contents: read
     steps:
-      - if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            ${{ env.ROOT_CARGO_TOML }}
+          sparse-checkout-cone-mode: false
       - id: changed
-        uses: tj-actions/changed-files@v45
-        with:
-          files: ${{ env.UBUNTU_DOCKERFILE }}
+        run: ./.github/workflows/should-rebuild.sh
       - id: name
         run: echo "container_path=${{ env.REGISTRY }}/${GITHUB_REPOSITORY@L}" >> "$GITHUB_OUTPUT"
     outputs:
-      should-build: ${{ steps.changed.outputs.any_changed }}
+      should-build: ${{ steps.changed.outputs.should_build }}
       container-path: ${{ steps.name.outputs.container_path }}
 
   ubuntu-build:
@@ -74,6 +75,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
+    - name: Check
+      run: cargo check --keep-going --workspace --exclude xwayland-satellite
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests

--- a/.github/workflows/should-rebuild.sh
+++ b/.github/workflows/should-rebuild.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+git diff HEAD~1 --quiet -- "$UBUNTU_DOCKERFILE"
+if [ $? -eq 1 ]; then
+    msrv=$(awk '/^.*rust-version = "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+"$/ \
+    { print substr($NF, 2, length($NF) - 2) }' "$ROOT_CARGO_TOML");
+else
+    msrv=$(git diff HEAD~1 --output-indicator-new=+ -- "$ROOT_CARGO_TOML" |
+    awk '/^+.*rust-version = "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+"$/ \
+    { print substr($NF, 2, length($NF) - 2) }');
+fi
+
+if [ -z "$msrv" ]; then
+    echo "should_build=false" >> "$GITHUB_OUTPUT";
+else
+    echo "should_build=true" >> "$GITHUB_OUTPUT";
+    echo "msrv=$msrv" >> "$GITHUB_OUTPUT";
+fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ rustix = "0.38.31"
 [workspace.lints.clippy]
 all = "deny"
 
+[workspace.package]
+rust-version = "1.87.0"
+
 [package]
 name = "xwayland-satellite"
 version = "0.6.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.95"
 quote = "1.0.37"
-syn = "2.0.79"
+syn = { version = "2.0.79", features = ["full"] }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "macros"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "testwl"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-wayland-protocols = { workspace = true, features = ["server", "unstable"] }
+wayland-protocols = { workspace = true, features = ["server", "staging", "unstable"] }
 wayland-server.workspace = true
 wl_drm = { path = "../wl_drm" }
 rustix = { workspace = true, features = ["pipe"] }

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map, HashMap, HashSet};
 use std::io::Read;
-use std::io::Write;
+use std::io::{PipeWriter, Write};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -1026,7 +1026,7 @@ impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
                     .position(|data| data.mime_type == mime_type)
                     .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
 
-                let mut stream = UnixStream::from(fd);
+                let mut stream = PipeWriter::from(fd);
                 stream.write_all(&data[pos].data).unwrap();
             }
             wl_data_offer::Request::Destroy => {}

--- a/wl_drm/Cargo.toml
+++ b/wl_drm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wl_drm"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
See [the oriiginal explanation](https://github.com/Supreeeme/xwayland-satellite/pull/198#issue-3193403020) for these changes.

Since last time, I discovered that the `testwl` and `macros` would fail to build on their own due to missing feature flags. In `testwl`'s case, the "staging" feature flag was specified by `xwayland-satellite` itself, which is not a major deal since compiling `xwayland-satellite` is necessary for `testwl` to be useful. The `macros` package, on the other hand, needs the "full" feature flag of `syn`, and was only getting it by a *dependency* of `xwayland-satellite`, which had much more potential to break down the line. An additional check in CI for workspace members was added.

The CI now checks for package rebuilds on PRs, along with checking for a modification of the project-wide `rust-version`. Giving each project its own MSRV and rebuilding on a bump only if the combined latest MSRV was bumped felt not worth the additional complexity to me.

Lastly, the script which checks for if a rebuild is needed also determines the MSRV, although nothing it done with it yet. It should not be too hard to set the toolchain to the MSRV in the Dockerfile, which would rebuild the toolchain, and can be done either in this PR or in the future.