### PR TITLE
check if window is main window

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -659,8 +659,15 @@ impl XState {
             .resolve()?
             .flatten();
 
-        let is_popup =
-            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some())?;
+        // Main window cannot be a popup
+        // check if current window and pid window are same
+        let is_main_window = server_state
+            .get_window_pid(window)
+            .map(|pid| server_state.is_pid_window(window, pid))
+            .unwrap_or(false);
+
+        let is_popup = !is_main_window
+            && self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some())?;
         server_state.set_popup(window, is_popup);
         if let Some(parent) = transient_for.and_then(|t| (!is_popup).then_some(t)) {
             server_state.set_transient_for(window, parent);


### PR DESCRIPTION
popup heuristic can mark main app window as popup. When that happens one app can spawn as anothers app popup if last_focused_toplevel exists (which points to second app). App marked as popup will ONLY spawn as toplevel if no other app is opened (last_focused_toplevel does not exits).

Since main app cannot be a popup we check the current window against pid. If current window is same as pid window then its main app window.

While it fixed https://github.com/Supreeeme/xwayland-satellite/issues/362 it still has some issues that needs to be tracked down and fixed. While now the app spawns as toplevel it can crash other wine windows when focus is changed (mouse hover over app that was previously spawned as popup).

```
09:01:21 [AR-1-6ILMQntx] [Wine STDERR] X Error of failed request:  BadWindow (invalid Window parameter)
09:01:21 [AR-1-6ILMQntx] [Wine STDERR]   Major opcode of failed request:  10 (X_UnmapWindow)
09:01:21 [AR-1-6ILMQntx] [Wine STDERR]   Resource id in failed request:  0x2c00001
09:01:21 [AR-1-6ILMQntx] [Wine STDERR]   Serial number of failed request:  268
09:01:21 [AR-1-6ILMQntx] [Wine STDERR]   Current serial number in output stream:  269
```

I assume because its still tracking `last_focused_toplevel' when `activate_window` was called and `last_hovered` then unmapping is called on stale window when focus is changed.

EDIT: Crash happens even without this commit just by launching the app alone without any other app opened so there is no `last_focused_toplevel` ( https://github.com/Supreeeme/xwayland-satellite/issues/362 `1.`)

https://github.com/user-attachments/assets/0a171589-cb7f-4967-8b71-6517514ec9ac

EDIT3: It seems to be a wine bug in 9.xx since this does not happen on 11 when focus change

https://github.com/user-attachments/assets/1737638b-ffae-41e4-a2c9-a7f7561791ca

This above previously would crash reaper and now with updated wine it works fine. 

But still on its own (when opened and there are no other apps opened) it can crash sometimes. It does not crash always but very rarely and I cant even reproduce it which was not the case before (would always crash no matter what with or without this commit)

EDIT4: On its own crash is not related to satellite (it also crashes on hyprlands x). So this is some buggy app (but to be completely honest its a obscure one that 3 people in the world are using). It just happened to be on my system for test case.



