### PR TITLE
fix: avoid panic when no outputs are present

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -701,25 +701,25 @@ impl<C: XConnection> ServerState<C> {
             let mut scale;
 
             let mut outputs = self.world.query_mut::<&OutputScaleFactor>().into_iter();
-            let (_, output_scale) = outputs.next().unwrap();
+            if let Some((_, output_scale)) = outputs.next() {
+                scale = output_scale.get();
 
-            scale = output_scale.get();
-
-            for (_, output_scale) in outputs {
-                if output_scale.get() != scale {
-                    mixed_scale = true;
-                    scale = scale.min(output_scale.get());
+                for (_, output_scale) in outputs {
+                    if output_scale.get() != scale {
+                        mixed_scale = true;
+                        scale = scale.min(output_scale.get());
+                    }
                 }
-            }
 
-            if mixed_scale {
-                warn!(
-                    "Mixed output scales detected, choosing to give apps the smallest detected scale ({scale}x)"
-                );
-            }
+                if mixed_scale {
+                    warn!(
+                        "Mixed output scales detected, choosing to give apps the smallest detected scale ({scale}x)"
+                    );
+                }
 
-            debug!("Using new scale {scale}");
-            self.new_scale = Some(scale);
+                debug!("Using new scale {scale}");
+                self.new_scale = Some(scale);
+            }
         }
 
         {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1774,6 +1774,17 @@ fn output_offset_remove_output() {
 }
 
 #[test]
+fn remove_all_outputs() {
+    let (mut f, _) = TestFixture::new_with_compositor();
+
+    let (_, output) = f.new_output(0, 0);
+    f.run();
+
+    f.remove_output(output);
+    f.run();
+}
+
+#[test]
 fn output_offset_surface_positioning() {
     let (mut f, comp) = TestFixture::new_with_compositor();
 


### PR DESCRIPTION
Fixes this bug I was having when turning off my TV on Hyprland:
```
⋊> ~ RUST_BACKTRACE=full xwayland-satellite                                                                                                                                                                 19:15:20
 2026-02-26T18:15:23.556Z INFO  xwayland_satellite > Starting xwayland-satellite version v0.8.1-1-g33c344f-dirty
 2026-02-26T18:15:23.655Z INFO  xwayland_satellite::xstate > xfixes version: 1.0
 2026-02-26T18:15:23.657Z INFO  xwayland_satellite         > Connected to Xwayland on :0
 2026-02-26T18:15:23.658Z INFO  xwayland_satellite         > Successfully notified systemd of ready state.
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > The XKEYBOARD keymap compiler (xkbcomp) reports:
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > > Warning:          Unsupported maximum keycode 708, clipping.
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > >                   X11 cannot support keycodes above 255.
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > > Warning:          Virtual modifier Hyper multiply defined
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > >                   Using 0, ignoring 0
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > > Warning:          Virtual modifier ScrollLock multiply defined
 2026-02-26T18:15:23.662Z INFO  xwayland_process           > >                   Using 0, ignoring 0
 2026-02-26T18:15:23.663Z INFO  xwayland_process           > Errors from xkbcomp are not fatal to the X server

thread 'main' (925410) panicked at /xwayland-satellite/src/server/mod.rs:704:52:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0:     0x5636cceecbe2 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h718e2d17a1928e63
   1:     0x5636cceff06f - core::fmt::write::h1d2246b072ea91eb
   2:     0x5636ccebd823 - std::io::Write::write_fmt::haf55272405c09d9b
   3:     0x5636ccec88a2 - std::sys::backtrace::BacktraceLock::print::h61c3bd81a9458a03
   4:     0x5636ccecb66f - std::panicking::default_hook::{{closure}}::haf1ffb5d1e33a97f
   5:     0x5636ccecb4c9 - std::panicking::default_hook::hc32245deb6eaa988
   6:     0x5636ccecbc45 - std::panicking::panic_with_hook::h43adc00fd0e494cb
   7:     0x5636ccecbaa6 - std::panicking::panic_handler::{{closure}}::h44391079756da3e7
   8:     0x5636ccec89e9 - std::sys::backtrace::__rust_end_short_backtrace::h934e1568393e5b8f
   9:     0x5636cceb167d - __rustc[d9b87f19e823c0ef]::rust_begin_unwind
  10:     0x5636ccf08c70 - core::panicking::panic_fmt::h62031895f6e012da
  11:     0x5636ccf08c4c - core::panicking::panic::hfe04fa80380612d4
  12:     0x5636ccf081d9 - core::option::unwrap_failed::h02f41afc018838f2
  13:     0x5636ccb8f58b - xwayland_satellite::server::ServerState<C>::run::hfc4d85d9876003a6
  14:     0x5636ccc12d87 - xwayland_satellite::main::h2e6cb341a99152ff
  15:     0x5636ccbe66e3 - std::sys::backtrace::__rust_begin_short_backtrace::h582d10273b0d3890
  16:     0x5636ccbfa5c9 - std::rt::lang_start::{{closure}}::h3dcc6f02e0dcf2a1
  17:     0x5636ccebf670 - std::rt::lang_start_internal::h00c7908c7c2f92b8
  18:     0x5636ccc1a855 - main
  19:     0x7f678cad86c1 - <unknown>
  20:     0x7f678cad87f9 - __libc_start_main
  21:     0x5636ccb41a95 - _start
  22:                0x0 - <unknown>
```