### PR TITLE
tests: preset `RUST_TEST_THREADS` to 1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUST_TEST_THREADS = "1"


### PR DESCRIPTION
Since running the tests using all available threads is inconsistent, set the default number of test threads to be 1. This can be overridden with another use of the environment variable or with the `--test-threads` flag. This improves packages which use `cargo test` as part of the build process with no changes needeed from the packagers' side.

`RUST_TEST_THREADS` is documented as deprecated, but cannot be removed by Cargo before a way to specify Cargo test flags becomes available.