### PR TITLE
Add `-noscaling` flag to disable xwayland-satellite monitor-rescaling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@ pub trait RunData {
     fn flags(&self) -> &[String] {
         &[]
     }
+    /// When true, xwayland-satellite keeps surfaces at 1x and lets the compositor scale them.
+    fn noscaling(&self) -> bool {
+        false
+    }
     fn server(&self) -> Option<UnixStream> {
         None
     }
@@ -153,7 +157,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         }
     };
 
-    let mut server_state = EarlyServerState::new(dh, data.server(), connection);
+    let mut server_state = EarlyServerState::new(dh, data.server(), connection, data.noscaling());
     server_state.run();
 
     // Remove the lifetimes on our fds to avoid borrowing issues, since we know they will exist for

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ struct RealData {
     display: Option<String>,
     listenfds: Vec<OwnedFd>,
     flags: Vec<String>,
+    noscaling: bool,
 }
 impl xwayland_satellite::RunData for RealData {
     fn display(&self) -> Option<&str> {
@@ -26,6 +27,10 @@ impl xwayland_satellite::RunData for RealData {
     fn flags(&self) -> &[String] {
         &self.flags
     }
+
+    fn noscaling(&self) -> bool {
+        self.noscaling
+    }
 }
 
 struct ParsedFlags {
@@ -38,6 +43,7 @@ struct ParsedFlags {
     glamor: Option<&'static str>,
     listen_plus: Vec<String>,
     listen_minus: Vec<String>,
+    noscaling: bool,
     verbosity: u32,
 }
 impl Default for ParsedFlags {
@@ -52,6 +58,7 @@ impl Default for ParsedFlags {
             glamor: None,
             listen_plus: vec![],
             listen_minus: vec![],
+            noscaling: false,
             verbosity: 0,
         }
     }
@@ -180,6 +187,10 @@ fn parse_args() -> RealData {
                 );
                 println!("{:<25} prints message with these options", "-help");
                 println!("{:<25} listen on protocol", "-listen");
+                println!(
+                    "{:<25} keep surfaces at 1x and let the compositor scale them",
+                    "-noscaling"
+                );
                 println!("{:<25} don't listen on protocol", "-nolisten");
                 println!("{:<25} add given fd as a listen socket", "-listenfd");
                 println!(
@@ -199,6 +210,9 @@ fn parse_args() -> RealData {
                     flags.listen_minus.swap_remove(idx);
                 }
                 flags.listen_plus.push(protocol.to_owned());
+            }
+            "-noscaling" => {
+                flags.noscaling = true;
             }
             "-nolisten" => {
                 let protocol = args.next().expect("argument to -nolisten not provided");
@@ -242,6 +256,7 @@ fn parse_args() -> RealData {
             }
         }
     }
+    data.noscaling = flags.noscaling;
     data.flags = flags.to_vec();
 
     data

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -94,6 +94,9 @@ impl Event for SurfaceEvents {
             SurfaceEvents::FractionalScale(event) => match event {
                 wp_fractional_scale_v1::Event::PreferredScale { scale } => {
                     let state = state.deref_mut();
+                    if state.noscaling {
+                        return;
+                    }
                     let entity = state.world.entity(target).unwrap();
                     let factor = scale as f64 / 120.0;
                     debug!(
@@ -229,7 +232,7 @@ impl SurfaceEvents {
                         connection.focus_window(*window, output);
                     }
 
-                    if state.fractional_scale.is_none() {
+                    if state.fractional_scale.is_none() && !state.noscaling {
                         let output_scale = output_data.get::<&OutputScaleFactor>().unwrap().get();
                         data.get::<&mut SurfaceScaleFactor>().unwrap().0 = output_scale;
                         drop(query);
@@ -1331,7 +1334,7 @@ impl OutputEvent {
                 ) {
                     state.updated_outputs.push(target);
                 }
-                if state.fractional_scale.is_none() {
+                if state.fractional_scale.is_none() && !state.noscaling {
                     state.world.get::<&WlOutput>(target).unwrap().scale(factor);
                 }
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -465,6 +465,7 @@ pub struct InnerServerState<S: X11Selection> {
     shm: client::wl_shm::WlShm,
     viewporter: WpViewporter,
     fractional_scale: Option<WpFractionalScaleManagerV1>,
+    noscaling: bool,
     decoration_manager: Option<ZxdgDecorationManagerV1>,
     selection_states: selection::SelectionStates<S>,
     last_kb_serial: Option<(client::wl_seat::WlSeat, u32)>,
@@ -480,6 +481,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
         mut dh: DisplayHandle,
         server_connection: Option<UnixStream>,
         client: UnixStream,
+        noscaling: bool,
     ) -> Self {
         let connection = if let Some(stream) = server_connection {
             Connection::from_socket(stream).unwrap()
@@ -565,6 +567,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             shm,
             viewporter,
             fractional_scale,
+            noscaling,
             selection_states,
             last_kb_serial: None,
             activation_state,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -374,7 +374,12 @@ impl EarlyTestFixture {
         });
 
         let (fake_client, xwls_server) = UnixStream::pair().unwrap();
-        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server);
+        let satellite = ServerState::new(
+            display.handle(),
+            Some(client_s),
+            xwls_server,
+            false,
+        );
         let testwl = thread.join().unwrap();
 
         let xwls_connection = Connection::from_socket(fake_client).unwrap();


### PR DESCRIPTION
This was the most annoying bug that actually made me start working on this project! 
Having a big screen with 100% scaling and a high dpi smaller screen with 150% scaling totally broke using the ui due to endless window shrinks and unresponsive ui.
The thing is, that it's actually not even necessary to change the window size on moving windows to another monitor.
All the distros I can think of already take care of this with independent pixel scaling based on monitor scales, which lets the app keep its logical pixels. This already works perfectly smooth. So with this PR (and arg -noscaling) you will get the default behavior how it should be.
I implemented it with an option, but I highly recommend to implement this as always no rescaling on monitor changes. You can still scale your app with env vars / [xsettingsd](https://codeberg.org/derat/xsettingsd)
If you want, I will add a commit to make this permanent, not optional. (**Please!!!**)
I hope you have two monitors to test this! 

Now here comes the LLM part: 

## Summary

This patch adds a `-noscaling` flag that keeps Xwayland surfaces at 1x and stops xwayland-satellite from trying to rescale them when outputs change.

The current mixed-DPI scaling behavior has a few concrete problems:

- dragging a window toward another monitor can rescale it before the window has actually changed screens, and repeated edge crossings can shrink it multiple times
- while resizing the window, the titlebar close button can become unresponsive
- moving the window back does not always restore the original size

In practice this means simple window motion can permanently change the apparent size of the application without the compositor ever actually moving the window to a different display in a stable way.

## Why this is needed

The host desktop environment is already responsible for the final pixel scaling of X11/Xwayland content on Wayland.

That is the normal model used by modern desktops:

- GNOME/Mutter applies monitor scaling through the compositor and has explicit Xwayland scaling behavior in its fractional-scaling design
- KDE Plasma exposes Xwayland scaling modes at the compositor level, including a system-scaled mode where the compositor magnifies X applications
- other Wayland desktops generally already treat monitor scale as compositor policy, not something each X11 bridge should try to second-guess by resizing windows on monitor transitions

Because of that, xwayland-satellite attempting to dynamically rescale the X11 window itself is redundant at best and actively incorrect in mixed-DPI setups at worst.

For Ubuntu/GNOME in particular, the compositor-side behavior already produces the correct result: the window keeps its logical size and the host display settings handle the pixel scaling.

## Reproduction

```sh
git clone https://github.com/5andr0/xwayland-satellite.git
cd xwayland-satellite
git checkout docker_test
cd docker
# Configure your .env for the correct wayland user, display and runtime paths
./configure.sh

# Builds all branch binaries once, no rebuild needed. Only switch your env vars

# Beyond broken on multi monitor with different scales
# titlebar=1 to have working window dragging
BRANCH=main TEST_USE_TITLEBAR=1 docker compose up

# Same with a non qt app
BRANCH=main TEST_USE_TITLEBAR=1 QT=0 docker compose up

# No window size changes with host xwayland socket:
# Host already properly takes care of independent pixel scaling with different monitor scales
BRANCH=host TEST_USE_TITLEBAR=0 docker compose up
BRANCH=xwayland TEST_USE_TITLEBAR=0 QT=0 docker compose up

# Works properly with this PR:
BRANCH=noscale TEST_USE_TITLEBAR=1 docker compose up
BRANCH=noscale TEST_USE_TITLEBAR=1 QT=0 docker compose up
```

## What this patch does

- adds a new `-noscaling` flag
- threads a `noscaling: bool` setting through startup state
- ignores `wp_fractional_scale_v1::PreferredScale` when `-noscaling` is enabled
- disables the integer fallback paths that rewrite surface scale or forward output scale changes when `-noscaling` is enabled
- leaves the standard fractional-scale manager binding path intact

This keeps the change small and targeted:

- normal protocol setup still happens
- normal window configure/maximize behavior still happens
- only the monitor-driven rescaling reactions are suppressed

## Result

With `-noscaling`, xwayland-satellite stops fighting the compositor over scaling.

The host desktop remains in control of how Xwayland windows are displayed on differently scaled outputs, which is both simpler and more robust than the current behavior.

## Testing

Tested against a mixed-DPI setup where the original implementation showed repeated incorrect resizes when dragging windows near or across monitor boundaries.

Observed with `-noscaling`:

- window size remains stable while moving around on the same monitor
- crossing monitor boundaries no longer triggers xwayland-satellite-driven shrink/grow loops
- resizing no longer leaves the titlebar close button unresponsive
- moving a window back does not leave it stuck at the wrong size
- compositor-side scaling still provides the expected visible result on the host desktop