### PR TITLE
fix: panics on output removal

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -983,7 +983,7 @@ impl Event for client::wl_touch::Event {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(super) struct OnOutput(pub Entity);
 struct OutputName(String);
 fn get_output_name(output: Option<&OnOutput>, world: &World) -> Option<String> {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2770,6 +2770,17 @@ fn disconnected_output_rescaling() {
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
 
     f.remove_output(output_ext);
+    let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
+    let fractional = surface_data
+        .fractional
+        .as_ref()
+        .expect("No fractional scale for surface");
+    fractional.preferred_scale(120); // 1.0 scale
+    f.run();
+    f.run();
+    // An fractional scale change done while the surface is on a removed output is ignored
+    assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+
     f.testwl.move_surface_to_output(id, &output_main);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
     let fractional = surface_data
@@ -2779,7 +2790,7 @@ fn disconnected_output_rescaling() {
     fractional.preferred_scale(240); // 2.0 scale
     f.run();
     f.run();
-    // Afteer the output is disconnected, only the 2x scale output remains, so use that scale
+    // After the output is disconnected, only the 2x scale output remains, so use that scale
     assert_eq!(f.satellite.inner.new_scale, Some(2.0));
 }
 


### PR DESCRIPTION
Despawning the output when its global was removed proved to be overzealous, as the Dispatch of `zxdg_output_v1` still needed it for cleanup. Instead, only the `OutputScaleFactor` element is removed, and every surface entity with an `OnOutput` referencing the removed output, so scaling events sent to surfaces on non-existent outputs did not panic or use the provided scale as if an output still existed for it.