### PR TITLE
Log to file when integrated, document running latest build with integration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,8 +20,7 @@ body:
     id: problem
     attributes:
       label: Describe the issue.
-      value: |
-        **Please attach a log if applicable.**
+      description: You should also attach a log file. If integrated with your compositor, the logs will be at `$XDG_STATE_HOME/xwayland-satellite`.
     validations:
       required: true
   - type: textarea
@@ -31,6 +30,7 @@ body:
   - type: checkboxes
     attributes:
       label: Please confirm you have reproduced this on the latest commit.
+      description: See the README for details about correctly running your build.
       options:
         - label: I have reproduced this on the latest commit
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,8 +20,7 @@ body:
     id: problem
     attributes:
       label: Describe the issue.
-      value: |
-        **Please attach a log if applicable.**
+      description: Provide a debug log file. If integrated with your compositor, the logs will be at `$XDG_STATE_HOME/xwayland-satellite`. See the README to learn how to set the logs to `debug` verbosity.
     validations:
       required: true
   - type: textarea
@@ -30,7 +29,8 @@ body:
       label: Steps to reproduce
   - type: checkboxes
     attributes:
-      label: Please confirm you have reproduced this on the latest commit.
+      label: Confirm you have reproduced this on the latest commit and provided `satellite` logs.
+      description: See the README to learn how to run your build of `satellite`.
       options:
         - label: I have reproduced this on the latest commit
           required: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "ident_case"
@@ -1249,6 +1249,7 @@ dependencies = [
  "fontconfig",
  "fontdue",
  "hecs",
+ "humantime",
  "log",
  "macros",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,14 @@ crate-type = ["lib"]
 
 [dependencies]
 bitflags = "2.5.0"
-rustix = { workspace = true, features = ["event"] }
+rustix = { workspace = true, features = ["event", "stdio"] }
 wayland-client.workspace = true
 wayland-protocols = { workspace = true, features = ["client", "server", "staging", "unstable"] }
 wayland-server.workspace = true
 xcb = { version = "1.7.0", features = ["composite", "randr", "res"] }
 wl_drm = { path = "wl_drm" }
 log = "0.4.21"
+humantime = "2.4.0"
 pretty_env_logger = "0.5.0"
 xcb-util-cursor = "0.4"
 smithay-client-toolkit = { version = "0.20.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@ Some (most?) Java applications may present themselves as a blank screen by defau
 cargo build
 # release build
 cargo build --release
+```
 
-# run - will also build if not already built
+## Running
+```
+# will also build if not already built
 cargo run # --release
 ```
+If `satellite` is integrated into your compositor, the compositor's integration will take precedence over other running instances, even if its `satellite` instance is not running. To test latest commit and/or changes, either disable the integration, configure it to launch your built executable, or install `satellite` to the currently-configured location (likely `/usr/bin/xwayland-satellite`) and kill all running `satellite`. In all but the last case, you will need to restart the compositor for the changes to take effect.
 
 ## Systemd support
 xwayland-satellite can be built with systemd support - simply add `-F systemd` to your build command - i.e. `cargo build --release -F systemd`.

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ Some (most?) Java applications may present themselves as a blank screen by defau
 cargo build
 # release build
 cargo build --release
+```
 
-# run - will also build if not already built
+## Running
+```
+# will also build if not already built
 cargo run # --release
 ```
+If `satellite` is integrated into your compositor, the compositor's integration will take precedence over other instances of `satellite`, even if its `satellite` is not currently running. To test the latest commit and/or patches, kill all running `satellite`, then either disable the integration, configure it to launch your executable, or install your build to where the integration looks for it. In all but the last case, you will need to restart the compositor for the changes to take effect.
+
+The `RUST_LOG` environment variable can be set to `debug` to output higher levels of logging. If built without the `--release` flag, the debug logs will be enabled by default.
 
 ## Systemd support
 xwayland-satellite can be built with systemd support - simply add `-F systemd` to your build command - i.e. `cargo build --release -F systemd`.

--- a/README.md
+++ b/README.md
@@ -4,62 +4,6 @@ This is particularly useful for compositors that (understandably) do not want to
 
 Found a bug? [Open a bug report.](https://github.com/Supreeeme/xwayland-satellite/issues/new?template=bug_report.yaml)
 
-Need help troubleshooting, or have some other general question? [Ask on GitHub Discussions.](https://github.com/Supreeeme/xwayland-satellite/discussions)
-
-## Dependencies
-- Xwayland >=23.1
-- xcb
-- xcb-util-cursor
-- clang (building only)
-
-## Usage
-Run `xwayland-satellite`. You can specify an X display to use (i.e. `:12`). Be sure to set the same `DISPLAY` environment variable for any X11 clients.
-Because xwayland-satellite is a Wayland client (in addition to being a Wayland compositor), it will need to launch after your compositor launches, but obviously before any X11 applications.
-
-## Java applications
-Some (most?) Java applications may present themselves as a blank screen by default with satellite. To fix this, simply set the environment variable
-`_JAVA_AWT_WM_NONREPARENTING=1` before launching it to fix this. Unfortunately there is not a way for satellite to automatically do this.
-
-## Building
-```
-# dev build
-cargo build
-# release build
-cargo build --release
-```
-
-## Running
-```
-# will also build if not already built
-cargo run # --release
-```
-If `satellite` is integrated into your compositor, the compositor's integration will take precedence over other instances of `satellite`, even if its `satellite` is not currently running. To test the latest commit and/or patches, kill all running `satellite`, then either disable the integration, configure it to launch your executable, or install your build to where the integration looks for it. In all but the last case, you will need to restart the compositor for the changes to take effect.
-
-The `RUST_LOG` environment variable can be set to `debug` to output higher levels of logging. If built without the `--release` flag, the debug logs will be enabled by default.
-
-## Systemd support
-xwayland-satellite can be built with systemd support - simply add `-F systemd` to your build command - i.e. `cargo build --release -F systemd`.
-
-With systemd support, satellite will send a state change notification when Xwayland has been initialized, allowing for having services dependent on satellite's startup.
-
-An example service file is located in `resources/xwayland-satellite.service` - be sure to replace the `ExecStart` line with the proper location before using it.
-It can be placed in a systemd user unit directory (i.e. `$XDG_CONFIG_HOME/systemd/user` or `/etc/systemd/user`),
-and be launched and enabled with `systemctl --user enable --now xwayland-satellite`.
-It will be started when the `graphical-session.target` is reached,
-which is likely after your compositor is started if it supports systemd.
-
-Note that you *do not* need the systemd service if the compositor already integrates xwayland-satellite (see below).
-
-## Scaling/HiDPI
-For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
-the smallest monitor's DPI, meaning apps may have small text on other monitors.
-
-Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
-so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.
-
-Satellite acts as an Xsettings manager for setting scaling related settings, but will get out of the way of other Xsettings managers.
-To manually set these settings, try [xsettingsd](https://codeberg.org/derat/xsettingsd) or another Xsettings manager.
-
 ## Wayland protocols used
 The host compositor **must** implement the following protocols/interfaces for satellite to function:
 - Core interfaces (wl_output, wl_surface, wl_compositor, etc)
@@ -69,15 +13,80 @@ The host compositor **must** implement the following protocols/interfaces for sa
 Additionally, satellite can *optionally* take advantage of the following protocols:
 - Linux dmabuf
 - XDG activation
+- XDG decoration
 - XDG foreign
 - Pointer constraints
+- Primary selection
 - Tablet input
 - Fractional scale
 
-## Compositor integration
+## Building
+
+xwayland-satellite has the following dependencies:
+- Xwayland >=23.1
+- xcb
+- xcb-util-cursor
+- cargo (building only)
+- clang (building only)
+- git (building only, optional)
+
+```
+# dev build
+cargo build
+# release build
+cargo build --release
+```
+
+In addition, xwayland-satellite also has the following optional features, which can be enabled by adding the `-F <feature>` flag to the `cargo build` command:
+
+### `systemd`
+With the `systemd` feature enabled, xwayland-satellite will send a state change notification when Xwayland has been initialized, allowing for having services dependent on satellite's startup. This feature can be enabled without systemd installed, though it does nothing.
+
+### `fontconfig`
+The `fontconfig` feature uses fontconfig to load Open Sans at runtime instead of compiling Open Sans directly into the binary. The Open Sans font and `fontconfig` are runtime depenedencies when this feature is enabled.
+
+## Running
+
+Because xwayland-satellite is a Wayland client (in addition to being a Wayland compositor), it will need to launch after your compositor launches, but obviously before any X11 applications.
+
+The `RUST_LOG` environment variable can be set to `debug` to output higher levels of logging. If built without the `--release` flag, the debug logs will be enabled by default.
+
+### Manually
+Run the `xwayland-satellite` binary, or use `cargo run` (with or without `--release`). You can specify an X display to use (i.e. `:12`). Be sure to set the same `DISPLAY` environment variable for any X11 clients. Setting the display allows you to choose which instance of `satellite` the X11 client communicates with, which can be useful for debugging crashes or bypassing automatically started instances (see below).
+
+### Systemd support
+An example service file is located in `resources/xwayland-satellite.service` - be sure to replace the `ExecStart` line with the proper location before using it.
+It can be placed in a systemd user unit directory (i.e. `$XDG_CONFIG_HOME/systemd/user` or `/etc/systemd/user`),
+and be launched and enabled with `systemctl --user enable --now xwayland-satellite`.
+It will be started when the `graphical-session.target` is reached,
+which is likely after your compositor is started if it supports systemd.
+
+Note that you *do not* need the systemd service if the compositor already integrates xwayland-satellite (see below).
+
+### Compositor integration
 Satellite supports passing through the `-listenfd` Xwayland argument. What this means is you can integrate satellite
 (and by extension Xwayland) into your compositor, and do things like on demand activation. Note that you *must* pass
 a display number to satellite as the first argument, and then the `-listenfd` argument.
 
 You can view [Niri's implementation of this integration](https://github.com/YaLTeR/niri/pull/1728/files) for understanding
 how it should work.
+
+If `satellite` is integrated into your compositor, updating either `xwayland-satellite` or your compositor's satellite settings requires restarting the compositor. To test latest commit and/or patches without restarting the compositor, add a display when launching `xwayland-satellite` and use the same `DISPLAY` environment variables for applications you wish to test.
+
+## Troubleshooting
+
+Need help troubleshooting, or have some other general question? [Ask on GitHub Discussions.](https://github.com/Supreeeme/xwayland-satellite/discussions)
+
+### Java applications
+Some (most?) Java applications may present themselves as a blank screen by default with satellite. To fix this, simply set the environment variable
+`_JAVA_AWT_WM_NONREPARENTING=1` before launching it to fix this. Unfortunately there is not a way for satellite to automatically do this.
+
+### Scaling/HiDPI
+For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
+the smallest monitor's DPI, meaning apps may have small text on other monitors.
+
+Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
+so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.
+
+Satellite acts as an Xsettings manager for setting scaling related settings, but will get out of the way of other Xsettings managers.
+To manually set these settings, try [xsettingsd](https://codeberg.org/derat/xsettingsd) or another Xsettings manager.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
+use pretty_env_logger::env_logger::fmt::Target;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 fn main() {
-    pretty_env_logger::formatted_timed_builder()
-        .filter_level(log::LevelFilter::Info)
-        .parse_default_env()
-        .init();
-    xwayland_satellite::main(parse_args());
+    let arg_data = parse_args();
+    init_logger(!arg_data.listenfds.is_empty());
+    xwayland_satellite::main(arg_data);
 }
 
 #[derive(Default)]
@@ -245,4 +244,34 @@ fn parse_args() -> RealData {
     data.flags = flags.to_vec();
 
     data
+}
+
+fn init_logger(integrated: bool) {
+    let output_file = || -> Option<std::fs::File> {
+        if !integrated {
+            return None;
+        }
+        let mut file_path = match std::env::var_os("XDG_STATE_HOME").map(std::path::PathBuf::from) {
+            Some(f) => f,
+            None => std::env::var_os("HOME")
+                .map(std::path::PathBuf::from)?
+                .join(".local/state"),
+        };
+        file_path.push("xwayland-satellite");
+        std::fs::create_dir_all(&file_path).ok()?;
+        file_path.push("log");
+        std::fs::File::create(file_path).ok()
+    }();
+    let (default_level, log_output) = match output_file {
+        Some(f) => (
+            log::LevelFilter::Debug,
+            Target::Pipe(Box::new(std::io::BufWriter::new(f))),
+        ),
+        None => (log::LevelFilter::Info, Default::default()),
+    };
+    pretty_env_logger::formatted_timed_builder()
+        .filter_level(default_level)
+        .target(log_output)
+        .parse_default_env()
+        .init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 fn main() {
-    pretty_env_logger::formatted_timed_builder()
-        .filter_level(log::LevelFilter::Info)
-        .parse_default_env()
-        .init();
-    xwayland_satellite::main(parse_args());
+    let arg_data = parse_args();
+    init_logger(!arg_data.listenfds.is_empty());
+    xwayland_satellite::main(arg_data);
 }
 
 #[derive(Default)]
@@ -245,4 +243,39 @@ fn parse_args() -> RealData {
     data.flags = flags.to_vec();
 
     data
+}
+
+fn init_logger(integrated: bool) {
+    || -> Option<()> {
+        if !integrated {
+            return None;
+        }
+        let mut file_path = match std::env::var_os("XDG_STATE_HOME").map(std::path::PathBuf::from) {
+            Some(f) => f,
+            None => std::env::var_os("HOME")
+                .map(std::path::PathBuf::from)?
+                .join(".local/state"),
+        };
+        file_path.push("xwayland-satellite");
+        std::fs::create_dir_all(&file_path).ok()?;
+        file_path.push(format!(
+            "{}.log",
+            humantime::format_rfc3339_seconds(std::time::SystemTime::now())
+        ));
+        // By directing `stderr` to the log file instead of directing the logger's output to the file,
+        // we capture any panic messages output as well
+        if let Ok(file) = std::fs::File::create(file_path) {
+            rustix::stdio::dup2_stderr(file).ok()?;
+        }
+        Some(())
+    }();
+    let log_level = if cfg!(debug_assertions) {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+    pretty_env_logger::formatted_timed_builder()
+        .filter_level(log_level)
+        .parse_default_env()
+        .init();
 }


### PR DESCRIPTION
After multiple instances of an integration with Niri relaunching a old version (as opposed to the latest commit/patch build) on their behalf (see comment on #340, #406, #413), I have done two things to reduce user/dev confusion. 
* I added documentation on configuring a `satelllite` integration to run their build
* When integrated with the `-listenfd` flag, it now logs to a file. This log file contains the version of `satellite` as the first line of the log, confirming whether the latest build is being run, and makes reporting `satellite` bugs easier for people who use it integrated with their compositor (for this motivation, logging to a file also ups the log level to Debug).