### PR TITLE
Detect yabridge popups (hardcoded wm_class)

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -697,7 +697,7 @@ impl XState {
         wm_class: Option<String>,
     ) -> XResult<bool> {
         if let Some(class) = wm_class {
-            // If class is predefined is popup
+            // If class is predefined it's a popup
             if KNOWN_POPUP_WMCLASS.contains(&class.as_ref()) {
                 return Ok(true);
             }


### PR DESCRIPTION
Anything that has "yabridge-host" as a `wm_class` is 100% popup, tooltip, drag and drop operation. Yabridge popups cant be properly identified with ATOMS.

Yabridge popups come in 4 forms:
1. Tooltips
2. Menu popups
3. Right Click context menus
4. Drag and drop within the plugin

All of them have same generic `xprop` ATOMS such as: `_KDE_NET_WM_STATE_SKIP_SWITCHER, _NET_WM_STATE_ABOVE, _NET_WM_STATE_SKIP_PAGER, _NET_WM_STATE_SKIP_TASKBAR` and its always `_NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_NORMAL`. This makes it difficult to differentiate them from other popups and introduce regressions. One thing in common they all have is that `WM_CLASS = "yabridge-host.exe`. This is more of a hack but it isolates `yabridge` from rest of them.

Predefined array of known popup wm_classes is used here for potentially expanding it in future for other apps.

Fixes: https://github.com/Supreeeme/xwayland-satellite/issues/221 , https://github.com/Supreeeme/xwayland-satellite/issues/293

After thoroughly testing this for a while now in `Reaper` I can confirm it works without any regressions or misbehaviors. Huge number of plugins now work properly with popups, tooltips and drag and drop.

Not sure how you feel about this fix since its a hardcoded workaround but currently don't seem to find any other better solution. Feel free to close it if you don't like this approach.