### PR TITLE
fix: translate ConfigureRequest drags to xdg_toplevel.move

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -121,6 +121,7 @@ struct WindowData {
     attrs: WindowAttributes,
     output_offset: WindowOutputOffset,
     activation_token: Option<String>,
+    configure_move_serial: Option<u32>,
 }
 
 impl WindowData {
@@ -134,6 +135,7 @@ impl WindowData {
             },
             output_offset: WindowOutputOffset::default(),
             activation_token,
+            configure_move_serial: None,
         }
     }
 
@@ -1041,6 +1043,82 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         !win.mapped || win.attrs.is_popup
     }
 
+    pub fn begin_configure_move(
+        &mut self,
+        window: x::Window,
+        dims: WindowDims,
+        mask: x::ConfigWindowMask,
+    ) -> bool {
+        let should_move = {
+            let Some(data) = self
+                .windows
+                .get(&window)
+                .copied()
+                .and_then(|id| self.world.entity(id).ok())
+            else {
+                return false;
+            };
+
+            let Some(last_click_data) = data.get::<&LastClickSerial>() else {
+                return false;
+            };
+            let serial = last_click_data.1;
+
+            let Some(role) = data.get::<&SurfaceRole>() else {
+                return false;
+            };
+            if !matches!(&*role, SurfaceRole::Toplevel(Some(_))) {
+                return false;
+            }
+            drop(role);
+
+            let mut win = data.get::<&mut WindowData>().unwrap();
+            let current_dims = win.attrs.dims;
+            let requested_x = if mask.contains(x::ConfigWindowMask::X) {
+                dims.x
+            } else {
+                current_dims.x
+            };
+            let requested_y = if mask.contains(x::ConfigWindowMask::Y) {
+                dims.y
+            } else {
+                current_dims.y
+            };
+            let requested_width = if mask.contains(x::ConfigWindowMask::WIDTH) {
+                dims.width
+            } else {
+                current_dims.width
+            };
+            let requested_height = if mask.contains(x::ConfigWindowMask::HEIGHT) {
+                dims.height
+            } else {
+                current_dims.height
+            };
+            let has_position_change =
+                requested_x != current_dims.x || requested_y != current_dims.y;
+            let has_size_change =
+                requested_width != current_dims.width || requested_height != current_dims.height;
+
+            if !win.mapped || win.attrs.is_popup || !has_position_change || has_size_change {
+                return false;
+            }
+
+            if win.configure_move_serial == Some(serial) {
+                return true;
+            }
+
+            win.configure_move_serial = Some(serial);
+            true
+        };
+
+        if !should_move {
+            return false;
+        }
+
+        self.move_window(window);
+        true
+    }
+
     pub fn reconfigure_window(&mut self, event: x::ConfigureNotifyEvent) {
         let Some((mut win, data)) = self
             .windows
@@ -1094,6 +1172,9 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 popup.popup.reposition(&popup.positioner, 0);
             }
             SurfaceRole::Toplevel(Some(_)) => {
+                if dims.width != win.attrs.dims.width || dims.height != win.attrs.dims.height {
+                    win.configure_move_serial = None;
+                }
                 win.attrs.dims.width = dims.width;
                 win.attrs.dims.height = dims.height;
                 drop(query);
@@ -1246,12 +1327,14 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return;
         };
 
-        let Some(last_click_data) = data.get::<&LastClickSerial>() else {
+        let last_click_data = data.get::<&LastClickSerial>();
+        let role = data.get::<&SurfaceRole>();
+
+        let Some(last_click_data) = last_click_data else {
             warn!("Requested move of window {window:?} but we don't have a click serial for it");
             return;
         };
 
-        let role = data.get::<&SurfaceRole>();
         let Some(SurfaceRole::Toplevel(Some(data))) = role.as_deref() else {
             warn!("Requested move of non toplevel {window:?} ({role:?})");
             return;
@@ -1271,12 +1354,14 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return;
         };
 
-        let Some(last_click_data) = data.get::<&LastClickSerial>() else {
+        let last_click_data = data.get::<&LastClickSerial>();
+        let role = data.get::<&SurfaceRole>();
+
+        let Some(last_click_data) = last_click_data else {
             warn!("Requested resize of window {window:?} but we don't have a click serial for it");
             return;
         };
 
-        let role = data.get::<&SurfaceRole>();
         let Some(SurfaceRole::Toplevel(Some(data))) = role.as_deref() else {
             warn!("Requested resize of non toplevel {window:?} ({role:?})");
             return;

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -486,12 +486,19 @@ impl XState {
                     self.handle_property_change(e, server_state);
                 }
                 xcb::Event::X(x::Event::ConfigureRequest(e)) => {
-                    debug!("{:?} request: {:?}", e.window(), e.value_mask());
-
+                    let can_change_position = server_state.can_change_position(e.window());
+                    let dims = WindowDims {
+                        x: e.x(),
+                        y: e.y(),
+                        width: e.width(),
+                        height: e.height(),
+                    };
                     let mut list = Vec::new();
                     let mask = e.value_mask();
+                    let translated_move = mask.intersects(x::ConfigWindowMask::X | x::ConfigWindowMask::Y)
+                        && server_state.begin_configure_move(e.window(), dims, mask);
 
-                    if server_state.can_change_position(e.window()) {
+                    if !translated_move && can_change_position {
                         if mask.contains(x::ConfigWindowMask::X) {
                             list.push(x::ConfigWindow::X(e.x().into()));
                         }
@@ -721,6 +728,17 @@ impl XState {
         if let Some(states) = window_state.resolve()? {
             has_skip_taskbar = Some(states.contains(&self.atoms.skip_taskbar));
         }
+
+        let override_redirect = self.connection.wait_for_reply(attrs)?.override_redirect();
+        let window_types = window_types.resolve()?.unwrap_or_else(|| {
+            if !override_redirect && has_transient_for {
+                vec![self.window_atoms.dialog]
+            } else {
+                vec![self.window_atoms.normal]
+            }
+        });
+        let has_explicit_normal_type = window_types.contains(&self.window_atoms.normal);
+
         if let Some(hints) = motif_hints {
             // If MOTIF_WM_HINTS provides no decorations for client assume its a popup
             motif_popup = hints.decorations.is_some_and(|d| d.is_clientside());
@@ -738,23 +756,14 @@ impl XState {
                             | motif::Functions::All,
                     )
                 });
-            // If the motif hints indicate the user shouldn't be able to do anything
-            // to the window at all, it stands to reason it's probably a popup.
-            if hints.functions.is_some_and(|f| f.is_empty()) {
+            // Empty function hints are common on client-side decorated toplevels.
+            // Respect an explicit NORMAL window type instead of forcing such windows
+            // down the popup path, which breaks configure-request drag translation.
+            if hints.functions.is_some_and(|f| f.is_empty()) && !has_explicit_normal_type {
                 return Ok(true);
             }
         }
-
-        let override_redirect = self.connection.wait_for_reply(attrs)?.override_redirect();
         let mut is_popup = override_redirect;
-
-        let window_types = window_types.resolve()?.unwrap_or_else(|| {
-            if !override_redirect && has_transient_for {
-                vec![self.window_atoms.dialog]
-            } else {
-                vec![self.window_atoms.normal]
-            }
-        });
 
         if log::log_enabled!(log::Level::Debug) {
             let win_types = window_types


### PR DESCRIPTION
## Summary

This fixes frameless drag for X11 apps that implement their own client-side title bar and move the window by issuing mapped toplevel `ConfigureRequest` position updates.

Without this patch, custom-decorated windows do not drag correctly under `xwayland-satellite` because the bridge forwards those X11 X/Y changes as raw geometry updates instead of starting a compositor-side interactive move.

With a normal system/compositor title bar, dragging already works. In that path the compositor or window manager owns the decorations and already has the correct interactive move contract, so no translation from client-side geometry mutation is needed.

The broken case is specifically the custom-decorated path: the client draws its own title bar, watches pointer motion itself, and repeatedly asks X11 to move the toplevel while the button is held.

## User-Visible Bug

Before this patch:

- windows with a normal title bar drag correctly
- windows with a custom title bar do not drag correctly under `xwayland-satellite`
- the client keeps emitting mapped toplevel `ConfigureRequest` position changes, but the compositor never receives the equivalent of `xdg_toplevel.move`

In practice, the window looks draggable from the application's point of view, but the compositor is never put into an interactive move, so the drag either stalls, behaves inconsistently, or falls back to repeated raw reconfiguration instead of a real Wayland move.

## Reproduction

```sh
git clone https://github.com/5andr0/xwayland-satellite.git
cd xwayland-satellite
git checkout docker_test
cd docker
# Configure your .env for the correct wayland user, display and runtime paths
./configure.sh

# Builds all branch binaries once, no rebuild needed. Only switch your env vars

# Doesn't work with custom decorated qt windows
BRANCH=main TEST_USE_TITLEBAR=0 docker compose up

# Same with a non qt app
BRANCH=main TEST_USE_TITLEBAR=0 QT=0 docker compose up

# Only works with regular title bars
BRANCH=main TEST_USE_TITLEBAR=1 docker compose up

# Works on host xwayland socket:
BRANCH=host TEST_USE_TITLEBAR=0 docker compose up
BRANCH=xwayland TEST_USE_TITLEBAR=0 QT=0 docker compose up

# Works properly with this PR:
BRANCH=dragfix TEST_USE_TITLEBAR=0 docker compose up
BRANCH=dragfix TEST_USE_TITLEBAR=0 QT=0 docker compose up
```

## Why System Title Bars Work

This distinction matters:

- system/compositor title bar: drag already works
- custom/client-drawn title bar: drag fails without this patch

When a window uses server-side decorations or a normal title bar, the window manager/compositor already owns the drag gesture and can initiate the move directly.

When a window uses a custom title bar, the client usually does not call a Wayland system-move API. Instead, it computes cursor deltas itself and mutates the X11 window position directly. On X11 that becomes a stream of `ConfigureRequest` X/Y updates.

Unpatched `xwayland-satellite` handled explicit `_NET_WM_MOVERESIZE` move requests, but it did not reinterpret these click-backed `ConfigureRequest` position changes as an interactive Wayland move. That gap is why custom-decorated drag failed while normal titlebar drag still worked.

## Root Cause

The root cause is a protocol mismatch between what the client is doing and what the Wayland compositor expects.

Custom-decorated X11 clients:

- detect pointer press in their own title bar
- track pointer motion themselves
- update the window position directly
- generate mapped toplevel `ConfigureRequest` X/Y changes

Wayland compositors expect:

- an interactive move request tied to a valid click/pointer serial
- typically `xdg_toplevel.move`

Without translation, `xwayland-satellite` only sees raw X11 geometry requests. That is not enough to establish the compositor-side drag session required for frameless move behavior under Wayland.

## What This Patch Changes

### 1. Translate click-backed position-only ConfigureRequests into `xdg_toplevel.move`

The patch detects the important drag shape:

- mapped toplevel window
- non-popup window
- valid last click serial
- X and/or Y changed
- no real size change requested

When that pattern is seen, `xwayland-satellite` starts an interactive Wayland move instead of forwarding the raw X11 position change.

That makes custom title bar drag behave like a proper compositor move rather than a client repeatedly trying to reposition itself.

### 2. Deduplicate repeated drag requests per click serial

During a drag, clients may emit many `ConfigureRequest` updates for the same pointer press.

The patch records the click serial and only starts the compositor move once for that click. Repeated requests for the same drag do not keep restarting the move.

### 3. Keep resize behavior separate

This patch is only for drag translation, not for general reconfigure changes.

Resize handling remains on the normal path. The drag translation is limited to requests that are actually position-only moves.

### 4. Respect the ConfigureRequest mask when classifying move vs resize

The merged follow-up fix matters here.

Originally, the drag classification compared requested width and height against the current window size even when `WIDTH` or `HEIGHT` were not present in the `ConfigureRequest` mask.

That could make a pure move request look like a move-and-resize request and incorrectly reject it from the drag-translation path.

The final patch uses the mask when deciding whether a size change was really requested, so size-only requests are not treated as drags and position-only requests are not rejected for fake size differences.

## Why This Fix Is Narrow

This patch does not try to reinterpret arbitrary reconfiguration traffic as a drag.

It is intentionally limited to:

- mapped toplevels
- non-popup windows
- click-backed requests with a valid serial
- position-only configure requests

That keeps the change focused on the actual compatibility gap for custom-decorated dragging.

## Validation

This change was validated against the custom-decoration drag path that previously failed.

The important behavior difference is:

- before: repeated click-backed `ConfigureRequest` X/Y updates never became `xdg_toplevel.move`
- after: the first eligible request starts a compositor move, repeated requests for that click are deduplicated, and drag behaves like a real interactive move

It also explains the observed contrast during testing:

- with a normal title bar, dragging already worked
- with a custom/client-drawn title bar, dragging needed this patch

## Result

After this patch, custom-decorated X11 windows can drag under `xwayland-satellite` using the same client-side geometry pattern that previously failed, because the bridge now translates that pattern into the Wayland compositor move primitive it was missing.