### PR TITLE
Update dialog window type handling for popups

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -763,7 +763,7 @@ impl XState {
         for ty in window_types {
             match ty {
                 x if x == self.window_atoms.normal => is_popup = override_redirect || wmhint_popup,
-                x if x == self.window_atoms.dialog => is_popup = override_redirect,
+                x if x == self.window_atoms.dialog => is_popup = override_redirect || has_transient_for,
                 x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,
                 x if [
                     self.window_atoms.menu,


### PR DESCRIPTION
Dialog windows with WM_TRANSIENT_FOR (parent window) but without override_redirect are currently classified as regular toplevels, preventing them from positioning themselves. This causes issues with applications like the [Star Citizen launcher](https://github.com/Supreeeme/xwayland-satellite/issues/189) where dialogs crash or fail to render

This fix utilizes the already present has_transient_for check to properly classify these dialog windows as popups