### PR TITLE
Add metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.83.0"
 [package]
 name = "xwayland-satellite"
 version = "0.7.0"
+authors = ["Shawn Wallace"]
+license = "MPL-2.0"
+description = "xwayland-satellite grants rootless Xwayland integration to any Wayland compositor implementing xdg_wm_base and viewporter. This is particularly useful for compositors that (understandably) do not want to go through implementing support for rootless Xwayland themselves."
 edition = "2021"
 rust-version.workspace = true
 


### PR DESCRIPTION
This is the minimum metadata to allow `cargo-deb` to build a package without warnings.