### PR TITLE
Check _WINE_HWND_STYLE flags for POPUP

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -710,8 +710,11 @@ impl XState {
         let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
         let mut wine_popup = false;
-
+        let mut wine_hints = false;
+        // Used for steam games, motif hints are not enough here to determine popup vs toplevel on
+        // some apps
         if let Some(style) = wine_style {
+            wine_hints = true;
             wine_popup = style.has_popup_flag();
         }
 
@@ -783,7 +786,11 @@ impl XState {
         for ty in window_types {
             match ty {
                 x if x == self.window_atoms.normal => {
-                    is_popup = wine_popup || override_redirect || wmhint_popup
+                    if wine_hints {
+                        is_popup = wine_popup
+                    } else {
+                        is_popup = override_redirect || wmhint_popup
+                    }
                 }
                 x if x == self.window_atoms.dialog => is_popup = override_redirect,
                 x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -635,6 +635,7 @@ impl XState {
         let class = self.get_wm_class(window);
         let size_hints = self.get_wm_size_hints(window);
         let motif_wm_hints = self.get_motif_wm_hints(window);
+        let wine_hwnd_style = self.get_wine_hwnd_style(window);
         let wm_hints = self.get_wm_hints(window);
         let mut title = name.resolve()?;
         if title.is_none() {
@@ -655,7 +656,7 @@ impl XState {
         if let Some(decorations) = motif_hints.as_ref().and_then(|m| m.decorations) {
             server_state.set_win_decorations(window, decorations);
         }
-
+        let wine_style = wine_hwnd_style.resolve()?;
         let transient_for = self
             .property_cookie_wrapper(
                 window,
@@ -668,7 +669,7 @@ impl XState {
             .flatten();
 
         let is_popup =
-            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some())?;
+            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some(), wine_style)?;
         server_state.set_popup(window, is_popup);
         if let Some(parent) = transient_for.and_then(|t| (!is_popup).then_some(t)) {
             server_state.set_transient_for(window, parent);
@@ -698,10 +699,17 @@ impl XState {
         motif_hints: Option<motif::Hints>,
         wm_hints: Option<WmHints>,
         has_transient_for: bool,
+        wine_style: Option<WineHwndStyle>,
     ) -> XResult<bool> {
         let mut motif_popup = false;
         let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
+        //Take priority (appears in games/steam/proton). Motif hints can fail on games so check
+        //directly what wine is assigning. There are some cases where even wine reports window as
+        //WS_POPUP...
+        if wine_style.is_some_and(|s| s.has_popup_flag()) {
+            return Ok(true)
+        }
 
         let attrs = self
             .connection
@@ -948,6 +956,29 @@ impl XState {
         }
     }
 
+    fn get_wine_hwnd_style(
+        &self,
+        window: x::Window,
+    ) -> PropertyCookieWrapper<'_, impl PropertyResolver<Output = WineHwndStyle>> {
+        let cookie = self.get_property_cookie(
+            window,
+            self.atoms.wine_hwnd_style,
+            x::ATOM_CARDINAL,
+            1,
+        );
+
+        let resolver = |reply: x::GetPropertyReply| {
+            let data: &[u32] = reply.value();
+            WineHwndStyle::from(data)
+        };
+
+        PropertyCookieWrapper {
+            connection: &self.connection,
+            cookie,
+            resolver,
+        }
+    }
+
     fn get_pid(&self, window: x::Window) -> Option<u32> {
         let Some(pid) = self
             .connection
@@ -1053,6 +1084,7 @@ xcb::atoms_struct! {
         client_list => b"_NET_CLIENT_LIST" only_if_exists = false,
         supported => b"_NET_SUPPORTED" only_if_exists = false,
         motif_wm_hints => b"_MOTIF_WM_HINTS" only_if_exists = false,
+        wine_hwnd_style => b"_WINE_HWND_STYLE" only_if_exists = false,
         utf8_string => b"UTF8_STRING" only_if_exists = false,
         clipboard => b"CLIPBOARD" only_if_exists = false,
         clipboard_targets => b"_clipboard_targets" only_if_exists = false,
@@ -1120,6 +1152,40 @@ pub struct WinSize {
 pub struct WmNormalHints {
     pub min_size: Option<WinSize>,
     pub max_size: Option<WinSize>,
+}
+
+bitflags! {
+    /// https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub struct Window32Style: u32 {
+        const WS_POPUP = 0x80000000;
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct WineHwndStyle {
+    pub style: Option<Window32Style>,
+}
+
+impl From<&[u32]> for WineHwndStyle {
+    fn from(value: &[u32]) -> Self {
+        let mut ret = Self::default();
+
+        if let Some(&raw) = value.first() {
+            ret.style = Some(Window32Style::from_bits_truncate(raw));
+        }
+
+        ret
+    }
+}
+
+impl WineHwndStyle {
+    pub fn has_popup_flag(&self) -> bool {
+        match self.style{
+            Some(s) => s.contains(Window32Style::WS_POPUP),
+            None => false,
+        }
+    }
 }
 
 impl From<&[u32]> for WmNormalHints {

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -709,13 +709,10 @@ impl XState {
         let mut motif_popup = false;
         let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
-        let mut wine_popup = false;
-        let mut wine_hints = false;
-        // Used for steam games, motif hints are not enough here to determine popup vs toplevel on
-        // some apps
+        let mut is_wine_toplevel = false;
+        // Used for steam/proton games, motif hints are not enough here to determine popup vs toplevel
         if let Some(style) = wine_style {
-            wine_hints = true;
-            wine_popup = style.has_popup_flag();
+            is_wine_toplevel = !style.is_popup();
         }
 
         let attrs = self
@@ -786,13 +783,11 @@ impl XState {
         for ty in window_types {
             match ty {
                 x if x == self.window_atoms.normal => {
-                    if wine_hints {
-                        is_popup = wine_popup
-                    } else {
-                        is_popup = override_redirect || wmhint_popup
-                    }
+                    is_popup = !is_wine_toplevel && (override_redirect || wmhint_popup);
                 }
-                x if x == self.window_atoms.dialog => is_popup = override_redirect,
+                x if x == self.window_atoms.dialog => {
+                    is_popup = override_redirect || has_transient_for
+                }
                 x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,
                 x if [
                     self.window_atoms.menu,
@@ -1168,13 +1163,25 @@ bitflags! {
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct Window32Style: u32 {
         const WS_POPUP = 0x80000000;
-        const WS_CLIPSIBLINGS = 0x04000000;
+        const WS_CAPTION    = 0x00C00000;
+        const WS_THICKFRAME = 0x00040000;
+    }
+}
+
+bitflags! {
+    /// https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    pub struct Window32StyleEx: u32 {
+        const WS_EX_APPWINDOW  = 0x00040000;
+        const WS_EX_TOOLWINDOW = 0x00000080;
+        const WS_EX_LAYERED    = 0x00080000;
     }
 }
 
 #[derive(Default, Debug)]
 pub struct WineHwndStyle {
     pub style: Option<Window32Style>,
+    pub ex_style: Option<Window32StyleEx>,
 }
 
 impl From<&[u32]> for WineHwndStyle {
@@ -1184,16 +1191,33 @@ impl From<&[u32]> for WineHwndStyle {
         if let Some(&raw) = value.first() {
             ret.style = Some(Window32Style::from_bits_truncate(raw));
         }
+        if let Some(&raw) = value.get(1) {
+            ret.ex_style = Some(Window32StyleEx::from_bits_truncate(raw));
+        }
 
         ret
     }
 }
 
 impl WineHwndStyle {
-    pub fn has_popup_flag(&self) -> bool {
+    pub fn is_popup(&self) -> bool {
+        if let Some(ex) = self.ex_style {
+            if ex.contains(Window32StyleEx::WS_EX_APPWINDOW) {
+                return false;
+            }
+            // Toolwindows are popups
+            if ex.contains(Window32StyleEx::WS_EX_TOOLWINDOW) {
+                return true;
+            }
+        }
+
         match self.style {
             Some(s) => {
-                s.contains(Window32Style::WS_POPUP) && !s.contains(Window32Style::WS_CLIPSIBLINGS)
+                if !s.contains(Window32Style::WS_POPUP) {
+                    return false;
+                }
+                // caption or frame it toplevel
+                !s.intersects(Window32Style::WS_CAPTION | Window32Style::WS_THICKFRAME)
             }
             None => false,
         }
@@ -1262,6 +1286,7 @@ mod motif {
     }
 
     bitflags! {
+        #[derive(Debug)]
         pub(super) struct Functions: u32 {
             const All = 1;
             const Resize = 2;

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -1160,6 +1160,7 @@ bitflags! {
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     pub struct Window32Style: u32 {
         const WS_POPUP = 0x80000000;
+        const WS_CLIPSIBLINGS = 0x04000000;
     }
 }
 
@@ -1183,7 +1184,9 @@ impl From<&[u32]> for WineHwndStyle {
 impl WineHwndStyle {
     pub fn has_popup_flag(&self) -> bool {
         match self.style {
-            Some(s) => s.contains(Window32Style::WS_POPUP),
+            Some(s) => {
+                s.contains(Window32Style::WS_POPUP) && !s.contains(Window32Style::WS_CLIPSIBLINGS)
+            }
             None => false,
         }
     }

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -707,8 +707,8 @@ impl XState {
         //Take priority (appears in games/steam/proton). Motif hints can fail on games so check
         //directly what wine is assigning. There are some cases where even wine reports window as
         //WS_POPUP...
-        if wine_style.is_some_and(|s| s.has_popup_flag()) {
-            return Ok(true)
+        if let Some(style) = wine_style {
+            return Ok(style.has_popup_flag());
         }
 
         let attrs = self

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -709,11 +709,10 @@ impl XState {
         let mut motif_popup = false;
         let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
-        //Take priority (appears in games/steam/proton). Motif hints can fail on games so check
-        //directly what wine is assigning. There are some cases where even wine reports window as
-        //WS_POPUP...
+        let mut wine_popup = false;
+
         if let Some(style) = wine_style {
-            return Ok(style.has_popup_flag());
+            wine_popup = style.has_popup_flag();
         }
 
         let attrs = self
@@ -783,7 +782,9 @@ impl XState {
         let mut known_window_type = false;
         for ty in window_types {
             match ty {
-                x if x == self.window_atoms.normal => is_popup = override_redirect || wmhint_popup,
+                x if x == self.window_atoms.normal => {
+                    is_popup = wine_popup || override_redirect || wmhint_popup
+                }
                 x if x == self.window_atoms.dialog => is_popup = override_redirect,
                 x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,
                 x if [

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -668,8 +668,13 @@ impl XState {
             .resolve()?
             .flatten();
 
-        let is_popup =
-            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some(), wine_style)?;
+        let is_popup = self.guess_is_popup(
+            window,
+            motif_hints,
+            wmhints,
+            transient_for.is_some(),
+            wine_style,
+        )?;
         server_state.set_popup(window, is_popup);
         if let Some(parent) = transient_for.and_then(|t| (!is_popup).then_some(t)) {
             server_state.set_transient_for(window, parent);
@@ -960,12 +965,8 @@ impl XState {
         &self,
         window: x::Window,
     ) -> PropertyCookieWrapper<'_, impl PropertyResolver<Output = WineHwndStyle>> {
-        let cookie = self.get_property_cookie(
-            window,
-            self.atoms.wine_hwnd_style,
-            x::ATOM_CARDINAL,
-            1,
-        );
+        let cookie =
+            self.get_property_cookie(window, self.atoms.wine_hwnd_style, x::ATOM_CARDINAL, 1);
 
         let resolver = |reply: x::GetPropertyReply| {
             let data: &[u32] = reply.value();
@@ -1181,7 +1182,7 @@ impl From<&[u32]> for WineHwndStyle {
 
 impl WineHwndStyle {
     pub fn has_popup_flag(&self) -> bool {
-        match self.style{
+        match self.style {
             Some(s) => s.contains(Window32Style::WS_POPUP),
             None => false,
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2197,6 +2197,34 @@ fn popup_heuristics() {
     );
     f.map_as_toplevel(&mut connection, wallpaper_engine);
 
+    let warframe = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.set_property(
+        warframe,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_normal],
+    );
+    connection.set_property(
+        warframe,
+        connection.atoms.motif_wm_hints,
+        connection.atoms.motif_wm_hints,
+        &[0x3_u32, 0x24, 0x0, 0x0, 0x0],
+    );
+    connection.set_property(
+        warframe,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+
+    connection.set_property(
+        warframe,
+        x::ATOM_CARDINAL,
+        connection.atoms.wine_hwnd_style,
+        &[2491416576_u32],
+    );
+    f.map_as_toplevel(&mut connection, warframe);
+
     let wine_popup = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(
         wine_popup,
@@ -2206,9 +2234,21 @@ fn popup_heuristics() {
     );
     connection.set_property(
         wine_popup,
+        connection.atoms.motif_wm_hints,
+        connection.atoms.motif_wm_hints,
+        &[0x3_u32, 0x24, 0x0, 0x0, 0x0],
+    );
+    connection.set_property(
+        wine_popup,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+    connection.set_property(
+        wine_popup,
         x::ATOM_CARDINAL,
         connection.atoms.wine_hwnd_style,
-        &[2147483648_u32],
+        &[2617245696_u32],
     );
     f.map_as_popup(&mut connection, wine_popup);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2208,7 +2208,7 @@ fn popup_heuristics() {
         wine_popup,
         x::ATOM_CARDINAL,
         connection.atoms.wine_hwnd_style,
-        &[2483027968_u32],
+        &[2147483648_u32],
     );
     f.map_as_popup(&mut connection, wine_popup);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -347,6 +347,7 @@ xcb::atoms_struct! {
         win_type_dnd => b"_NET_WM_WINDOW_TYPE_DND",
         win_type_combo => b"_NET_WM_WINDOW_TYPE_COMBO",
         motif_wm_hints => b"_MOTIF_WM_HINTS" only_if_exists = false,
+        wine_hwnd_style => b"_WINE_HWND_STYLE" only_if_exists = false,
         wm_hints => b"WM_HINTS",
         mime1 => b"text/plain" only_if_exists = false,
         mime2 => b"blah/blah" only_if_exists = false,
@@ -2195,6 +2196,21 @@ fn popup_heuristics() {
         &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
     );
     f.map_as_toplevel(&mut connection, wallpaper_engine);
+
+    let wine_popup = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.set_property(
+        wine_popup,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_normal],
+    );
+    connection.set_property(
+        wine_popup,
+        x::ATOM_CARDINAL,
+        connection.atoms.wine_hwnd_style,
+        &[2483027968_u32],
+    );
+    f.map_as_popup(&mut connection, wine_popup);
 }
 
 #[test]


### PR DESCRIPTION
Steam games provide this Atom. Since `_MOTIF_WM_HINTS` can fail on them we check _WINE_HWND_STYLE` flags: https://learn.microsoft.com/en-us/windows/win32/winmsg/window-styles
https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles

We determine by `WS_POPUP, WS_CAPTION, WS_THICKFRAME` + `WS_EX_APPWINDOW, WS_EX_TOOLWINDOW` is the wine window a popup.

Hopefully fixes https://github.com/Supreeeme/xwayland-satellite/issues/392
Fixes also: https://github.com/Supreeeme/xwayland-satellite/issues/392#issuecomment-4006218161

Setting as draft since it needs testing + more work (breaks other steam apps).

EDIT: Latest commit tested across these games/apps no regressions seen:
<img width="391" height="713" alt="image" src="https://github.com/user-attachments/assets/fb408ffe-e354-4d92-a246-f3c10465abba" />

NOTE: This fix affects only games run thru steam/proton

