### PR TITLE
Advertise _NET_WM_MOVERESIZE

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -302,6 +302,7 @@ impl XState {
                 self.atoms.motif_wm_hints,
                 self.atoms.net_wm_state,
                 self.atoms.wm_fullscreen,
+                self.atoms.moveresize,
             ],
         );
 


### PR DESCRIPTION
Makes GTK 4 use compositor-side move and resize.

Disclaimer: idk anything about X11; @bugaevc suggested me that GTK 4 can do compositor-side move/resize, so we checked in gdb, and this was the atom that it was checking the presence of.