### PR TITLE
fix: dragging jitter bug

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -976,7 +976,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
         if dims == win.attrs.dims {
             return;
-        } else if win.attrs.is_popup {
+        } else if win.attrs.is_popup && (win.attrs.dims.x <= 0 || win.attrs.dims.y <= 0) {
             win.attrs.dims = dims;
         }
 


### PR DESCRIPTION
In fixing the pop-up window coordinates last time, a new bug was introduced: dragged objects would produce high-frequency jitter. Now, we've limited it so that the x and y coordinates of the pop-up window are only reassigned when they are less than or equal to 0. This way, dragging no longer causes jitter.

### BEFORE

https://github.com/user-attachments/assets/46d39b26-7d1e-4155-b151-f64c8955f57b

### AFTER

https://github.com/user-attachments/assets/fca5cf0e-77f4-4e0e-8dfa-3557c85bfc91

### EDIT:

I found that the `reconfigure_popup_after_map` test failed. Should we mark dragging as a special state, or modify the test data?