### PR TITLE
fix: cast ExitStatus to correct type, remove Boxes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
     ];
 
     fn xwayland_exit_code(rx: &mut UnixStream) -> ExitStatus {
-        let mut data = [0; (i32::BITS / 8) as usize];
+        let mut data = [0; std::mem::size_of::<i32>()];
         rx.read_exact(&mut data).unwrap();
         ExitStatus::from_raw(i32::from_ne_bytes(data))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use server::selection::{Clipboard, Primary};
 use smithay_client_toolkit::data_device_manager::WritePipe;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
-use std::os::unix::net::UnixStream;
+use std::os::unix::{net::UnixStream, process::ExitStatusExt};
 use std::process::{Command, ExitStatus, Stdio};
 use wayland_server::{Display, ListeningSocket};
 use xcb::x;
@@ -121,9 +121,9 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             let line = line.unwrap();
             info!(target: "xwayland_process", "{line}");
         }
-        let status = Box::new(xwayland.wait().unwrap());
-        let status = Box::into_raw(status) as usize;
-        finish_tx.write_all(&status.to_ne_bytes()).unwrap();
+        let status = xwayland.wait().unwrap().into_raw();
+        // On a successful integration test, the rx will be dropped, so keep logs/GDB clean
+        let _ = finish_tx.write_all(&status.to_ne_bytes());
     });
 
     let mut ready_fds = [
@@ -131,11 +131,10 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         PollFd::new(&finish_rx, PollFlags::IN),
     ];
 
-    fn xwayland_exit_code(rx: &mut UnixStream) -> Box<ExitStatus> {
-        let mut data = [0; (usize::BITS / 8) as usize];
+    fn xwayland_exit_code(rx: &mut UnixStream) -> ExitStatus {
+        let mut data = [0; (i32::BITS / 8) as usize];
         rx.read_exact(&mut data).unwrap();
-        let data = usize::from_ne_bytes(data);
-        unsafe { Box::from_raw(data as *mut _) }
+        ExitStatus::from_raw(i32::from_ne_bytes(data))
     }
 
     let connection = match poll(&mut ready_fds, None) {
@@ -179,7 +178,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             Ok(_) => {
                 if !fds[3].revents().is_empty() {
                     let status = xwayland_exit_code(&mut quit_rx);
-                    if *status != ExitStatus::default() {
+                    if status != ExitStatus::default() {
                         error!("Xwayland exited early with {status}");
                     }
                     return None;
@@ -246,7 +245,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             Ok(_) => {
                 if !fds[3].revents().is_empty() {
                     let status = xwayland_exit_code(&mut quit_rx);
-                    if *status != ExitStatus::default() {
+                    if status != ExitStatus::default() {
                         error!("Xwayland exited early with {status}");
                     }
                     return None;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -102,12 +102,11 @@ impl Drop for Fixture {
         let thread = unsafe { ManuallyDrop::take(&mut self.thread) };
         // Sending anything to the quit receiver to stop the main loop. Then we guarantee a main
         // thread does not use file descriptors which outlive the Fixture's BorrowedFd
-        let return_ptr = Box::into_raw(Box::new(0_usize)) as usize;
         // If the receiver end of the pipe closed, the main thread dropped it, which means that
         // thread already terminated
         if self
             .quit_tx
-            .write_all(&return_ptr.to_ne_bytes())
+            .write_all(&0_i32.to_ne_bytes())
             .is_err_and(|e| e.kind() != std::io::ErrorKind::BrokenPipe)
         {
             panic!("could not message the main thread to terminate");


### PR DESCRIPTION
Absolutely no clue why Past Me thought `usize` was the correct type to convert `ExitStatus` from. Rust docs make it really clear it is a `c_int` (i32) on Unix.

Past Me also decided both leaking memory with `Box::into_raw` then unsoundly calling `Box::from_raw` on a pointer to a stack-allocated array was smart. Dunno why. Loser did not even leave a safety comment smh.

Did I actually author this exactly a year ago? Proves how much I'm still improving, on the plus side.