### PR TITLE
Prevent copy tests from failing in Rust 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustix = "0.38.31"
 all = "deny"
 
 [workspace.package]
-rust-version = "1.83.0"
+rust-version = "1.87.0"
 
 [package]
 name = "xwayland-satellite"

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::{hash_map, HashMap, HashSet};
 use std::io::Read;
-use std::io::Write;
+use std::io::{PipeWriter, Write};
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -1134,7 +1134,7 @@ impl Dispatch<ZwpPrimarySelectionOfferV1, Vec<PasteData>> for State {
                     .position(|data| data.mime_type == mime_type)
                     .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
 
-                let mut stream = UnixStream::from(fd);
+                let mut stream = PipeWriter::from(fd);
                 stream.write_all(&data[pos].data).unwrap();
             }
             Request::Destroy => {}
@@ -1219,7 +1219,7 @@ impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
                     .position(|data| data.mime_type == mime_type)
                     .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
 
-                let mut stream = UnixStream::from(fd);
+                let mut stream = PipeWriter::from(fd);
                 stream.write_all(&data[pos].data).unwrap();
             }
             wl_data_offer::Request::Destroy => {}


### PR DESCRIPTION
Finally, the original issue that required all the CI wrangling.

As a reminder, in Rust 1.90 [the behavior of UnixStream is changing to set `MSG_NOSIGNAL` on writes](https://github.com/rust-lang/rust/issues/139956). This means [`UnixStream` is no longer suited for writing to non-socket file descriptors](https://github.com/rust-lang/rust/pull/140005#issuecomment-2853932531). 

This fix uses the fairly new PipeWriter, which is designed to do this kind of write, and bumps MSRV from 1.83.0 to 1.87.0.

Happy I did a second run of all of the tests on beta, which caught the second `UnixStream` introduced in the primary selection changes.