### PR TITLE
server: track global scale to initialize new surfaces correctly

### DIFF
--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -234,7 +234,7 @@ impl<S: X11Selection>
                         client,
                         server,
                         viewport,
-                        scale: SurfaceScaleFactor(1.0),
+                        scale: SurfaceScaleFactor(state.current_scale),
                     },
                 );
                 if let Some(f) = fractional {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -473,6 +473,7 @@ pub struct InnerServerState<S: X11Selection> {
     global_offset_updated: bool,
     updated_outputs: Vec<Entity>,
     new_scale: Option<f64>,
+    current_scale: f64,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -581,6 +582,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
+            current_scale: 1.0,
             decoration_manager,
             world,
         };
@@ -719,6 +721,7 @@ impl<C: XConnection> ServerState<C> {
 
                 debug!("Using new scale {scale}");
                 self.new_scale = Some(scale);
+                self.current_scale = scale;
             }
         }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -741,6 +741,10 @@ impl TestFixture<FakeXConnection> {
             assert!(surface_data.buffer.is_some());
         }
 
+        let scale = self.satellite.current_scale;
+        let expected_width = (100.0 * scale) as u16;
+        let expected_height = (100.0 * scale) as u16;
+
         let win_data = self.connection().windows.get(&window).map(|d| &d.dims);
         assert!(
             matches!(
@@ -748,9 +752,9 @@ impl TestFixture<FakeXConnection> {
                 Some(&super::WindowDims {
                     x: 0,
                     y: 0,
-                    width: 100,
-                    height: 100
-                })
+                    width,
+                    height
+                }) if width == expected_width && height == expected_height
             ),
             "Incorrect window geometry: {win_data:?}"
         );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -223,6 +223,17 @@ impl Fixture {
         window: x::Window,
         surface: testwl::SurfaceId,
     ) {
+        self.configure_and_verify_new_toplevel_with_size(connection, window, surface, 100, 100);
+    }
+
+    fn configure_and_verify_new_toplevel_with_size(
+        &mut self,
+        connection: &mut Connection,
+        window: x::Window,
+        surface: testwl::SurfaceId,
+        width: u16,
+        height: u16,
+    ) {
         let data = self.testwl.get_surface_data(surface).unwrap();
         assert!(
             matches!(data.role, Some(testwl::SurfaceRole::Toplevel(_))),
@@ -240,8 +251,8 @@ impl Fixture {
 
         assert_eq!(geometry.x(), 0);
         assert_eq!(geometry.y(), 0);
-        assert_eq!(geometry.width(), 100);
-        assert_eq!(geometry.height(), 100);
+        assert_eq!(geometry.width(), width);
+        assert_eq!(geometry.height(), height);
     }
 
     #[track_caller]
@@ -250,13 +261,24 @@ impl Fixture {
         connection: &mut Connection,
         window: x::Window,
     ) -> testwl::SurfaceId {
+        self.map_as_toplevel_with_size(connection, window, 100, 100)
+    }
+
+    #[track_caller]
+    fn map_as_toplevel_with_size(
+        &mut self,
+        connection: &mut Connection,
+        window: x::Window,
+        width: u16,
+        height: u16,
+    ) -> testwl::SurfaceId {
         connection.map_window(window);
         self.wait_and_dispatch();
         let surface = self
             .testwl
             .last_created_surface_id()
             .expect("No surface created");
-        self.configure_and_verify_new_toplevel(connection, window, surface);
+        self.configure_and_verify_new_toplevel_with_size(connection, window, surface, width, height);
         surface
     }
 
@@ -1884,7 +1906,7 @@ fn forced_1x_scale_consistent_x11_size() {
 
     let mut conn = Connection::new(&f.display);
     let window = conn.new_window(conn.root, 0, 0, 200, 200, false);
-    let surface = f.map_as_toplevel(&mut conn, window);
+    let surface = f.map_as_toplevel_with_size(&mut conn, window, 200, 200);
     f.testwl.move_surface_to_output(surface, &output);
     f.testwl.move_pointer_to(surface, 30.0, 40.0);
     f.wait_and_dispatch();


### PR DESCRIPTION
Maintain the last known global scale in InnerServerState and use it to initialize the scale factor for new surfaces.
This fixes a race condition where a surface could have its initial size hints calculated with a default 1.0 scale before it officially entered an output, preventing feedback loops that caused windows to double in size on HiDPI displays.

Issue illustrated:

https://github.com/user-attachments/assets/fe15c630-65a0-45c5-b4ae-50a5691a57a7


https://github.com/user-attachments/assets/49906201-a90e-41b1-b3bf-89532c41f81f

