### PR TITLE
Bump `xcb` to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e2f212bb1a92cd8caac8051b829a6582ede155ccb60b5d5908b81b100952be"
+checksum = "f07c123b796139bfe0603e654eaf08e132e52387ba95b252c78bad3640ba37ea"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rustix = { workspace = true, features = ["event"] }
 wayland-client.workspace = true
 wayland-protocols = { workspace = true, features = ["client", "server", "staging", "unstable"] }
 wayland-server.workspace = true
-xcb = { version = "1.3.0", features = ["composite", "randr", "res"] }
+xcb = { version = "1.6.0", features = ["composite", "randr", "res"] }
 wl_drm = { path = "wl_drm" }
 log = "0.4.21"
 env_logger = "0.11.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,6 @@ pub fn main(mut data: impl RunData) -> Option<()> {
     data.created_server();
 
     let (xsock_wl, xsock_xwl) = UnixStream::pair().unwrap();
-    // XCB takes responsibility for cleaning up this FD, but since connecting takes a RawFd at the
-    // FFI level, see (`XState::new`), `xsock_wl`'s destructor also closes the FD, leading the FD
-    // being closed twice. This mainly caused problems in the integration tests, where `xsock_wl`'s
-    // destructor would be run after the descriptor was freed, leading to an opaque abort message.
-    // See https://github.com/rust-x-bindings/rust-xcb/issues/282 for further explanation.
-    let xsock_wl = Box::leak(Box::new(xsock_wl));
     // Prevent creation of new Xwayland command from closing fd
     rustix::io::fcntl_setfd(&xsock_xwl, rustix::io::FdFlags::empty()).unwrap();
 

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -9,7 +9,7 @@ use bitflags::bitflags;
 use log::{debug, trace, warn};
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::os::fd::{AsRawFd, BorrowedFd};
+use std::os::fd::BorrowedFd;
 use std::rc::Rc;
 use xcb::{x, Xid, XidNew};
 use xcb_util_cursor::{Cursor, CursorContext};
@@ -124,8 +124,8 @@ pub struct XState {
 impl XState {
     pub fn new(fd: BorrowedFd) -> Self {
         let connection = Rc::new(
-            xcb::Connection::connect_to_fd_with_extensions(
-                fd.as_raw_fd(),
+            xcb::Connection::connect_with_fd_and_extensions(
+                BorrowedFd::try_clone_to_owned(&fd).unwrap(),
                 None,
                 &[
                     xcb::Extension::Composite,


### PR DESCRIPTION
Now that `xcb` has deprecated `Connection::connect_to_fd_with_extensions` for the I/O safety problems it caused and added `Connection::connect_with_fd_and_extensions` to serve as the sound alternative, we bump to 1.6.0 and switch to it. Nicely get to remove the hacky line we were previously relying on for correct behavior.

Also, I have several small commits I want to contribute after the CI stuff gets resolved. Should I split them into seperate PRs or can I put them all in one?