### PR TITLE
Use typestate to eliminate `None` connections

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
     info!("Starting xwayland-satellite version {version}");
 
     let socket = ListeningSocket::bind_auto("xwls", 1..=128).unwrap();
-    let mut display = Display::<RealServerState>::new().unwrap();
+    let mut display = Display::new().unwrap();
     let dh = display.handle();
     data.created_server();
 
@@ -203,7 +203,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             xstate.handle_events(&mut server_state);
         }
 
-        display.dispatch_clients(&mut server_state).unwrap();
+        display.dispatch_clients(server_state.inner_mut()).unwrap();
         server_state.run();
         display.flush_clients().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use xcb::x;
 pub trait XConnection: Sized + 'static {
     type X11Selection: X11Selection;
 
-    fn set_window_dims(&mut self, window: x::Window, dims: PendingSurfaceState);
+    fn set_window_dims(&mut self, window: x::Window, dims: PendingSurfaceState) -> bool;
     fn set_fullscreen(&mut self, window: x::Window, fullscreen: bool);
     fn focus_window(&mut self, window: x::Window, output_name: Option<String>);
     fn close_window(&mut self, window: x::Window);
@@ -134,8 +134,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         }
     };
 
-    let mut server_state = EarlyServerState::new(dh, data.server());
-    server_state.connect(connection);
+    let mut server_state = EarlyServerState::new(dh, data.server(), connection);
     server_state.run();
 
     // Remove the lifetimes on our fds to avoid borrowing issues, since we know they will exist for
@@ -177,8 +176,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         display.flush_clients().unwrap();
     }
 
-    let mut xstate: Option<XState> = None;
-    let xstate = xstate.insert(XState::new(xsock_wl.as_fd()));
+    let mut xstate = XState::new(xsock_wl.as_fd());
     let mut reader = BufReader::new(&ready_rx);
     {
         let mut display = String::new();

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -65,7 +65,7 @@ use wayland_server::{
 };
 
 // noop
-impl<C: XConnection> Dispatch<WlCallback, ()> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlCallback, ()> for InnerServerState<S> {
     fn request(
         _: &mut Self,
         _: &wayland_server::Client,
@@ -79,7 +79,7 @@ impl<C: XConnection> Dispatch<WlCallback, ()> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlSurface, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -182,7 +182,7 @@ impl<C: XConnection> Dispatch<WlSurface, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlRegion, client::wl_region::WlRegion> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlRegion, client::wl_region::WlRegion> for InnerServerState<S> {
     fn request(
         _: &mut Self,
         _: &wayland_server::Client,
@@ -202,9 +202,9 @@ impl<C: XConnection> Dispatch<WlRegion, client::wl_region::WlRegion> for ServerS
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<WlCompositor, ClientGlobalWrapper<client::wl_compositor::WlCompositor>>
-    for ServerState<C>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -251,7 +251,7 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection> Dispatch<WlBuffer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlBuffer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -272,7 +272,7 @@ impl<C: XConnection> Dispatch<WlBuffer, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlShmPool, client::wl_shm_pool::WlShmPool> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlShmPool, client::wl_shm_pool::WlShmPool> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -316,8 +316,8 @@ impl<C: XConnection> Dispatch<WlShmPool, client::wl_shm_pool::WlShmPool> for Ser
     }
 }
 
-impl<C: XConnection> Dispatch<WlShm, ClientGlobalWrapper<client::wl_shm::WlShm>>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<WlShm, ClientGlobalWrapper<client::wl_shm::WlShm>>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -340,7 +340,7 @@ impl<C: XConnection> Dispatch<WlShm, ClientGlobalWrapper<client::wl_shm::WlShm>>
     }
 }
 
-impl<C: XConnection> Dispatch<WlPointer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlPointer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -383,7 +383,7 @@ impl<C: XConnection> Dispatch<WlPointer, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlKeyboard, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlKeyboard, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -407,7 +407,7 @@ impl<C: XConnection> Dispatch<WlKeyboard, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlTouch, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlTouch, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -431,7 +431,7 @@ impl<C: XConnection> Dispatch<WlTouch, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<WlSeat, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlSeat, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -484,7 +484,7 @@ impl<C: XConnection> Dispatch<WlSeat, Entity> for ServerState<C> {
 
 macro_rules! only_destroy_request_impl {
     ($server:ty, $client:ty) => {
-        impl<C: XConnection> Dispatch<$server, Entity> for ServerState<C> {
+        impl<S: X11Selection> Dispatch<$server, Entity> for InnerServerState<S> {
             fn request(
                 state: &mut Self,
                 _: &Client,
@@ -512,9 +512,9 @@ macro_rules! only_destroy_request_impl {
 
 only_destroy_request_impl!(RelativePointerServer, RelativePointerClient);
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<RelativePointerManServer, ClientGlobalWrapper<RelativePointerManClient>>
-    for ServerState<C>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -545,7 +545,7 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection> Dispatch<WlOutput, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlOutput, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -569,9 +569,9 @@ impl<C: XConnection> Dispatch<WlOutput, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<s_dmabuf::zwp_linux_dmabuf_feedback_v1::ZwpLinuxDmabufFeedbackV1, Entity>
-    for ServerState<C>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -599,11 +599,11 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<
         s_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
         c_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
-    > for ServerState<C>
+    > for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -662,11 +662,11 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<
         s_dmabuf::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1,
         ClientGlobalWrapper<c_dmabuf::zwp_linux_dmabuf_v1::ZwpLinuxDmabufV1>,
-    > for ServerState<C>
+    > for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -711,7 +711,7 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection> Dispatch<WlDrmServer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<WlDrmServer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -827,7 +827,7 @@ impl<C: XConnection> Dispatch<WlDrmServer, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<XdgOutputServer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<XdgOutputServer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -849,8 +849,8 @@ impl<C: XConnection> Dispatch<XdgOutputServer, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<OutputManServer, ClientGlobalWrapper<OutputManClient>>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<OutputManServer, ClientGlobalWrapper<OutputManClient>>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -880,7 +880,7 @@ impl<C: XConnection> Dispatch<OutputManServer, ClientGlobalWrapper<OutputManClie
     }
 }
 
-impl<C: XConnection> Dispatch<ConfinedPointerServer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<ConfinedPointerServer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -902,7 +902,7 @@ impl<C: XConnection> Dispatch<ConfinedPointerServer, Entity> for ServerState<C> 
     }
 }
 
-impl<C: XConnection> Dispatch<LockedPointerServer, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<LockedPointerServer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
@@ -941,9 +941,9 @@ impl<C: XConnection> Dispatch<LockedPointerServer, Entity> for ServerState<C> {
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<PointerConstraintsServer, ClientGlobalWrapper<PointerConstraintsClient>>
-    for ServerState<C>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1039,11 +1039,11 @@ impl<C: XConnection>
     }
 }
 
-impl<C: XConnection>
+impl<S: X11Selection>
     Dispatch<
         s_tablet::zwp_tablet_manager_v2::ZwpTabletManagerV2,
         ClientGlobalWrapper<c_tablet::zwp_tablet_manager_v2::ZwpTabletManagerV2>,
-    > for ServerState<C>
+    > for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1091,8 +1091,8 @@ only_destroy_request_impl!(
     c_tablet::zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2
 );
 
-impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_pad_v2::ZwpTabletPadV2, Entity>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_pad_v2::ZwpTabletPadV2, Entity>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1125,8 +1125,8 @@ impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_pad_v2::ZwpTabletPadV2, Entit
     }
 }
 
-impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, Entity>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, Entity>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1167,8 +1167,8 @@ impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, Ent
     }
 }
 
-impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2, Entity>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_pad_ring_v2::ZwpTabletPadRingV2, Entity>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1200,8 +1200,8 @@ impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_pad_ring_v2::ZwpTabletPadRing
     }
 }
 
-impl<C: XConnection> Dispatch<s_tablet::zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2, Entity>
-    for ServerState<C>
+impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_pad_strip_v2::ZwpTabletPadStripV2, Entity>
+    for InnerServerState<S>
 {
     fn request(
         state: &mut Self,
@@ -1251,9 +1251,9 @@ impl<T: Proxy> Default for ClientGlobalWrapper<T> {
 
 macro_rules! global_dispatch_no_events {
     ($server:ty, $client:ty) => {
-        impl<C: XConnection> GlobalDispatch<$server, Global> for ServerState<C>
+        impl<S: X11Selection> GlobalDispatch<$server, Global> for InnerServerState<S>
         where
-            ServerState<C>: Dispatch<$server, ClientGlobalWrapper<$client>>,
+            InnerServerState<S>: Dispatch<$server, ClientGlobalWrapper<$client>>,
             MyWorld: wayland_client::Dispatch<$client, ()>,
         {
             fn bind(
@@ -1282,11 +1282,11 @@ macro_rules! global_dispatch_no_events {
 
 macro_rules! global_dispatch_with_events {
     ($server:ty, $client:ty) => {
-        impl<C: XConnection> GlobalDispatch<$server, Global> for ServerState<C>
+        impl<S: X11Selection> GlobalDispatch<$server, Global> for InnerServerState<S>
         where
             $server: Resource,
             $client: Proxy,
-            ServerState<C>: Dispatch<$server, Entity>,
+            InnerServerState<S>: Dispatch<$server, Entity>,
             MyWorld: wayland_client::Dispatch<$client, Entity>,
         {
             fn bind(
@@ -1325,7 +1325,7 @@ global_dispatch_no_events!(
     c_tablet::zwp_tablet_manager_v2::ZwpTabletManagerV2
 );
 
-impl<C: XConnection> GlobalDispatch<WlSeat, Global> for ServerState<C> {
+impl<S: X11Selection> GlobalDispatch<WlSeat, Global> for InnerServerState<S> {
     fn bind(
         state: &mut Self,
         _: &DisplayHandle,
@@ -1348,7 +1348,7 @@ impl<C: XConnection> GlobalDispatch<WlSeat, Global> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> GlobalDispatch<WlOutput, Global> for ServerState<C> {
+impl<S: X11Selection> GlobalDispatch<WlOutput, Global> for InnerServerState<S> {
     fn bind(
         state: &mut Self,
         _: &DisplayHandle,
@@ -1383,7 +1383,7 @@ impl<C: XConnection> GlobalDispatch<WlOutput, Global> for ServerState<C> {
 }
 global_dispatch_with_events!(WlDrmServer, WlDrmClient);
 
-impl<C: XConnection> GlobalDispatch<XwaylandShellV1, ()> for ServerState<C> {
+impl<S: X11Selection> GlobalDispatch<XwaylandShellV1, ()> for InnerServerState<S> {
     fn bind(
         _: &mut Self,
         _: &DisplayHandle,
@@ -1396,7 +1396,7 @@ impl<C: XConnection> GlobalDispatch<XwaylandShellV1, ()> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<XwaylandShellV1, ()> for ServerState<C> {
+impl<S: X11Selection> Dispatch<XwaylandShellV1, ()> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         client: &wayland_server::Client,
@@ -1432,7 +1432,7 @@ impl<C: XConnection> Dispatch<XwaylandShellV1, ()> for ServerState<C> {
     }
 }
 
-impl<C: XConnection> Dispatch<XwaylandSurfaceV1, Entity> for ServerState<C> {
+impl<S: X11Selection> Dispatch<XwaylandSurfaceV1, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -718,7 +718,6 @@ impl Event for client::wl_keyboard::Event {
 
 impl Event for client::wl_touch::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         match self {
             Self::Down {
                 serial,
@@ -1034,7 +1033,7 @@ impl OutputEvent {
                     y,
                     state,
                 );
-                let state = state.deref_mut();
+                let global_output_offset = state.global_output_offset;
 
                 let (output, dimensions, xdg) = state
                     .world
@@ -1044,8 +1043,8 @@ impl OutputEvent {
                     .unwrap();
 
                 output.geometry(
-                    x - state.global_output_offset.x.value,
-                    y - state.global_output_offset.y.value,
+                    x - global_output_offset.x.value,
+                    y - global_output_offset.y.value,
                     physical_width,
                     physical_height,
                     convert_wenum(subpixel),
@@ -1076,7 +1075,6 @@ impl OutputEvent {
                 height,
                 refresh,
             } => {
-                let state = state.deref_mut();
                 let (output, dimensions) = state
                     .world
                     .query_one_mut::<(&WlOutput, &mut OutputDimensions)>(target)
@@ -1093,7 +1091,6 @@ impl OutputEvent {
                 output.mode(convert_wenum(flags), width, height, refresh);
             }
             Event::Scale { factor } => {
-                let state = state.deref_mut();
                 debug!(
                     "{} scale: {factor}",
                     state.world.get::<&WlOutput>(target).unwrap().id()
@@ -1109,7 +1106,6 @@ impl OutputEvent {
                 }
             }
             Event::Name { name } => {
-                let state = state.deref_mut();
                 state
                     .world
                     .get::<&WlOutput>(target)
@@ -1137,7 +1133,6 @@ impl OutputEvent {
         match event {
             Event::LogicalPosition { x, y } => {
                 update_output_offset(target, OutputDimensionsSource::Xdg, x, y, state);
-                let state = state.deref_mut();
                 state
                     .world
                     .get::<&XdgOutputServer>(target)
@@ -1148,7 +1143,6 @@ impl OutputEvent {
                     );
             }
             Event::LogicalSize { .. } => {
-                let state = state.deref_mut();
                 let (xdg, dimensions) = state
                     .world
                     .query_one_mut::<(&XdgOutputServer, &OutputDimensions)>(target)
@@ -1249,7 +1243,6 @@ impl Event for zwp_confined_pointer_v1::Event {
 
 impl Event for zwp_tablet_seat_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         let seat = state.world.get::<&TabletSeatServer>(target).unwrap();
         match self {
             Self::TabletAdded { id } => {
@@ -1292,7 +1285,6 @@ impl Event for zwp_tablet_v2::Event {
 
 impl Event for zwp_tablet_pad_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         let pad = state.world.get::<&TabletPadServer>(target).unwrap();
         let s_surf;
         match self {
@@ -1346,7 +1338,6 @@ impl Event for zwp_tablet_pad_v2::Event {
 
 impl Event for zwp_tablet_tool_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         match self {
             Self::ProximityIn {
                 serial,
@@ -1447,7 +1438,6 @@ where
 
 impl Event for zwp_tablet_pad_group_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         let group = state.world.get::<&TabletPadGroupServer>(target).unwrap();
         match self {
             Self::Buttons { buttons } => group.buttons(buttons),
@@ -1476,7 +1466,6 @@ impl Event for zwp_tablet_pad_group_v2::Event {
 
 impl Event for zwp_tablet_pad_ring_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         let ring = state.world.get::<&TabletPadRingServer>(target).unwrap();
         simple_event_shunt! {
             ring, self => [
@@ -1491,7 +1480,6 @@ impl Event for zwp_tablet_pad_ring_v2::Event {
 
 impl Event for zwp_tablet_pad_strip_v2::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
-        let state = state.deref_mut();
         let strip = state.world.get::<&TabletPadStripServer>(target).unwrap();
         simple_event_shunt! {
             strip, self => [

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -227,10 +227,13 @@ impl XState {
         r
     }
 
-    pub fn server_state_setup(&self, server_state: &mut super::RealServerState) {
+    pub fn server_state_setup(
+        &self,
+        server_state: super::EarlyServerState,
+    ) -> super::RealServerState {
         let mut c = RealConnection::new(self.connection.clone(), self.atoms.clone());
         c.update_outputs(self.root);
-        server_state.set_x_connection(c);
+        server_state.upgrade_connection(c)
     }
 
     fn set_root_property<P: x::PropEl>(&self, property: x::Atom, r#type: x::Atom, data: &[P]) {
@@ -1186,15 +1189,14 @@ impl RealConnection {
             self.outputs, self.primary_output
         );
     }
-}
-
-impl XConnection for RealConnection {
-    type X11Selection = Selection;
 
     fn root_window(&self) -> x::Window {
         self.connection.get_setup().roots().next().unwrap().root()
     }
+}
 
+impl XConnection for RealConnection {
+    type X11Selection = Selection;
     fn set_window_dims(&mut self, window: x::Window, dims: crate::server::PendingSurfaceState) {
         trace!("set window dimensions {window:?} {dims:?}");
         unwrap_or_skip_bad_window!(self.connection.send_and_check_request(&x::ConfigureWindow {


### PR DESCRIPTION
I have been thinking about #187 , since when I looked into it, I diagnosed the root problem as `server_state.run()` assuming `xstate` was not `None`, even though at the beginning of the program it necessarily had to be while managing XWayland's initialization. This felt to me like a design flaw, so after a little tinkering, I found a way to type the pre-initialized and post-initialized states of `ServerState`

The first commit is a refactor which seperates `connection` from the rest of `ServerState`'s contents so the rest of the server state can be transferred when the connection type is changed. Notably, this relies on the `Dispatch` impls not using `connection`, but Wayland events should never be touching the X connection anwyay. This is not a complex change but it does nothing on its own.

The second commit defines `EarlyConnection`, the type which serves as the minimal filler connection before the true connection is initialized and substituted in with `upgrade_connection`. Since this involves type changes, a big chunk of `main` also needed refactors, but it also removed a lot of the conditional checks jammed into the original `main` loop.

The third commit is the payoff. `ServerState::connection` and `InnerServerState::client` can now never be `None`, and so all of the `Option`s and `unwrap` associated with them can be removed. I also wanted [a conditional debug statement](https://github.com/Supreeeme/xwayland-satellite/commit/9872aa9519ecb05c7173fd1ba7f46f668c276c98#diff-1b33b1af1a8e35c4f324cac560774fc81865de0181472f33fd544f199e8cf931R153), so I ended up also added a return type to `set_window_dims`, which required additional changes.

The last commit gets the integration tests to work again, which in commits 2 & 3 always abort (with the `IO Safety violation: owned file descriptor already closed` message) due to [the `xcb::Connection::connect_to_fd*` functions not being sound](https://github.com/rust-x-bindings/rust-xcb/issues/167) (at least to me it is unsound. I have a minimal example and will make the issue and RustSec PR). The fix should prevent that abort from also spuriously occuring in integration runs.