### PR TITLE
Fix premature toplevel export for origin-mapped X11 windows

### DIFF
--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -92,8 +92,9 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
     ) {
         let data = state.world.entity(*entity).unwrap();
         let mut role = data.get::<&mut SurfaceRole>();
+        let waiting_for_initial_role = data.has::<x::Window>() && role.is_none();
         let xdg = role.as_ref().and_then(|role| role.xdg());
-        let configured = xdg.is_none_or(|xdg| xdg.configured);
+        let configured = !waiting_for_initial_role && xdg.is_none_or(|xdg| xdg.configured);
         let client = data.get::<&client::wl_surface::WlSurface>().unwrap();
 
         let mut cmd = CommandBuffer::new();
@@ -1578,11 +1579,8 @@ impl<S: X11Selection> Dispatch<XwaylandSurfaceV1, Entity> for InnerServerState<S
                     let win = data.get::<&x::Window>().as_deref().copied().unwrap();
                     state.windows.insert(win, *entity);
                     debug!("associate {surface_id} with {win:?} (serial {serial:?})");
-                    if data.get::<&WindowData>().unwrap().mapped
-                        && state.create_role_window(win, *entity)
-                    {
-                        state.activate_window(win);
-                    }
+                    let _ = data;
+                    state.maybe_create_mapped_window_role(win);
                 } else {
                     state.world.insert(*entity, (serial,)).unwrap();
                 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -404,10 +404,13 @@ impl SurfaceEvents {
                     }
                 };
 
+                let window = data.get::<&WindowData>().unwrap();
+
                 role.xdg_mut().unwrap().pending = Some(PendingSurfaceState {
+                    x: window.attrs.dims.x as i32,
+                    y: window.attrs.dims.y as i32,
                     width,
                     height,
-                    ..Default::default()
                 });
             }
             xdg_toplevel::Event::Close => {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::net::UnixStream;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use wayland_client::protocol::wl_subcompositor::WlSubcompositor;
 use wayland_client::{
     Connection, EventQueue, Proxy, QueueHandle,
@@ -115,15 +115,26 @@ struct WindowOutputOffset {
     y: i32,
 }
 
+#[derive(Debug, Default)]
+enum InitialToplevelMapState {
+    #[default]
+    None,
+    Deferred { deadline: Instant },
+    Released,
+}
+
 #[derive(Debug)]
 struct WindowData {
     mapped: bool,
     attrs: WindowAttributes,
     output_offset: WindowOutputOffset,
     activation_token: Option<String>,
+    initial_toplevel_map_state: InitialToplevelMapState,
 }
 
 impl WindowData {
+    const DEFERRED_INITIAL_TOPLEVEL_TIMEOUT: Duration = Duration::from_millis(200);
+
     fn new(override_redirect: bool, dims: WindowDims, activation_token: Option<String>) -> Self {
         Self {
             mapped: false,
@@ -134,7 +145,41 @@ impl WindowData {
             },
             output_offset: WindowOutputOffset::default(),
             activation_token,
+            initial_toplevel_map_state: InitialToplevelMapState::None,
         }
+    }
+
+    fn should_defer_initial_toplevel_map(&self) -> bool {
+        !self.attrs.is_popup
+            && !self
+                .attrs
+                .decorations
+                .is_some_and(|decorations| decorations.is_serverside())
+            && self.attrs.dims.x == 0
+            && self.attrs.dims.y == 0
+            && matches!(self.initial_toplevel_map_state, InitialToplevelMapState::None)
+    }
+
+    fn defer_initial_toplevel_map(&mut self) {
+        self.initial_toplevel_map_state = InitialToplevelMapState::Deferred {
+            deadline: Instant::now() + Self::DEFERRED_INITIAL_TOPLEVEL_TIMEOUT,
+        };
+    }
+
+    fn deferred_initial_toplevel_deadline(&self) -> Option<Instant> {
+        match self.initial_toplevel_map_state {
+            InitialToplevelMapState::Deferred { deadline } => Some(deadline),
+            InitialToplevelMapState::None | InitialToplevelMapState::Released => None,
+        }
+    }
+
+    fn release_initial_toplevel_map(&mut self) -> bool {
+        if matches!(self.initial_toplevel_map_state, InitialToplevelMapState::Deferred { .. }) {
+            self.initial_toplevel_map_state = InitialToplevelMapState::Released;
+            return true;
+        }
+
+        false
     }
 
     fn update_output_offset<C: XConnection>(
@@ -149,6 +194,15 @@ impl WindowData {
         }
 
         let dims = &mut self.attrs.dims;
+
+        // A non-zero startup position is already in global X11 coordinates when the
+        // surface first enters an output. Record the output origin without shifting
+        // the window again; later output moves should still apply deltas normally.
+        if self.output_offset == WindowOutputOffset::default() && (dims.x != 0 || dims.y != 0) {
+            self.output_offset = offset;
+            return;
+        }
+
         dims.x += (offset.x - self.output_offset.x) as i16;
         dims.y += (offset.y - self.output_offset.y) as i16;
         self.output_offset = offset;
@@ -739,6 +793,7 @@ impl<C: XConnection> ServerState<C> {
 
         self.handle_selection_events();
         self.handle_activations();
+        self.release_expired_deferred_initial_toplevels();
         if let Err(e) = self.queue.flush() {
             match e {
                 wayland_client::backend::WaylandError::Io(error)
@@ -1027,18 +1082,167 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         self.world.insert(id, (SurfaceSerial(serial),)).unwrap();
     }
 
+    fn maybe_create_mapped_window_role(&mut self, window: x::Window) -> bool {
+        let Some(entity) = self.windows.get(&window).copied() else {
+            return false;
+        };
+
+        if self.world.get::<&WlSurface>(entity).is_err()
+            || self.world.get::<&SurfaceRole>(entity).is_ok()
+        {
+            return false;
+        }
+
+        let mut win = self.world.get::<&mut WindowData>(entity).unwrap();
+        if !win.mapped {
+            return false;
+        }
+
+        if win.should_defer_initial_toplevel_map() {
+            debug!(
+                "deferring initial toplevel creation for {window:?} until startup geometry settles; provisional dims {:?}",
+                win.attrs.dims
+            );
+            win.defer_initial_toplevel_map();
+            return false;
+        }
+
+        if win.deferred_initial_toplevel_deadline().is_some() {
+            return false;
+        }
+
+        drop(win);
+
+        let is_toplevel = self.create_role_window(window, entity);
+        if is_toplevel {
+            self.activate_window(window);
+        }
+
+        is_toplevel
+    }
+
+    fn release_deferred_initial_toplevel_map(&mut self, window: x::Window, reason: &str) -> bool {
+        let Some(entity) = self.windows.get(&window).copied() else {
+            return false;
+        };
+
+        let Some(mut win) = self
+            .world
+            .entity(entity)
+            .ok()
+            .map(|data| data.get::<&mut WindowData>().unwrap())
+        else {
+            return false;
+        };
+
+        let dims = win.attrs.dims;
+        if !win.release_initial_toplevel_map() {
+            return false;
+        }
+
+        debug!(
+            "releasing deferred initial toplevel creation for {window:?} after {reason}; dims={dims:?}"
+        );
+        drop(win);
+
+        if self.world.get::<&WlSurface>(entity).is_ok()
+            && self.world.get::<&SurfaceRole>(entity).is_err()
+        {
+            let is_toplevel = self.create_role_window(window, entity);
+            if is_toplevel {
+                self.activate_window(window);
+            }
+        }
+
+        true
+    }
+
+    fn release_expired_deferred_initial_toplevels(&mut self) {
+        let now = Instant::now();
+        let deferred = self
+            .world
+            .query::<(&x::Window, &WindowData)>()
+            .with::<&WlSurface>()
+            .without::<&SurfaceRole>()
+            .iter()
+            .filter_map(|(_, (window, win))| {
+                let deadline = win.deferred_initial_toplevel_deadline()?;
+                (win.mapped && deadline <= now).then_some(*window)
+            })
+            .collect::<Vec<_>>();
+
+        for window in deferred {
+            self.release_deferred_initial_toplevel_map(window, "fallback timeout");
+        }
+    }
+
     pub fn can_change_position(&self, window: x::Window) -> bool {
-        let Some(win) = self
+        let Some(entity) = self
             .windows
             .get(&window)
             .copied()
-            .and_then(|id| self.world.entity(id).ok())
-            .map(|data| data.get::<&WindowData>().unwrap())
         else {
             return true;
         };
 
-        !win.mapped || win.attrs.is_popup
+        if self.world.get::<&SurfaceRole>(entity).is_err() {
+            return true;
+        }
+
+        let Some(win) = self.world.entity(entity).ok().map(|data| data.get::<&WindowData>().unwrap()) else {
+            return true;
+        };
+
+        !win.mapped || win.attrs.is_popup || win.deferred_initial_toplevel_deadline().is_some()
+    }
+
+    pub fn handle_configure_request(
+        &mut self,
+        window: x::Window,
+        mask: x::ConfigWindowMask,
+        x: i16,
+        y: i16,
+        width: u16,
+        height: u16,
+    ) {
+        let Some(entity) = self.windows.get(&window).copied() else {
+            return;
+        };
+
+        let Some(mut win) = self
+            .world
+            .entity(entity)
+            .ok()
+            .map(|data| data.get::<&mut WindowData>().unwrap())
+        else {
+            return;
+        };
+
+        let has_role = self.world.get::<&SurfaceRole>(entity).is_ok();
+        let has_deferred_initial_map = win.deferred_initial_toplevel_deadline().is_some();
+
+        if has_role && !has_deferred_initial_map {
+            return;
+        }
+
+        if mask.contains(x::ConfigWindowMask::X) {
+            win.attrs.dims.x = x;
+        }
+        if mask.contains(x::ConfigWindowMask::Y) {
+            win.attrs.dims.y = y;
+        }
+        if mask.contains(x::ConfigWindowMask::WIDTH) {
+            win.attrs.dims.width = width;
+        }
+        if mask.contains(x::ConfigWindowMask::HEIGHT) {
+            win.attrs.dims.height = height;
+        }
+
+        drop(win);
+
+        if !has_role {
+            self.maybe_create_mapped_window_role(window);
+        }
     }
 
     pub fn reconfigure_window(&mut self, event: x::ConfigureNotifyEvent) {
@@ -1059,7 +1263,12 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             width: event.width(),
             height: event.height(),
         };
-        if dims == win.attrs.dims {
+        let previous_dims = win.attrs.dims;
+        let had_deferred_initial_map = win.deferred_initial_toplevel_deadline().is_some();
+
+        if had_deferred_initial_map {
+            win.attrs.dims = dims;
+        } else if dims == previous_dims {
             return;
         } else if win.attrs.is_popup {
             win.attrs.dims = dims;
@@ -1069,6 +1278,12 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
         if !win.mapped {
             win.attrs.dims = dims;
+            return;
+        }
+
+        if had_deferred_initial_map {
+            drop(win);
+            self.release_deferred_initial_toplevel_map(event.window(), "post-map configure");
             return;
         }
 
@@ -1119,6 +1334,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
 
         win.mapped = true;
+        drop(win);
+        self.maybe_create_mapped_window_role(window);
     }
 
     pub fn unmap_window(&mut self, window: x::Window) {
@@ -1142,6 +1359,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 self.last_hovered.take();
             }
             win.mapped = false;
+            win.initial_toplevel_map_state = InitialToplevelMapState::None;
         }
 
         if let Ok(mut role) = self.world.remove_one::<SurfaceRole>(entity.unwrap()) {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1,4 +1,7 @@
-use super::{InnerServerState, NoConnection, ServerState, WindowDims, selection::Clipboard};
+use super::{
+    InitialToplevelMapState, InnerServerState, NoConnection, ServerState, WindowDims,
+    selection::Clipboard,
+};
 use crate::server::selection::{Primary, SelectionType};
 use crate::xstate::{SetState, WinSize, WmName};
 use crate::{XConnection, timespec_from_millis};
@@ -8,6 +11,7 @@ use std::io::Write;
 use std::os::fd::{AsRawFd, BorrowedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use testwl::{SendDataForMimeFn, SurfaceRole};
 use wayland_client::{
     Connection, Proxy, WEnum,
@@ -379,6 +383,45 @@ impl EarlyTestFixture {
 
         let xwls_connection = Connection::from_socket(fake_client).unwrap();
         let registry = TestObject::<WlRegistry>::from_request(
+
+            #[test]
+            fn reconfigure_toplevel_preserves_position() {
+                let (mut f, comp) = TestFixture::new_with_compositor();
+                let window = Window::new(1);
+                let (buffer, surface) = comp.create_surface();
+                let dims = WindowDims {
+                    x: 510,
+                    y: 110,
+                    width: 100,
+                    height: 100,
+                };
+
+                f.new_window(
+                    window,
+                    false,
+                    WindowData {
+                        mapped: true,
+                        dims,
+                        fullscreen: false,
+                    },
+                );
+                f.map_window(&comp, window, &surface.obj, &buffer);
+                f.run();
+                let surface_id = f.check_new_surface();
+
+                f.testwl.configure_toplevel(surface_id, 80, 120, vec![]);
+                f.run();
+
+                f.assert_window_dimensions(
+                    window,
+                    surface_id,
+                    WindowDims {
+                        width: 80,
+                        height: 120,
+                        ..dims
+                    },
+                );
+            }
             &xwls_connection.display(),
             Req::<WlDisplay>::GetRegistry {},
         );
@@ -1028,6 +1071,246 @@ fn toplevel_flow() {
     f.run();
 
     assert!(f.testwl.get_surface_data(testwl_id).is_none());
+}
+
+#[test]
+fn origin_toplevel_is_deferred_until_post_map_configure() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (_, surface) = compositor.create_surface();
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+    };
+
+    f.new_window(window, false, data);
+    f.satellite.map_window(window);
+    f.associate_window(&compositor, window, &surface.obj);
+    f.run();
+
+    assert!(
+        f.testwl.last_created_surface_id().is_none(),
+        "origin-starting toplevel should remain deferred until a post-map configure arrives"
+    );
+
+    f.reconfigure_window(
+        window,
+        WindowDims {
+            x: 1430,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        false,
+    );
+    f.run();
+
+    let id = f
+        .testwl
+        .last_created_surface_id()
+        .expect("Surface not created after configure");
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert!(matches!(surface_data.role, Some(SurfaceRole::Toplevel(_))));
+}
+
+#[test]
+fn deferred_origin_toplevel_releases_on_same_geometry_configure() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (_, surface) = compositor.create_surface();
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+    };
+
+    f.new_window(window, false, data);
+    f.satellite.map_window(window);
+    f.associate_window(&compositor, window, &surface.obj);
+    f.run();
+    assert!(f.testwl.last_created_surface_id().is_none());
+
+    f.reconfigure_window(
+        window,
+        WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        false,
+    );
+    f.run();
+
+    let id = f
+        .testwl
+        .last_created_surface_id()
+        .expect("Surface not created after same-geometry configure");
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert!(matches!(surface_data.role, Some(SurfaceRole::Toplevel(_))));
+}
+
+#[test]
+fn deferred_origin_toplevel_falls_back_to_timeout_release() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (_, surface) = compositor.create_surface();
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+    };
+
+    f.new_window(window, false, data);
+    f.satellite.map_window(window);
+    f.associate_window(&compositor, window, &surface.obj);
+    f.run();
+    assert!(f.testwl.last_created_surface_id().is_none());
+
+    let entity = f.satellite.windows[&window];
+    f.satellite
+        .world
+        .get::<&mut super::WindowData>(entity)
+        .unwrap()
+        .initial_toplevel_map_state = InitialToplevelMapState::Deferred {
+        deadline: Instant::now() - Duration::from_millis(1),
+    };
+
+    f.run();
+
+    let id = f
+        .testwl
+        .last_created_surface_id()
+        .expect("Surface not created after timeout fallback release");
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert!(matches!(surface_data.role, Some(SurfaceRole::Toplevel(_))));
+}
+
+#[test]
+fn deferred_origin_toplevel_preserves_buffer_attached_before_release() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (buffer, surface) = compositor.create_surface();
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+    };
+
+    f.new_window(window, false, data);
+    f.satellite.map_window(window);
+    f.associate_window(&compositor, window, &surface.obj);
+    f.run();
+    assert!(f.testwl.last_created_surface_id().is_none());
+
+    surface
+        .send_request(Req::<WlSurface>::Attach {
+            buffer: Some(buffer.obj.clone()),
+            x: 0,
+            y: 0,
+        })
+        .unwrap();
+    surface.send_request(Req::<WlSurface>::Commit).unwrap();
+
+    f.satellite.handle_configure_request(
+        window,
+        x::ConfigWindowMask::X
+            | x::ConfigWindowMask::Y
+            | x::ConfigWindowMask::WIDTH
+            | x::ConfigWindowMask::HEIGHT,
+        1430,
+        680,
+        50,
+        50,
+    );
+    f.reconfigure_window(
+        window,
+        WindowDims {
+            x: 1430,
+            y: 680,
+            width: 50,
+            height: 50,
+        },
+        false,
+    );
+    f.run();
+
+    let id = f
+        .testwl
+        .last_created_surface_id()
+        .expect("Surface not created after configure");
+    f.testwl.configure_toplevel(id, 50, 50, vec![]);
+    f.run();
+
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert!(surface_data.buffer.is_some(), "buffer attached before release was lost");
+}
+
+#[test]
+fn pre_role_configure_request_updates_startup_position_before_association() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (_, surface) = compositor.create_surface();
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+    };
+
+    f.new_window(window, false, data);
+    f.satellite.map_window(window);
+    f.satellite.handle_configure_request(
+        window,
+        x::ConfigWindowMask::X
+            | x::ConfigWindowMask::Y
+            | x::ConfigWindowMask::WIDTH
+            | x::ConfigWindowMask::HEIGHT,
+        1430,
+        680,
+        50,
+        50,
+    );
+
+    f.associate_window(&compositor, window, &surface.obj);
+    f.run();
+
+    let id = f
+        .testwl
+        .last_created_surface_id()
+        .expect("Surface not created after association");
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert!(matches!(surface_data.role, Some(SurfaceRole::Toplevel(_))));
 }
 
 #[test]
@@ -1856,6 +2139,42 @@ fn output_offset_surface_positioning() {
     popup_dims.x = 10;
     popup_dims.y = 10;
     f.assert_window_dimensions(popup, p_id, popup_dims);
+}
+
+#[test]
+fn output_offset_preserves_explicit_startup_position_on_first_enter() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+
+    f.new_output(0, 0);
+    let (_, output) = f.new_output(500, 100);
+    f.run();
+
+    let window = Window::new(1);
+    let (buffer, surface) = comp.create_surface();
+    let dims = WindowDims {
+        x: 510,
+        y: 110,
+        width: 100,
+        height: 100,
+    };
+
+    f.new_window(
+        window,
+        false,
+        WindowData {
+            mapped: true,
+            dims,
+            fullscreen: false,
+        },
+    );
+    f.map_window(&comp, window, &surface.obj, &buffer);
+    f.run();
+    let toplevel_id = f.check_new_surface();
+
+    f.testwl.move_surface_to_output(toplevel_id, &output);
+    f.run();
+
+    assert_eq!(f.connection().window(window).dims, dims);
 }
 
 #[test]

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -491,6 +491,15 @@ impl XState {
                     let mut list = Vec::new();
                     let mask = e.value_mask();
 
+                    server_state.handle_configure_request(
+                        e.window(),
+                        mask,
+                        e.x(),
+                        e.y(),
+                        e.width(),
+                        e.height(),
+                    );
+
                     if server_state.can_change_position(e.window()) {
                         if mask.contains(x::ConfigWindowMask::X) {
                             list.push(x::ConfigWindow::X(e.x().into()));
@@ -701,6 +710,7 @@ impl XState {
     ) -> XResult<bool> {
         let mut motif_popup = false;
         let mut wmhint_popup = false;
+        let mut motif_functions_empty = false;
         let mut has_skip_taskbar = None;
 
         let attrs = self
@@ -738,11 +748,7 @@ impl XState {
                             | motif::Functions::All,
                     )
                 });
-            // If the motif hints indicate the user shouldn't be able to do anything
-            // to the window at all, it stands to reason it's probably a popup.
-            if hints.functions.is_some_and(|f| f.is_empty()) {
-                return Ok(true);
-            }
+            motif_functions_empty = hints.functions.is_some_and(|f| f.is_empty());
         }
 
         let override_redirect = self.connection.wait_for_reply(attrs)?.override_redirect();
@@ -755,6 +761,14 @@ impl XState {
                 vec![self.window_atoms.normal]
             }
         });
+
+        let has_normal_type = window_types.contains(&self.window_atoms.normal);
+
+        // Empty MOTIF functions are a reasonable popup signal for ambiguous windows,
+        // but some normal undecorated toplevels use them for client-side chrome.
+        if motif_functions_empty && !has_normal_type {
+            return Ok(true);
+        }
 
         if log::log_enabled!(log::Level::Debug) {
             let win_types = window_types


### PR DESCRIPTION
First of all, I'm so grateful for this project! It's the only way I was able to realize rootless windows with docker on Mutter wayland hosts, because Mutter is not exposing `xwayland-shell-v1`, so with xwayland itself I could only run rootful. Satellite was also the only approach, that allowed proper host -> client clipboard sharing.
Now I can finally containerize all my gui apps, while only sharing the wayland socket to avoid spying on my xwayland socket.
However while doing this, I found most of my apps were having problems.
Since this is the only solution for me, I decided to patch all of the bugs myself.
I ended up with 3 PRs. I left you a donation as a small compensation for testing them.
I already did extensive testing with a [test environment](https://github.com/5andr0/xwayland-satellite/tree/docker_test) that I wrote.

**_Disclaimer:_** PRs are obviously written by LLM to save me some time. Hope you don't mind

## Summary

This fixes a startup placement bug where some X11 clients are exported to Wayland too early, before their real startup position has settled.

In the broken path, the window is first seen at `0,0`, `xwayland-satellite` immediately creates the Wayland toplevel there, and only afterwards receives the client's real startup geometry. By that point the compositor has already chosen output membership from the provisional origin placement.

Visible effect:

- single-monitor: the window initially comes up at the top-left corner instead of the application's requested startup position
- multi-monitor: the window can be associated with the top-left-most output, even when that output is not the primary monitor and not the monitor the app intended to open on

For apps with mixed output scales, this can also cascade into the wrong initial scale/output relationship because the window enters the wrong output first.

## Reproduction

```sh
git clone https://github.com/5andr0/xwayland-satellite.git
cd xwayland-satellite
git checkout docker_test
cd docker
# Configure your .env for the correct wayland user, display and runtime paths
./configure.sh

# Builds all branch binaries once, no rebuild needed. Only switch your env vars

# Spawns at 0,0 on left monitor
BRANCH=main TEST_USE_TITLEBAR=0 docker compose up

# Same with a non qt app
BRANCH=main TEST_USE_TITLEBAR=0 QT=0 docker compose up

# Only windows with a title bar center, but not correctly.
# The bar will end up in the vertical middle, not considering the window body size for centering
BRANCH=main TEST_USE_TITLEBAR=1 docker compose up

# Works on host xwayland socket:
BRANCH=host TEST_USE_TITLEBAR=0 docker compose up
BRANCH=xwayland TEST_USE_TITLEBAR=0 QT=0 docker compose up

# Works properly with this PR:
BRANCH=start_pos_fix TEST_USE_TITLEBAR=0 docker compose up
BRANCH=start_pos_fix TEST_USE_TITLEBAR=0 QT=0 docker compose up
```


## What Was Causing The Bug

The bug is a startup ordering problem.

Some client-decorated or otherwise ambiguous X11 toplevels are created and mapped with provisional geometry at `0,0`. Their real startup placement arrives a little later as one or more X11 `ConfigureRequest` events.

Before this change, once the X11 window was mapped and its `wl_surface` was associated, `xwayland-satellite` created the Wayland toplevel immediately. That made the compositor observe the window at the origin before the real startup position was known.

The log that led to this patch showed exactly that sequence:

1. window maps at `0,0`
2. `wl_surface` is associated
3. deferred startup path activates
4. first startup `ConfigureRequest` arrives
5. startup geometry is updated
6. later compositor/output handling can still collapse the window back toward origin if those coordinates are not preserved

That made two issues visible:

- the initial toplevel export still had to wait until startup placement had actually settled
- once the correct startup position was known, later output association and Wayland configure handling still had to preserve that explicit X11 position instead of rewriting it back to origin

## How The Patch Works

### 1. Delay initial toplevel creation for the problematic startup shape

When a mapped X11 window gets its `wl_surface`, the compositor-facing role is no longer created unconditionally.

Instead, `xwayland-satellite` checks whether the window matches the problematic startup pattern:

- not a popup
- not explicitly server-decorated
- initial X11 geometry is exactly `0,0`
- this is the first toplevel export attempt for the window

If all of those are true, the window enters a deferred initial-map state instead of immediately creating the Wayland toplevel.

### 2. Keep collecting startup geometry while deferred

While deferred, incoming X11 `ConfigureRequest` events and the first post-map `ConfigureNotify` continue updating the stored window dimensions before any Wayland role exists.

This is important because the startup position can arrive before or after `wl_surface` association, and it can arrive more than once.

### 3. Release on the first post-map startup configure

The fix does not create the toplevel from inside the first matching `ConfigureRequest`.

Instead, the deferred window is released on the first post-map `ConfigureNotify`, using the startup geometry accumulated before role creation. That keeps the startup decision tied to the point where X11 has actually finished applying the initial placement rather than to an earlier request in the same burst.

This directly targets the reproduced case where the real startup position arrives slightly after map and only becomes reliable once the post-map configure is observed.

### 4. Preserve explicit startup coordinates after release

Two follow-up fixes keep the now-correct startup position intact:

- explicit `_NET_WM_WINDOW_TYPE_NORMAL` undecorated windows are no longer misclassified as popups just because Motif reports empty function bits
- once a window has a real startup position, the first output-enter offset update and later `xdg_toplevel.configure` events preserve that X11 `x/y` instead of resetting it to `0,0`

Without those follow-up pieces, the deferred export could be correct but the window could still get dragged back toward the output origin immediately afterwards.

### 5. Preserve safety fallback behavior

If a window enters the deferred state but no qualifying startup geometry ever arrives, the existing timeout fallback still releases it. This avoids leaving a legitimate window permanently deferred.

### 6. Preserve pre-role surface state

While role creation is deferred, `wl_surface` traffic is still buffered so the eventual toplevel export keeps the buffer/content that arrived before release.

## Why This Is Narrowed To This Specific Case

The patch is intentionally not a general delay of all toplevel creation.

It only applies to windows that look like the problematic startup path discovered during reproduction:

- the window starts at the origin
- the window is not a popup
- the window is not clearly server-decorated
- startup geometry changes arrive before role creation

This excludes the common cases that do not need intervention:

- normal windows with stable non-origin startup geometry
- popups and override-redirect flows
- explicitly server-decorated windows, which did not exhibit the bug in reproduction

In other words, the patch is not trying to second-guess window movement in general. It is only holding back the first Wayland toplevel export long enough to avoid committing to a known-bad provisional startup position, and then preserving the explicit startup coordinates through the first output/Wayland configure transitions.

## Validation Strategy

The regression coverage added with this change exercises the intended boundaries:

- defer origin-starting ambiguous toplevels
- release on the first post-map `ConfigureNotify`
- release on a same-geometry post-map configure when origin is intentional
- keep timeout fallback behavior intact
- preserve buffers attached before release
- do not misclassify explicit NORMAL undecorated windows as popups
- preserve explicit startup position on first output enter
- preserve explicit startup position across later toplevel configure events

## User-Visible Result

Windows in this specific startup pattern are no longer exported to Wayland from the provisional origin position.

That means they stop appearing:

- at the top-left corner when the app asked to start elsewhere
- on the left-most/top-left-most monitor just because that monitor contains `0,0`
- on the wrong initial output during startup, which could also skew scale/output selection in mixed-DPI setups