### PR TITLE
fix: take ownership of `_NET_WM_CM_S0`

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -333,6 +333,14 @@ impl XState {
                 time: x::CURRENT_TIME,
             })
             .unwrap();
+
+        self.connection
+            .send_and_check_request(&x::SetSelectionOwner {
+                owner: self.wm_window,
+                selection: self.atoms.net_wm_cm_s0,
+                time: x::CURRENT_TIME,
+            })
+            .unwrap();
     }
 
     pub fn handle_events(&mut self, server_state: &mut super::RealServerState) {
@@ -1034,6 +1042,7 @@ xcb::atoms_struct! {
         wm_transient_for => b"WM_TRANSIENT_FOR" only_if_exists = false,
         wm_state => b"WM_STATE" only_if_exists = false,
         wm_s0 => b"WM_S0" only_if_exists = false,
+        net_wm_cm_s0 => b"_NET_WM_CM_S0" only_if_exists = false,
         wm_check => b"_NET_SUPPORTING_WM_CHECK" only_if_exists = false,
         net_wm_name => b"_NET_WM_NAME" only_if_exists = false,
         wm_pid => b"_NET_WM_PID" only_if_exists = false,


### PR DESCRIPTION
EWMH section 8.1 requires that compositing window managers take ownership of `_NET_WM_CM_Sn` for each screen `n` they manage (in the case of `satellite`, this is just screen 0).

The Avalonia UI toolkit needs this atom to be owned in order to provide transparent window support. Resolves #376.