### PR TITLE
fix: panic caused by `TabletServer` double init

### DIFF
--- a/src/server/clientside.rs
+++ b/src/server/clientside.rs
@@ -298,13 +298,14 @@ impl<P: Proxy> LateInitObjectKey<P>
 where
     P::Event: Into<ObjectEvent>,
 {
-    pub fn init(&self, key: Entity) {
-        self.key.set(key).expect("Object key should not be set");
+    pub fn get_or_init(&self, f: impl FnOnce() -> Entity) -> Entity {
+        let key = self.key.get_or_init(f);
         if let Some(sender) = self.sender.lock().unwrap().take() {
             for event in self.queued_events.lock().unwrap().drain(..) {
-                sender.send((key, event.into())).unwrap();
+                sender.send((*key, event.into())).unwrap();
             }
         }
+        *key
     }
 
     pub fn get(&self) -> Entity {


### PR DESCRIPTION
A compositor can send `zwp_tablet_seat_v2::tablet_added` followed by `zwp_tablet_pad_v2::enter` with the same tablet id calls `from_client`, which calls `LateInitObjectKey` twice. This function expects the underlying `OnceLock` to be uninitialized, so this scenario panics. Not every compositor sends the `Enter` event; this was found using Sway.

This fixes the issue by changing the `set`/`expect` to a `get_or_init`, returning the `Entity` contained in the `OnceLock`. On the event side, `from_client` needed to support only creating a serverside Wayland resource and adding it to the world if it did not already exist. This is complicated by not being able to return the server, as it may be in the `hecs::Ref` wrapper type. In addition, the result of `World::get` must be dropped before the entity is spawned, as does everything else dropped before the `World::spawn_at` calls. I decided the way to meet these needs was through rewriting `from_client` as the `handle_tablet_event` macro. Some of its logic is extracted into short, generic functions, since macros cannot determine the correct generics otherwise.