### PR TITLE
fix: problem unwrap in `wl_pointer::Event` (again)

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -624,7 +624,7 @@ impl Event for client::wl_pointer::Event {
                             .insert_one(target, CurrentSurface::Decoration(parent))
                             .unwrap();
                     } else {
-                        warn!("could not enter surface: stale surface");
+                        warn!("could not enter surface {}: stale surface", surface.id());
                     }
 
                     return;
@@ -676,7 +676,7 @@ impl Event for client::wl_pointer::Event {
                 if !surface.is_alive() {
                     return;
                 }
-                debug!("leaving surface ({serial})");
+                debug!("leaving surface ({})", surface.id());
                 if let Ok(CurrentSurface::Decoration(parent)) =
                     state.world.remove_one::<CurrentSurface>(target)
                 {
@@ -706,7 +706,10 @@ impl Event for client::wl_pointer::Event {
                     return;
                 }
                 {
-                    let surface = state.world.get::<&CurrentSurface>(target).unwrap();
+                    let Ok(surface) = state.world.get::<&CurrentSurface>(target) else {
+                        warn!("could not motion on surface: stale surface");
+                        return;
+                    };
                     if let CurrentSurface::Decoration(parent) = &*surface {
                         decoration::handle_pointer_motion(state, *parent, surface_x, surface_y);
                         return;
@@ -735,10 +738,16 @@ impl Event for client::wl_pointer::Event {
                 }
                 let mut cmd = CommandBuffer::new();
 
-                let mut query = state
-                    .world
-                    .query_one::<(&WlPointer, &client::wl_seat::WlSeat, &CurrentSurface)>(target)
-                    .unwrap();
+                let Ok(mut query) =
+                    state
+                        .world
+                        .query_one::<(&WlPointer, &client::wl_seat::WlSeat, &CurrentSurface)>(
+                            target,
+                        )
+                else {
+                    warn!("could not click on surface: stale surface");
+                    return;
+                };
 
                 let (server, seat, current_surface) = query.get().unwrap();
 


### PR DESCRIPTION
I triggered the unwrap in the `Motion` case while using the color picker in Krita. If you hold down the mouse such that the color comparison pop-up opens and flick to it, you can sometimes enter and motion on a stale surface. Somewhat inconsistent to trigger.

I also removed the unwrap in the `Button` event since it is logically equivalent to the other unwrap. A few logging statements also got changed to give wl_surface details.