### PR TITLE
fix: crash when surface destroyed during output removal

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -470,7 +470,9 @@ pub(super) fn update_surface_viewport(
         &WlSurface,
     )>,
 ) {
-    let (window_data, viewport, scale_factor, mut role, surface) = surface_query.get().unwrap();
+    let Some((window_data, viewport, scale_factor, mut role, surface)) = surface_query.get() else {
+        return;
+    };
     let dims = &window_data.attrs.dims;
     let size_hints = &window_data.attrs.size_hints;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -689,10 +689,9 @@ impl<C: XConnection> ServerState<C> {
 
                     drop(surface_query);
                     for surface in surfaces {
-                        update_surface_viewport(
-                            &self.world,
-                            self.world.query_one(surface).unwrap(),
-                        );
+                        if let Ok(query) = self.world.query_one(surface) {
+                            update_surface_viewport(&self.world, query);
+                        }
                     }
                 }
             }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1785,6 +1785,25 @@ fn remove_all_outputs() {
 }
 
 #[test]
+fn surface_destroy_during_output_removal() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+
+    let (_, output) = f.new_output(0, 0);
+    f.run();
+
+    let window = Window::new(1);
+    let (surface, toplevel_id) = f.create_toplevel(&comp, window);
+    f.testwl.move_surface_to_output(toplevel_id, &output);
+    f.run();
+
+    surface.send_request(Req::<WlSurface>::Destroy).unwrap();
+    f.run();
+
+    f.remove_output(output);
+    f.run();
+}
+
+#[test]
 fn output_offset_surface_positioning() {
     let (mut f, comp) = TestFixture::new_with_compositor();
 


### PR DESCRIPTION
When a Wayland output is removed (e.g., screen turns off), surfaces on that output may be destroyed simultaneously. The code previously used .unwrap() on query results that could fail when:
1. The surface entity was despawned (query_one returns Err)
2. The surface's components were removed (get() returns None)

This commit handles both cases gracefully by using if let patterns instead of unwrap(), preventing panics during output removal.

Fixes #405