### PR TITLE
fix: improve window classification to prevent games being embedded as popups

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,7 +7,10 @@ pub(crate) mod selection;
 mod tests;
 
 use self::event::*;
-use crate::xstate::{Decorations, MoveResizeDirection, WindowDims, WmHints, WmName, WmNormalHints};
+use crate::xstate::{
+    Decorations, MoveResizeDirection, PopupKind, WindowDims, WindowKind, WmHints, WmName,
+    WmNormalHints,
+};
 use crate::{X11Selection, XConnection, timespec_from_millis};
 use clientside::MyWorld;
 use decoration::{DecorationsData, DecorationsDataSatellite};
@@ -97,9 +100,9 @@ where
     u32::from(wenum).try_into().unwrap()
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct WindowAttributes {
-    is_popup: bool,
+    window_kind: WindowKind,
     dims: WindowDims,
     size_hints: Option<WmNormalHints>,
     title: Option<WmName>,
@@ -107,6 +110,21 @@ struct WindowAttributes {
     group: Option<x::Window>,
     decorations: Option<Decorations>,
     transient_for: Option<x::Window>,
+}
+
+impl Default for WindowAttributes {
+    fn default() -> Self {
+        Self {
+            window_kind: WindowKind::Toplevel(crate::xstate::ToplevelReason::Default),
+            dims: WindowDims::default(),
+            size_hints: None,
+            title: None,
+            class: None,
+            group: None,
+            decorations: None,
+            transient_for: None,
+        }
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Copy, Clone)]
@@ -128,7 +146,13 @@ impl WindowData {
         Self {
             mapped: false,
             attrs: WindowAttributes {
-                is_popup: override_redirect,
+                window_kind: if override_redirect {
+                    WindowKind::Popup(PopupKind::strong(
+                        crate::xstate::PopupReason::OverrideRedirect,
+                    ))
+                } else {
+                    WindowKind::Toplevel(crate::xstate::ToplevelReason::Default)
+                },
                 dims,
                 ..Default::default()
             },
@@ -867,17 +891,13 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         self.windows.insert(window, id);
     }
 
-    pub fn set_popup(&mut self, window: x::Window, is_popup: bool) {
+    pub fn set_window_kind(&mut self, window: x::Window, window_kind: WindowKind) {
         let Some(id) = self.windows.get(&window).copied() else {
-            debug!("not setting popup for unknown window {window:?}");
+            debug!("not setting window kind for unknown window {window:?}");
             return;
         };
 
-        self.world
-            .get::<&mut WindowData>(id)
-            .unwrap()
-            .attrs
-            .is_popup = is_popup;
+        self.world.get::<&mut WindowData>(id).unwrap().attrs.window_kind = window_kind;
     }
 
     pub fn set_win_title(&mut self, window: x::Window, name: WmName) {
@@ -1038,7 +1058,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return true;
         };
 
-        !win.mapped || win.attrs.is_popup
+        !win.mapped || win.attrs.window_kind.is_popup()
     }
 
     pub fn reconfigure_window(&mut self, event: x::ConfigureNotifyEvent) {
@@ -1061,7 +1081,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
         if dims == win.attrs.dims {
             return;
-        } else if win.attrs.is_popup {
+        } else if win.attrs.window_kind.is_popup() {
             win.attrs.dims = dims;
         }
 
@@ -1184,7 +1204,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         }
     }
 
-    pub fn set_transient_for(&mut self, window: x::Window, parent: x::Window) {
+    pub fn set_transient_for(&mut self, window: x::Window, parent: Option<x::Window>) {
         let Some(mut win) = self
             .windows
             .get(&window)
@@ -1195,7 +1215,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return;
         };
 
-        win.attrs.transient_for = Some(parent);
+        win.attrs.transient_for = parent;
     }
 
     pub fn activate_window(&mut self, window: x::Window) {
@@ -1354,6 +1374,10 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
     /// Returns true if the created window is a toplevel.
     fn create_role_window(&mut self, window: x::Window, entity: Entity) -> bool {
+        if self.world.get::<&SurfaceRole>(entity).is_ok() {
+            debug!("{window:?} already has a SurfaceRole, skipping create_role_window");
+            return false;
+        }
         let xdg_surface;
         let mut popup_for = None;
         let mut fullscreen = false;
@@ -1367,8 +1391,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             xdg_surface = self.xdg_wm_base.get_xdg_surface(&surface, &self.qh, entity);
 
             let window_data = data.get::<&WindowData>().unwrap();
-            if window_data.attrs.is_popup {
-                popup_for = self.last_hovered.or(self.last_focused_toplevel);
+            if let WindowKind::Popup(popup_kind) = window_data.attrs.window_kind {
+                popup_for = self.popup_parent(&window_data, popup_kind);
             }
 
             let (width, height) = (window_data.attrs.dims.width, window_data.attrs.dims.height);
@@ -1407,6 +1431,21 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         self.world.insert(entity, (role,)).unwrap();
 
         is_toplevel
+    }
+
+    fn popup_parent(&self, window_data: &WindowData, popup_kind: PopupKind) -> Option<x::Window> {
+        if let Some(parent) = window_data.attrs.transient_for {
+            return self
+                .windows
+                .get(&parent)
+                .copied()
+                .and_then(|id| self.world.get::<&SurfaceRole>(id).ok())
+                .and_then(|role| role.xdg().map(|_| parent));
+        }
+        if popup_kind.is_strong() {
+            return self.last_hovered.or(self.last_focused_toplevel);
+        }
+        None
     }
 
     fn create_toplevel(

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2584,7 +2584,7 @@ fn transient_for_toplevel() {
         },
     );
 
-    f.satellite.set_transient_for(sub_toplevel, toplevel);
+    f.satellite.set_transient_for(sub_toplevel, Some(toplevel));
     f.map_window(&comp, sub_toplevel, &surface.obj, &buffer);
     f.run();
     let id = f.check_new_surface();

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -595,6 +595,7 @@ impl XState {
                     return;
                 }
 
+                server_state.run();
                 match direction {
                     MoveResizeDirection::Move => {
                         server_state.move_window(e.window());
@@ -635,7 +636,6 @@ impl XState {
         let class = self.get_wm_class(window);
         let size_hints = self.get_wm_size_hints(window);
         let motif_wm_hints = self.get_motif_wm_hints(window);
-        let wm_hints = self.get_wm_hints(window);
         let mut title = name.resolve()?;
         if title.is_none() {
             title = self.get_wm_name(window).resolve()?;
@@ -650,7 +650,6 @@ impl XState {
         if let Some(hints) = size_hints.resolve()? {
             server_state.set_size_hints(window, hints);
         }
-        let wmhints = wm_hints.resolve()?;
         let motif_hints = motif_wm_hints.resolve()?;
         if let Some(decorations) = motif_hints.as_ref().and_then(|m| m.decorations) {
             server_state.set_win_decorations(window, decorations);
@@ -667,13 +666,21 @@ impl XState {
             .resolve()?
             .flatten();
 
-        let is_popup =
-            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some())?;
-        server_state.set_popup(window, is_popup);
-        if let Some(parent) = transient_for.and_then(|t| (!is_popup).then_some(t)) {
-            server_state.set_transient_for(window, parent);
-        }
+        self.update_window_kind(server_state, window, motif_hints, transient_for)?;
 
+        Ok(())
+    }
+
+    fn update_window_kind(
+        &self,
+        server_state: &mut super::RealServerState,
+        window: x::Window,
+        motif_hints: Option<motif::Hints>,
+        transient_for: Option<x::Window>,
+    ) -> XResult<()> {
+        let window_kind = self.guess_window_kind(window, motif_hints, transient_for.is_some())?;
+        server_state.set_window_kind(window, window_kind);
+        server_state.set_transient_for(window, transient_for);
         Ok(())
     }
 
@@ -692,15 +699,13 @@ impl XState {
         }
     }
 
-    fn guess_is_popup(
+    fn guess_window_kind(
         &self,
         window: x::Window,
         motif_hints: Option<motif::Hints>,
-        wm_hints: Option<WmHints>,
         has_transient_for: bool,
-    ) -> XResult<bool> {
+    ) -> XResult<WindowKind> {
         let mut motif_popup = false;
-        let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
 
         let attrs = self
@@ -722,34 +727,23 @@ impl XState {
             has_skip_taskbar = Some(states.contains(&self.atoms.skip_taskbar));
         }
         if let Some(hints) = motif_hints {
-            // If MOTIF_WM_HINTS provides no decorations for client assume its a popup
             motif_popup = hints.decorations.is_some_and(|d| d.is_clientside());
-            // WMHINTS is considered popup only if client is not decorated && client does not
-            // accept input focus
-            // Sometimes popup is false-positive meaning both MOTIF Decorations and WM_HINTS input indicates its a popup
-            // but MOTIF has function flags that toplevel window should do
-            wmhint_popup = motif_popup
-                && wm_hints.is_some_and(|h| !h.acquire_input_via_wm)
-                && !hints.functions.as_ref().is_some_and(|f| {
-                    f.intersects(
-                        motif::Functions::Minimize
-                            | motif::Functions::Maximize
-                            | motif::Functions::Resize
-                            | motif::Functions::All,
-                    )
-                });
-            // If the motif hints indicate the user shouldn't be able to do anything
-            // to the window at all, it stands to reason it's probably a popup.
             if hints.functions.is_some_and(|f| f.is_empty()) {
-                return Ok(true);
+                return Ok(WindowKind::Popup(PopupKind::strong(
+                    PopupReason::MotifNoFunctions,
+                )));
             }
         }
 
         let override_redirect = self.connection.wait_for_reply(attrs)?.override_redirect();
-        let mut is_popup = override_redirect;
+        if override_redirect {
+            return Ok(WindowKind::Popup(PopupKind::strong(
+                PopupReason::OverrideRedirect,
+            )));
+        }
 
         let window_types = window_types.resolve()?.unwrap_or_else(|| {
-            if !override_redirect && has_transient_for {
+            if has_transient_for {
                 vec![self.window_atoms.dialog]
             } else {
                 vec![self.window_atoms.normal]
@@ -767,40 +761,63 @@ impl XState {
         }
         debug!("{window:?} override_redirect: {override_redirect:?}");
 
-        let mut known_window_type = false;
         for ty in window_types {
             match ty {
-                x if x == self.window_atoms.normal => is_popup = override_redirect || wmhint_popup,
-                x if x == self.window_atoms.dialog => is_popup = override_redirect,
-                x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,
-                x if [
-                    self.window_atoms.menu,
-                    self.window_atoms.popup_menu,
-                    self.window_atoms.dropdown_menu,
-                    self.window_atoms.tooltip,
-                    self.window_atoms.drag_n_drop,
-                    self.window_atoms.combo,
-                ]
-                .contains(&x) =>
-                {
-                    is_popup = true;
+                x if x == self.window_atoms.normal => {
+                    return Ok(WindowKind::Toplevel(ToplevelReason::NormalWindowType));
                 }
-                _ => {
-                    continue;
+                x if x == self.window_atoms.dialog => {
+                    return Ok(WindowKind::Toplevel(ToplevelReason::Dialog));
                 }
+                x if x == self.window_atoms.utility && motif_popup => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::UtilityMotifPopup,
+                    )));
+                }
+                x if x == self.window_atoms.utility => {
+                    return Ok(WindowKind::Toplevel(ToplevelReason::Utility));
+                }
+                x if x == self.window_atoms.menu => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::Menu),
+                    )));
+                }
+                x if x == self.window_atoms.popup_menu => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::PopupMenu),
+                    )));
+                }
+                x if x == self.window_atoms.dropdown_menu => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::DropdownMenu),
+                    )));
+                }
+                x if x == self.window_atoms.tooltip => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::Tooltip),
+                    )));
+                }
+                x if x == self.window_atoms.drag_n_drop => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::DragAndDrop),
+                    )));
+                }
+                x if x == self.window_atoms.combo => {
+                    return Ok(WindowKind::Popup(PopupKind::strong(
+                        PopupReason::ExplicitWindowType(PopupWindowType::Combo),
+                    )));
+                }
+                _ => {}
             }
-
-            known_window_type = true;
-            break;
         }
 
-        if !known_window_type {
-            if let Some(has_skip_taskbar) = has_skip_taskbar {
-                is_popup = has_skip_taskbar || override_redirect;
-            }
+        if has_skip_taskbar == Some(true) {
+            return Ok(WindowKind::Toplevel(ToplevelReason::SuppressedPopup(
+                PopupKind::weak(PopupReason::SkipTaskbarHint),
+            )));
         }
 
-        Ok(is_popup)
+        Ok(WindowKind::Toplevel(ToplevelReason::Default))
     }
 
     fn get_property_cookie(
@@ -989,6 +1006,23 @@ impl XState {
                 let hints =
                     unwrap_or_skip_bad_window_ret!(self.get_wm_hints(window).resolve()).unwrap();
                 server_state.set_win_hints(window, hints);
+                let motif_hints = unwrap_or_skip_bad_window_ret!(self.get_motif_wm_hints(window).resolve());
+                let transient_for = unwrap_or_skip_bad_window_ret!(self
+                    .property_cookie_wrapper(
+                        window,
+                        self.atoms.wm_transient_for,
+                        x::ATOM_WINDOW,
+                        1,
+                        |reply: x::GetPropertyReply| reply.value::<x::Window>().first().copied(),
+                    )
+                    .resolve())
+                    .flatten();
+                unwrap_or_skip_bad_window_ret!(self.update_window_kind(
+                    server_state,
+                    window,
+                    motif_hints,
+                    transient_for,
+                ));
             }
             x if x == x::ATOM_WM_NORMAL_HINTS => {
                 let hints =
@@ -1011,13 +1045,31 @@ impl XState {
                     unwrap_or_skip_bad_window_ret!(self.get_wm_class(window).resolve()).unwrap();
                 server_state.set_win_class(window, class);
             }
-            x if x == self.atoms.motif_wm_hints => {
+            x if x == self.atoms.motif_wm_hints
+                || x == self.window_atoms.ty
+                || x == self.atoms.net_wm_state
+                || x == self.atoms.wm_transient_for => {
                 let motif_hints =
-                    unwrap_or_skip_bad_window_ret!(self.get_motif_wm_hints(window).resolve())
-                        .unwrap();
-                if let Some(decorations) = motif_hints.decorations {
+                    unwrap_or_skip_bad_window_ret!(self.get_motif_wm_hints(window).resolve());
+                if let Some(decorations) = motif_hints.as_ref().and_then(|m| m.decorations) {
                     server_state.set_win_decorations(window, decorations);
                 }
+                let transient_for = unwrap_or_skip_bad_window_ret!(self
+                    .property_cookie_wrapper(
+                        window,
+                        self.atoms.wm_transient_for,
+                        x::ATOM_WINDOW,
+                        1,
+                        |reply: x::GetPropertyReply| reply.value::<x::Window>().first().copied(),
+                    )
+                    .resolve())
+                    .flatten();
+                unwrap_or_skip_bad_window_ret!(self.update_window_kind(
+                    server_state,
+                    window,
+                    motif_hints,
+                    transient_for,
+                ));
             }
             _ => {
                 if log::log_enabled!(log::Level::Debug) {
@@ -1085,6 +1137,78 @@ xcb::atoms_struct! {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowKind {
+    Toplevel(ToplevelReason),
+    Popup(PopupKind),
+}
+
+impl WindowKind {
+    pub fn is_popup(&self) -> bool {
+        matches!(self, Self::Popup(_))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToplevelReason {
+    Default,
+    NormalWindowType,
+    Dialog,
+    Utility,
+    SuppressedPopup(PopupKind),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PopupKind {
+    pub strength: PopupStrength,
+    pub reason: PopupReason,
+}
+
+impl PopupKind {
+    pub const fn strong(reason: PopupReason) -> Self {
+        Self {
+            strength: PopupStrength::Strong,
+            reason,
+        }
+    }
+
+    pub const fn weak(reason: PopupReason) -> Self {
+        Self {
+            strength: PopupStrength::Weak,
+            reason,
+        }
+    }
+
+    pub fn is_strong(&self) -> bool {
+        matches!(self.strength, PopupStrength::Strong)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopupStrength {
+    Strong,
+    Weak,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopupReason {
+    OverrideRedirect,
+    MotifNoFunctions,
+    UtilityMotifPopup,
+    ExplicitWindowType(PopupWindowType),
+    SkipTaskbarHint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopupWindowType {
+    Menu,
+    PopupMenu,
+    DropdownMenu,
+    Tooltip,
+    DragAndDrop,
+    Combo,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct WindowDims {
     pub x: i16,
@@ -1145,7 +1269,7 @@ impl From<&[u32]> for WmNormalHints {
     }
 }
 
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct WmHints {
     pub window_group: Option<x::Window>,
     pub acquire_input_via_wm: bool,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -345,6 +345,7 @@ xcb::atoms_struct! {
         win_type_utility => b"_NET_WM_WINDOW_TYPE_UTILITY",
         win_type_dnd => b"_NET_WM_WINDOW_TYPE_DND",
         win_type_combo => b"_NET_WM_WINDOW_TYPE_COMBO",
+        win_type_splash => b"_NET_WM_WINDOW_TYPE_SPLASH",
         motif_wm_hints => b"_MOTIF_WM_HINTS" only_if_exists = false,
         wm_hints => b"WM_HINTS",
         mime1 => b"text/plain" only_if_exists = false,
@@ -2130,7 +2131,7 @@ fn popup_heuristics() {
         connection.atoms.net_wm_state,
         &[connection.atoms.skip_taskbar],
     );
-    f.map_as_popup(&mut connection, yabridge_popup);
+    f.map_as_toplevel(&mut connection, yabridge_popup);
 
     let steam = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(
@@ -2194,6 +2195,107 @@ fn popup_heuristics() {
         &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
     );
     f.map_as_toplevel(&mut connection, wallpaper_engine);
+
+    let forza_like = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.set_property(
+        forza_like,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_normal],
+    );
+    connection.set_property(
+        forza_like,
+        connection.atoms.motif_wm_hints,
+        connection.atoms.motif_wm_hints,
+        &[0x3_u32, 0x26, 0x0, 0x0, 0x0],
+    );
+    connection.set_property(
+        forza_like,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+    f.map_as_toplevel(&mut connection, forza_like);
+}
+
+#[test]
+fn popup_heuristics_property_recompute() {
+    let mut f = Fixture::new();
+    let mut connection = Connection::new(&f.display);
+
+    let win_toplevel = connection.new_window(connection.root, 0, 0, 20, 20, false);
+    f.map_as_toplevel(&mut connection, win_toplevel);
+
+    let delayed_normal = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.map_window(delayed_normal);
+    f.wait_and_dispatch();
+
+    connection.set_property(
+        delayed_normal,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_normal],
+    );
+    connection.set_property(
+        delayed_normal,
+        connection.atoms.motif_wm_hints,
+        connection.atoms.motif_wm_hints,
+        &[0x3_u32, 0x26, 0x0, 0x0, 0x0],
+    );
+    connection.set_property(
+        delayed_normal,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+    f.wait_and_dispatch();
+
+    let surface = f
+        .testwl
+        .last_created_surface_id()
+        .expect("No surface created");
+    f.configure_and_verify_new_toplevel(&mut connection, delayed_normal, surface);
+}
+
+#[test]
+fn weak_popup_heuristics_do_not_auto_parent() {
+    let mut f = Fixture::new();
+    let mut connection = Connection::new(&f.display);
+
+    let parent = connection.new_window(connection.root, 0, 0, 100, 100, false);
+    let parent_surface = f.map_as_toplevel(&mut connection, parent);
+    f.testwl.focus_toplevel(parent_surface);
+    f.testwl.move_pointer_to(parent_surface, 20.0, 20.0);
+    f.wait_and_dispatch();
+
+    let weak_popup = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.set_property(
+        weak_popup,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_splash],
+    );
+    connection.set_property(
+        weak_popup,
+        x::ATOM_ATOM,
+        connection.atoms.net_wm_state,
+        &[connection.atoms.skip_taskbar],
+    );
+
+    connection.map_window(weak_popup);
+    f.wait_and_dispatch();
+
+    let surface = f
+        .testwl
+        .last_created_surface_id()
+        .expect("No surface created");
+    let data = f.testwl.get_surface_data(surface).unwrap();
+    assert!(
+        matches!(data.role, Some(testwl::SurfaceRole::Toplevel(_))),
+        "weak heuristic popup should fall back to toplevel, got {:?}",
+        data.role
+    );
+    f.configure_and_verify_new_toplevel(&mut connection, weak_popup, surface);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix games like Forza Horizon 5 and Cyberpunk 2077 being incorrectly classified as popups and embedded into Steam's window.

I've been experiencing this issue myself while trying to play Cyberpunk 2077 on Steam with Arch Linux + Niri. After waiting over a month without being able to play, I decided to take a shot at fixing it myself.

I referenced the approach in #395, though I ended up taking a slightly different direction — focusing on improving the window classification logic itself rather than adding Wine-specific checks.

## Root Cause

Games often set X11 properties (like `_NET_WM_WINDOW_TYPE_NORMAL`) **after** mapping their windows. The previous heuristics could misclassify windows with incomplete property information as popups, causing them to be embedded into the parent window (Steam).

## Changes

- Replace boolean `is_popup` with typed `WindowKind` enum for clearer semantics
- Introduce `PopupKind` with strong/weak classification to distinguish explicit popup evidence from heuristic guesses
- Only classify as popup when **strong evidence** exists:
  - `override_redirect`
  - Explicit popup window types (menu, tooltip, combo, etc.)
  - Motif no-functions hint
- Default ambiguous windows to toplevel (safer failure mode — a misplaced toplevel is far less disruptive than a game window embedded as popup)
- Re-evaluate window kind when relevant properties change after map
- Weak popup heuristics (e.g. `_NET_WM_STATE_SKIP_TASKBAR`) no longer auto-parent to last focused window

## Test Plan

- [x] All existing tests pass (82 tests)
- [x] `cargo clippy` clean
- [x] Manually verified Cyberpunk 2077 launches correctly as a standalone window on Arch Linux + Niri

---

If there's anything that needs to be changed or if you have concerns about this approach, please let me know — I'm happy to iterate on it.

Fixes #392