### PR TITLE
Translate X11 urgency hints to Wayland

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -951,6 +951,36 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
 
         self.world.get::<&mut WindowData>(id).unwrap().attrs.group = hints.window_group;
+
+        if hints.urgent {
+            self.request_attention(window);
+        }
+    }
+
+    pub fn request_attention(&mut self, window: x::Window) {
+        let Some(activation_state) = self.activation_state.as_ref() else {
+            return;
+        };
+
+        let app_id = self
+            .windows
+            .get(&window)
+            .copied()
+            .and_then(|id| self.world.entity(id).ok())
+            .and_then(|e| e.get::<&WindowData>())
+            .and_then(|d| d.attrs.class.clone());
+
+        activation_state.request_token_with_data(
+            &self.qh,
+            clientside::ActivationData::new(
+                window,
+                smithay_client_toolkit::activation::RequestData {
+                    app_id,
+                    seat_and_serial: None,
+                    surface: None,
+                },
+            ),
+        );
     }
 
     pub fn set_size_hints(&mut self, window: x::Window, hints: WmNormalHints) {

--- a/src/server/selection.rs
+++ b/src/server/selection.rs
@@ -40,12 +40,17 @@ impl<S: X11Selection> SelectionStates<S> {
     }
 
     pub fn seat_created(&mut self, qh: &QueueHandle<MyWorld>, seat: &WlSeat) {
+        // Track a data device per seat rather than a single one: a compositor may expose more than
+        // one seat (e.g. niri's keyboard-only "injector" seat), and a later seat must not clobber
+        // the device for the seat the user actually copies/pastes on.
         if let Some(c) = &mut self.clipboard {
-            c.device = Some(c.manager.get_data_device(qh, seat));
+            c.devices
+                .push((seat.clone(), c.manager.get_data_device(qh, seat)));
         }
 
         if let Some(d) = &mut self.primary {
-            d.device = Some(d.manager.get_selection_device(qh, seat));
+            d.devices
+                .push((seat.clone(), d.manager.get_selection_device(qh, seat)));
         }
     }
 }
@@ -57,7 +62,8 @@ enum SelectionData<S: X11Selection, T: SelectionType> {
 
 struct SelectionState<S: X11Selection, T: SelectionType> {
     manager: T::Manager,
-    device: Option<T::DataDevice>,
+    /// One data device per seat, so an extra seat cannot displace the one carrying the selection.
+    devices: Vec<(WlSeat, T::DataDevice)>,
     source: Option<SelectionData<S, T>>,
 }
 
@@ -65,7 +71,7 @@ impl<S: X11Selection, T: SelectionType> SelectionState<S, T> {
     fn new(manager: T::Manager) -> Self {
         Self {
             manager,
-            device: None,
+            devices: Vec::new(),
             source: None,
         }
     }
@@ -120,13 +126,13 @@ impl<S: X11Selection> InnerServerState<S> {
             let SelectionData::X11 { inner, .. } = state.source.insert(data) else {
                 unreachable!();
             };
-            if let Some(serial) = self
-                .last_kb_serial
-                .as_ref()
-                .map(|(_seat, serial)| serial)
-                .copied()
-            {
-                T::set_selection(inner, state.device.as_ref().unwrap(), serial);
+            // Set the selection on the seat that produced the most recent keyboard serial (the
+            // seat the user is actually using). set_selection is ignored unless the device's seat
+            // matches the serial, so pick the matching device among the seats we know about.
+            if let Some((seat, serial)) = self.last_kb_serial.as_ref() {
+                if let Some((_, device)) = state.devices.iter().find(|(s, _)| s == seat) {
+                    T::set_selection(inner, device, *serial);
+                }
             }
         }
     }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1339,6 +1339,7 @@ fn window_group_properties() {
         super::WmHints {
             window_group: Some(prop_win),
             acquire_input_via_wm: false,
+            urgent: false,
         },
     );
     f.satellite.map_window(win);

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -651,6 +651,9 @@ impl XState {
             server_state.set_size_hints(window, hints);
         }
         let wmhints = wm_hints.resolve()?;
+        if let Some(hints) = wmhints {
+            server_state.set_win_hints(window, hints);
+        }
         let motif_hints = motif_wm_hints.resolve()?;
         if let Some(decorations) = motif_hints.as_ref().and_then(|m| m.decorations) {
             server_state.set_win_decorations(window, decorations);
@@ -1107,6 +1110,7 @@ bitflags! {
     pub struct WmHintsFlags: u32 {
         const Input = 1;
         const WindowGroup = 64;
+        const UrgencyHint = 256;
     }
 }
 
@@ -1145,10 +1149,11 @@ impl From<&[u32]> for WmNormalHints {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
 pub struct WmHints {
     pub window_group: Option<x::Window>,
     pub acquire_input_via_wm: bool,
+    pub urgent: bool,
 }
 
 impl From<&[u32]> for WmHints {
@@ -1162,6 +1167,9 @@ impl From<&[u32]> for WmHints {
         }
         if flags.contains(WmHintsFlags::Input) {
             ret.acquire_input_via_wm = value[1] == 1;
+        }
+        if flags.contains(WmHintsFlags::UrgencyHint) {
+            ret.urgent = true;
         }
 
         ret

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -982,6 +982,34 @@ fn activation_x11_to_x11() {
 }
 
 #[test]
+fn urgency_hint_requests_attention() {
+    let mut f = Fixture::new();
+    let mut connection = Connection::new(&f.display);
+
+    let window1 = connection.new_window(connection.root, 0, 0, 20, 20, false);
+    let surface1 = f.map_as_toplevel(&mut connection, window1);
+    let window2 = connection.new_window(connection.root, 0, 0, 20, 20, false);
+    let surface2 = f.map_as_toplevel(&mut connection, window2);
+
+    f.testwl.focus_toplevel(surface2);
+    std::thread::sleep(Duration::from_millis(10));
+
+    // Set WM_HINTS with urgency bit (256) on window1
+    connection.set_property(
+        window1,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[256_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+    f.wait_and_dispatch();
+
+    // Focus must not change: urgency is "wants attention", not a focus request
+    assert_eq!(f.testwl.get_focused(), Some(surface2));
+    // An xdg_activation_v1 Activate request must have been sent for surface1
+    assert_eq!(f.testwl.last_activation_request(), Some(surface1));
+}
+
+#[test]
 fn quick_delete() {
     let mut f = Fixture::new();
     let connection = Connection::new(&f.display);

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -286,6 +286,7 @@ struct State {
     xdg_activation: Option<XdgActivationV1>,
     valid_tokens: HashSet<String>,
     token_counter: u32,
+    last_activation_request: Option<SurfaceId>,
 }
 
 impl Default for State {
@@ -318,6 +319,7 @@ impl Default for State {
             xdg_activation: None,
             valid_tokens: HashSet::new(),
             token_counter: 0,
+            last_activation_request: None,
         }
     }
 }
@@ -624,6 +626,11 @@ impl Server {
     #[track_caller]
     pub fn get_focused(&self) -> Option<SurfaceId> {
         self.state.get_focused()
+    }
+
+    #[track_caller]
+    pub fn last_activation_request(&self) -> Option<SurfaceId> {
+        self.state.last_activation_request
     }
 
     #[track_caller]
@@ -2124,8 +2131,9 @@ impl Dispatch<XdgActivationV1, ()> for State {
                 data_init.init(id, Mutex::new(ActivationTokenData::default()));
             }
             xdg_activation_v1::Request::Activate { token, surface } => {
+                let surface_id = SurfaceId(surface.id().protocol_id());
+                state.last_activation_request = Some(surface_id);
                 if state.valid_tokens.remove(&token) {
-                    let surface_id = SurfaceId(surface.id().protocol_id());
                     state.focus_toplevel(surface_id);
                 }
             }


### PR DESCRIPTION
Some applications set the X11 urgency hint to request attention. Wayland has a similar mechanism but XWayland did not translate one into the other. This PR adds that feature.

I have tested this with Pidgin 2.x with the Message Notification plugin with the 'Set window manager "URGENT" hint' option on the niri compositor and it seems to work as intended.