### PR TITLE
Fix properly specify subprojects' required features

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,4 +12,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.95"
 quote = "1.0.37"
-syn = "2.0.79"
+syn = { version = "2.0.79", features = ["full"] }

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-wayland-protocols = { workspace = true, features = ["server", "unstable"] }
+wayland-protocols = { workspace = true, features = ["server", "staging", "unstable"] }
 wayland-server.workspace = true
 wl_drm = { path = "../wl_drm" }
 rustix = { workspace = true, features = ["pipe"] }


### PR DESCRIPTION
I found a couple of incomplete feature specifications which cause the `macros` and `testwl` workspaces to not pass `cargo check`. The "staging" feature needed by `testwl` is needed by `xwayland_satellite` itself, so it was unlikely to become a problem, but the "full" feature of `syn` in the `macros` workspace was only being fulfilled by `xwayland_satellite`'s other depenedencies, which had the potential (albeit small) for breakage on dependency updates. Since these features were already fulfilled, no Cargo.lock updates are needed.