### PR TITLE
Only use `PipeWriter` in `testw`l if `rust-version` >= 1.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sd-notify"
@@ -635,6 +635,7 @@ name = "testwl"
 version = "0.1.0"
 dependencies = [
  "rustix",
+ "rustversion",
  "wayland-protocols",
  "wayland-server",
  "wl_drm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["macros", "testwl"]
+members = ["macros", "testwl", "wl_drm"]
 
 [workspace.dependencies]
 wayland-client = "0.31.2"
@@ -12,7 +12,7 @@ rustix = "0.38.31"
 all = "deny"
 
 [workspace.package]
-rust-version = "1.87.0"
+rust-version = "1.83.0"
 
 [package]
 name = "xwayland-satellite"

--- a/testwl/Cargo.toml
+++ b/testwl/Cargo.toml
@@ -11,3 +11,4 @@ wayland-protocols = { workspace = true, features = ["server", "staging", "unstab
 wayland-server.workspace = true
 wl_drm = { path = "../wl_drm" }
 rustix = { workspace = true, features = ["pipe"] }
+rustversion = "1.0.22"


### PR DESCRIPTION
By using conditional compilation, we now support running the test suite with Rust versions 1.83 to 1.86 again. This allows us to lower the `rust-version` specified in the root Cargo.toml (because it was controlling the toolchain used in CI) to 1.83, resolving #230.

This solution keeps tests operational on our MSRV while also lowering it. It would have been unsatisfying to have an MSRV which could not compile the tests.

`rustversion` was selected as the dependency to control the conditional compilation since it was already a build dependency needed by `vergen-gitcl`, so no new dependencies were added.

If I had thought to use conditional compilation earlier, there would not have been the whole CI rewrite fiasco (point at idiot LOL :rofl: :point_up: )