### PR TITLE
fix: popup position

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -941,13 +941,14 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
         if dims == win.attrs.dims {
             return;
-        } else {
+        } else if win.attrs.is_popup {
             win.attrs.dims = dims;
         }
 
         debug!("Reconfiguring {:?} {:?}", event.window(), dims);
 
         if !win.mapped {
+            win.attrs.dims = dims;
             return;
         }
 


### PR DESCRIPTION
Maybe this can fix some popup menu position issues, at least for WeChat.

I found WeChat's menu position is set after it's mapped.

The position starts at (0,0). When win.mapped is set to true, the reconfiguration path is bypassed, though the dims now contain the genuine coordinates.

``` rust
if !win.mapped {
    win.attrs.dims = dims;
    return;
}
```

<img width="209" height="350" alt="screenshot-2025-11-19_14-15-18" src="https://github.com/user-attachments/assets/ad89092c-1f98-4e8e-bacf-5693215a57a3" />

There are still other popup detection issues, but those are related to the heuristic function and are outside the scope of this PR. Therefore, this PR can only partially address the related problems."