### PR TITLE
feat: Scale relative pointer motion by display scaling factor

### DIFF
--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -537,7 +537,7 @@ impl<S: X11Selection>
                     client.get_relative_pointer(&client_pointer, &state.qh, entity)
                 };
                 let server = data_init.init(id, entity);
-                state.world.spawn_at(entity, (server, client));
+                state.world.spawn_at(entity, (server, client, PointerEntity(pointer_entity)));
             }
             _ => warn!("unhandled relative pointer request: {request:?}"),
         }

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -537,7 +537,9 @@ impl<S: X11Selection>
                     client.get_relative_pointer(&client_pointer, &state.qh, entity)
                 };
                 let server = data_init.init(id, entity);
-                state.world.spawn_at(entity, (server, client));
+                state
+                    .world
+                    .spawn_at(entity, (server, client, PointerEntity(pointer_entity)));
             }
             _ => warn!("unhandled relative pointer request: {request:?}"),
         }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -51,6 +51,9 @@ use wayland_server::protocol::{
 #[derive(Copy, Clone)]
 pub(super) struct SurfaceScaleFactor(pub f64);
 
+#[derive(Copy, Clone)]
+pub(super) struct PointerEntity(pub Entity);
+
 #[derive(hecs::Bundle)]
 pub(super) struct SurfaceBundle {
     pub client: client::wl_surface::WlSurface,
@@ -1436,13 +1439,17 @@ impl Event for c_dmabuf::zwp_linux_dmabuf_feedback_v1::Event {
 impl Event for zwp_relative_pointer_v1::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
         let server = state.world.get::<&RelativePointerServer>(target).unwrap();
+        let pointer_entity = state.world.get::<&PointerEntity>(target).unwrap().0;
+        let scale = state.world.get::<&SurfaceScaleFactor>(pointer_entity)
+            .map(|s| s.0).unwrap_or(1.0);
+
         simple_event_shunt! {
             server, self => [
                 RelativeMotion {
                     utime_hi,
                     utime_lo,
-                    dx,
-                    dy,
+                    |dx| dx * scale,
+                    |dy| dy * scale,
                     dx_unaccel,
                     dy_unaccel
                 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -51,6 +51,9 @@ use wayland_server::protocol::{
 #[derive(Copy, Clone)]
 pub(super) struct SurfaceScaleFactor(pub f64);
 
+#[derive(Copy, Clone)]
+pub(super) struct PointerEntity(pub Entity);
+
 #[derive(hecs::Bundle)]
 pub(super) struct SurfaceBundle {
     pub client: client::wl_surface::WlSurface,
@@ -1450,13 +1453,20 @@ impl Event for c_dmabuf::zwp_linux_dmabuf_feedback_v1::Event {
 impl Event for zwp_relative_pointer_v1::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
         let server = state.world.get::<&RelativePointerServer>(target).unwrap();
+        let pointer_entity = state.world.get::<&PointerEntity>(target).unwrap().0;
+        let scale = state
+            .world
+            .get::<&SurfaceScaleFactor>(pointer_entity)
+            .map(|s| s.0)
+            .unwrap_or(1.0);
+
         simple_event_shunt! {
             server, self => [
                 RelativeMotion {
                     utime_hi,
                     utime_lo,
-                    dx,
-                    dy,
+                    |dx| dx * scale,
+                    |dy| dy * scale,
                     dx_unaccel,
                     dy_unaccel
                 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -36,7 +36,10 @@ use wayland_protocols::{
             zwp_locked_pointer_v1::ZwpLockedPointerV1,
             zwp_pointer_constraints_v1::{self, ZwpPointerConstraintsV1},
         },
-        relative_pointer::zv1::client::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
+        relative_pointer::zv1::client::{
+            zwp_relative_pointer_manager_v1::{self, ZwpRelativePointerManagerV1},
+            zwp_relative_pointer_v1::ZwpRelativePointerV1,
+        },
         tablet::zv2::client::{
             zwp_tablet_manager_v2::{self, ZwpTabletManagerV2},
             zwp_tablet_pad_group_v2::{
@@ -114,6 +117,7 @@ struct Compositor {
     seat: TestObject<WlSeat>,
     tablet_man: TestObject<ZwpTabletManagerV2>,
     pointer_constraints: TestObject<ZwpPointerConstraintsV1>,
+    relative_pointer_man: TestObject<ZwpRelativePointerManagerV1>,
 } => CompositorOptional
 
 }
@@ -451,6 +455,9 @@ impl<C: XConnection> TestFixture<C> {
                     x if x == ZwpTabletManagerV2::interface().name => bind!(tablet_man),
                     x if x == ZwpPointerConstraintsV1::interface().name => {
                         bind!(pointer_constraints)
+                    }
+                    x if x == ZwpRelativePointerManagerV1::interface().name => {
+                        bind!(relative_pointer_man)
                     }
                     _ => {}
                 }
@@ -2981,6 +2988,90 @@ fn scaled_pointer_lock_position_hint() {
         lock_data.cursor_hint,
         Some(testwl::Vec2f { x: 50.0, y: 50.0 })
     );
+}
+
+#[test]
+fn scaled_relative_pointer_motion() {
+    let mut f = TestFixture::new_pre_connect(|testwl| {
+        testwl.enable_fractional_scale();
+    });
+    let comp = f.compositor();
+    let pointer =
+        TestObject::<WlPointer>::from_request(&comp.seat.obj, wl_seat::Request::GetPointer {});
+    let relative_pointer = TestObject::<ZwpRelativePointerV1>::from_request(
+        &comp.relative_pointer_man.obj,
+        zwp_relative_pointer_manager_v1::Request::GetRelativePointer {
+            pointer: pointer.obj.clone(),
+        },
+    );
+
+    let (_, output_unscaled) = f.new_output(0, 0);
+    let (_, output_scaled) = f.new_output(1000, 0);
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+    let dx_in = 10.0;
+    let dy_in = -6.0;
+
+    f.testwl.move_surface_to_output(id, &output_unscaled);
+    f.testwl.move_pointer_to(id, 25.0, 25.0);
+    f.run();
+    f.run();
+    std::mem::take(&mut *relative_pointer.data.events.lock().unwrap());
+
+    f.testwl.relative_pointer_motion(dx_in, dy_in, dx_in, dy_in);
+    f.run();
+    f.run();
+
+    let mut events = std::mem::take(&mut *relative_pointer.data.events.lock().unwrap());
+    let event = events.pop().expect("No relative pointer event");
+    let Ev::<ZwpRelativePointerV1>::RelativeMotion {
+        dx,
+        dy,
+        dx_unaccel,
+        dy_unaccel,
+        ..
+    } = event
+    else {
+        panic!("Unexpected event: {event:?}");
+    };
+
+    assert_eq!(dx, dx_in);
+    assert_eq!(dy, dy_in);
+    assert_eq!(dx_unaccel, dx_in);
+    assert_eq!(dy_unaccel, dy_in);
+
+    let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
+    let fractional = surface_data
+        .fractional
+        .as_ref()
+        .expect("No fractional scale for surface");
+    fractional.preferred_scale(180); // 1.5 scale
+    f.testwl.move_surface_to_output(id, &output_scaled);
+    f.testwl.move_pointer_to(id, 25.0, 25.0);
+    f.run();
+    f.run();
+
+    f.testwl.relative_pointer_motion(dx_in, dy_in, dx_in, dy_in);
+    f.run();
+    f.run();
+
+    let mut events = std::mem::take(&mut *relative_pointer.data.events.lock().unwrap());
+    let event = events.pop().expect("No relative pointer event");
+    let Ev::<ZwpRelativePointerV1>::RelativeMotion {
+        dx,
+        dy,
+        dx_unaccel,
+        dy_unaccel,
+        ..
+    } = event
+    else {
+        panic!("Unexpected event: {event:?}");
+    };
+
+    assert_eq!(dx, dx_in * 1.5);
+    assert_eq!(dy, dy_in * 1.5);
+    assert_eq!(dx_unaccel, dx_in);
+    assert_eq!(dy_unaccel, dy_in);
 }
 
 #[test]

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -22,7 +22,10 @@ use wayland_protocols::{
             zwp_locked_pointer_v1::{self, ZwpLockedPointerV1},
             zwp_pointer_constraints_v1::{self, ZwpPointerConstraintsV1},
         },
-        relative_pointer::zv1::server::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
+        relative_pointer::zv1::server::{
+            zwp_relative_pointer_manager_v1::{self, ZwpRelativePointerManagerV1},
+            zwp_relative_pointer_v1::{self, ZwpRelativePointerV1},
+        },
         tablet::zv2::server::{
             zwp_tablet_manager_v2::ZwpTabletManagerV2,
             zwp_tablet_pad_group_v2::ZwpTabletPadGroupV2,
@@ -256,6 +259,7 @@ pub struct LockedPointer {
 struct PointerState {
     pointer: WlPointer,
     locked: Option<LockedPointer>,
+    relative_pointers: Vec<ZwpRelativePointerV1>,
 }
 
 struct State {
@@ -480,8 +484,8 @@ impl Server {
         let decorations_global = dh.create_global::<State, ZxdgDecorationManagerV1, _>(1, ());
         dh.create_global::<State, WpViewporter, _>(1, ());
         dh.create_global::<State, ZwpPointerConstraintsV1, _>(1, ());
+        dh.create_global::<State, ZwpRelativePointerManagerV1, _>(1, ());
         global_noop!(ZwpLinuxDmabufV1);
-        global_noop!(ZwpRelativePointerManagerV1);
         global_noop!(WpLinuxDrmSyncobjManagerV1);
 
         struct HandlerData;
@@ -869,6 +873,19 @@ impl Server {
         self.display.flush_clients().unwrap();
     }
 
+    #[track_caller]
+    pub fn relative_pointer_motion(&mut self, dx: f64, dy: f64, dx_unaccel: f64, dy_unaccel: f64) {
+        let pointer = self.state.pointer.as_ref().expect("No pointer created");
+        let time = self.state.begin.elapsed().as_micros() as u64;
+        let utime_hi = (time >> 32) as u32;
+        let utime_lo = time as u32;
+
+        for relative_pointer in &pointer.relative_pointers {
+            relative_pointer.relative_motion(utime_hi, utime_lo, dx, dy, dx_unaccel, dy_unaccel);
+        }
+        self.display.flush_clients().unwrap();
+    }
+
     pub fn get_output(&mut self, name: &str) -> Option<WlOutput> {
         self.state
             .outputs
@@ -1021,6 +1038,7 @@ simple_global_dispatch!(ZxdgDecorationManagerV1);
 simple_global_dispatch!(WpViewporter);
 simple_global_dispatch!(WpFractionalScaleManagerV1);
 simple_global_dispatch!(ZwpPointerConstraintsV1);
+simple_global_dispatch!(ZwpRelativePointerManagerV1);
 
 impl Dispatch<ZwpTabletManagerV2, ()> for State {
     fn request(
@@ -1419,6 +1437,7 @@ impl Dispatch<WlSeat, ()> for State {
                 state.pointer = Some(PointerState {
                     pointer: data_init.init(id, ()),
                     locked: None,
+                    relative_pointers: Vec::new(),
                 });
             }
             wl_seat::Request::GetKeyboard { id } => {
@@ -2471,6 +2490,51 @@ impl Dispatch<ZwpPointerConstraintsV1, ()> for State {
                     surface: surface_id,
                     cursor_hint: None,
                 });
+            }
+            _ => todo!("{request:?}"),
+        }
+    }
+}
+
+impl Dispatch<ZwpRelativePointerManagerV1, ()> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &ZwpRelativePointerManagerV1,
+        request: <ZwpRelativePointerManagerV1 as Resource>::Request,
+        _: &(),
+        _: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            zwp_relative_pointer_manager_v1::Request::GetRelativePointer { id, pointer } => {
+                let pointer_state = state.pointer.as_mut().unwrap();
+                assert_eq!(pointer, pointer_state.pointer);
+                let relative_pointer = data_init.init(id, ());
+                pointer_state.relative_pointers.push(relative_pointer);
+            }
+            _ => todo!("{request:?}"),
+        }
+    }
+}
+
+impl Dispatch<ZwpRelativePointerV1, ()> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        relative_pointer: &ZwpRelativePointerV1,
+        request: <ZwpRelativePointerV1 as Resource>::Request,
+        _: &(),
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            zwp_relative_pointer_v1::Request::Destroy => {
+                if let Some(pointer_state) = state.pointer.as_mut() {
+                    pointer_state
+                        .relative_pointers
+                        .retain(|p| p != relative_pointer);
+                }
             }
             _ => todo!("{request:?}"),
         }


### PR DESCRIPTION
When using a display scale other than 1, relative pointer motion events on Xwayland were not being scaled appropriately, causing mismatched pointer speeds compared to Wayland.

To match pointer speed expectations between wayland and xwayland, scale dx and dy by the surface scale. {dx,dy}_unaccel are left unscaled, matching the behaviour in kwin.

Closes: #409
---
So, the [first iteration](https://github.com/1Naim/xwayland-satellite/commit/828156c3ba45549218fbc8ca5634ff8ce5f9382a) of this was done entirely by AI. Since then, I've dabbled a bit in Rust and refactored/reimplemented it myself. While I can't say I'm proficient at Rust, I'm atleast confident enough to push this and fix any mistakes.