### PR TITLE
Workarounds for issues with HiDPI cursor resolution and theme

### DIFF
--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -167,7 +167,7 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                 }
             }
             Request::<WlSurface>::SetBufferScale { scale } => {
-                client.set_buffer_scale(scale);
+                client.set_buffer_scale(state.last_configured_scale.map_or(scale, |f| f as i32));
             }
             Request::<WlSurface>::SetInputRegion { region } => {
                 let region = region.as_ref().map(|r| r.data().unwrap());

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -65,6 +65,30 @@ use wayland_server::{
     },
 };
 
+struct CursorSurface;
+
+fn cursor_scale<S: X11Selection>(state: &InnerServerState<S>) -> i32 {
+    state.last_configured_scale.map_or(1, |f| f as i32).max(1)
+}
+
+fn prepare_cursor_surface<S: X11Selection>(
+    state: &mut InnerServerState<S>,
+    surface_entity: Option<Entity>,
+) -> i32 {
+    let scale = cursor_scale(state);
+    let Some(surface_entity) = surface_entity else {
+        return scale;
+    };
+    let _ = state.world.insert_one(surface_entity, CursorSurface);
+    let s = state
+        .world
+        .get::<&client::wl_surface::WlSurface>(surface_entity)
+        .unwrap();
+    s.set_buffer_scale(scale);
+    s.commit();
+    scale
+}
+
 // noop
 impl<S: X11Selection> Dispatch<WlCallback, ()> for InnerServerState<S> {
     fn request(
@@ -167,7 +191,11 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                 }
             }
             Request::<WlSurface>::SetBufferScale { scale } => {
-                client.set_buffer_scale(state.last_configured_scale.map_or(scale, |f| f as i32));
+                let scale = data
+                    .has::<CursorSurface>()
+                    .then(|| cursor_scale(state))
+                    .unwrap_or(scale);
+                client.set_buffer_scale(scale);
             }
             Request::<WlSurface>::SetInputRegion { region } => {
                 let region = region.as_ref().map(|r| r.data().unwrap());
@@ -358,20 +386,19 @@ impl<S: X11Selection> Dispatch<WlPointer, Entity> for InnerServerState<S> {
                 hotspot_y,
                 surface,
             } => {
+                let surf_key: Option<Entity> = surface.map(|s| s.data().copied().unwrap());
+                let scale = prepare_cursor_surface(state, surf_key);
                 let c_pointer = state
                     .world
                     .get::<&client::wl_pointer::WlPointer>(*entity)
                     .unwrap();
-
-                let c_surface = surface.and_then(|s| {
-                    let e = s.data().copied()?;
-                    Some(
-                        state
-                            .world
-                            .get::<&client::wl_surface::WlSurface>(e)
-                            .unwrap(),
-                    )
+                let c_surface = surf_key.map(|e| {
+                    state
+                        .world
+                        .get::<&client::wl_surface::WlSurface>(e)
+                        .unwrap()
                 });
+                let (hotspot_x, hotspot_y) = (hotspot_x / scale, hotspot_y / scale);
                 c_pointer.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             Request::<WlPointer>::Release => {
@@ -1148,12 +1175,19 @@ impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, En
                 hotspot_y,
             } => {
                 let surf_key: Option<Entity> = surface.map(|s| s.data().copied().unwrap());
+                drop(client);
+                let scale = prepare_cursor_surface(state, surf_key);
+                let client = state
+                    .world
+                    .get::<&c_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2>(*entity)
+                    .unwrap();
                 let c_surface = surf_key.map(|key| {
                     state
                         .world
                         .get::<&client::wl_surface::WlSurface>(key)
                         .unwrap()
                 });
+                let (hotspot_x, hotspot_y) = (hotspot_x / scale, hotspot_y / scale);
                 client.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             s_tablet::zwp_tablet_tool_v2::Request::Destroy => {

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -65,6 +65,30 @@ use wayland_server::{
     },
 };
 
+struct CursorSurface;
+
+fn cursor_scale<S: X11Selection>(state: &InnerServerState<S>) -> i32 {
+    state.current_scale.max(1.0) as i32
+}
+
+fn prepare_cursor_surface<S: X11Selection>(
+    state: &mut InnerServerState<S>,
+    surface_entity: Option<Entity>,
+) -> i32 {
+    let scale = cursor_scale(state);
+    let Some(surface_entity) = surface_entity else {
+        return scale;
+    };
+    let _ = state.world.insert_one(surface_entity, CursorSurface);
+    let s = state
+        .world
+        .get::<&client::wl_surface::WlSurface>(surface_entity)
+        .unwrap();
+    s.set_buffer_scale(scale);
+    s.commit();
+    scale
+}
+
 // noop
 impl<S: X11Selection> Dispatch<WlCallback, ()> for InnerServerState<S> {
     fn request(
@@ -167,7 +191,11 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                 }
             }
             Request::<WlSurface>::SetBufferScale { scale } => {
-                client.set_buffer_scale(state.current_scale as i32);
+                let scale = data
+                    .has::<CursorSurface>()
+                    .then(|| cursor_scale(state))
+                    .unwrap_or(scale);
+                client.set_buffer_scale(scale);
             }
             Request::<WlSurface>::SetInputRegion { region } => {
                 let region = region.as_ref().map(|r| r.data().unwrap());
@@ -358,20 +386,19 @@ impl<S: X11Selection> Dispatch<WlPointer, Entity> for InnerServerState<S> {
                 hotspot_y,
                 surface,
             } => {
+                let surf_key: Option<Entity> = surface.map(|s| s.data().copied().unwrap());
+                let scale = prepare_cursor_surface(state, surf_key);
                 let c_pointer = state
                     .world
                     .get::<&client::wl_pointer::WlPointer>(*entity)
                     .unwrap();
-
-                let c_surface = surface.and_then(|s| {
-                    let e = s.data().copied()?;
-                    Some(
-                        state
-                            .world
-                            .get::<&client::wl_surface::WlSurface>(e)
-                            .unwrap(),
-                    )
+                let c_surface = surf_key.map(|e| {
+                    state
+                        .world
+                        .get::<&client::wl_surface::WlSurface>(e)
+                        .unwrap()
                 });
+                let (hotspot_x, hotspot_y) = (hotspot_x / scale, hotspot_y / scale);
                 c_pointer.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             Request::<WlPointer>::Release => {
@@ -1148,12 +1175,19 @@ impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, En
                 hotspot_y,
             } => {
                 let surf_key: Option<Entity> = surface.map(|s| s.data().copied().unwrap());
+                drop(client);
+                let scale = prepare_cursor_surface(state, surf_key);
+                let client = state
+                    .world
+                    .get::<&c_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2>(*entity)
+                    .unwrap();
                 let c_surface = surf_key.map(|key| {
                     state
                         .world
                         .get::<&client::wl_surface::WlSurface>(key)
                         .unwrap()
                 });
+                let (hotspot_x, hotspot_y) = (hotspot_x / scale, hotspot_y / scale);
                 client.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             s_tablet::zwp_tablet_tool_v2::Request::Destroy => {

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -167,7 +167,7 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                 }
             }
             Request::<WlSurface>::SetBufferScale { scale } => {
-                client.set_buffer_scale(scale);
+                client.set_buffer_scale(state.current_scale as i32);
             }
             Request::<WlSurface>::SetInputRegion { region } => {
                 let region = region.as_ref().map(|r| r.data().unwrap());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -485,6 +485,7 @@ pub struct InnerServerState<S: X11Selection> {
     global_offset_updated: bool,
     updated_outputs: Vec<Entity>,
     new_scale: Option<f64>,
+    last_configured_scale: Option<f64>,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -593,6 +594,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
+            last_configured_scale: None,
             decoration_manager,
             world,
         };
@@ -731,6 +733,7 @@ impl<C: XConnection> ServerState<C> {
 
                 debug!("Using new scale {scale}");
                 self.new_scale = Some(scale);
+                self.last_configured_scale = Some(scale);
             }
         }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3043,6 +3043,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // Multiple monitors with different scaling will select the lowest scale across monitors
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+    assert_eq!(f.satellite.inner.last_configured_scale, Some(1.5));
 
     f.remove_output(output_ext);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3055,6 +3056,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // An fractional scale change done while the surface is on a removed output is ignored
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+    assert_eq!(f.satellite.inner.last_configured_scale, Some(1.5));
 
     f.testwl.move_surface_to_output(id, &output_main);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3067,6 +3069,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // After the output is disconnected, only the 2x scale output remains, so use that scale
     assert_eq!(f.satellite.inner.new_scale, Some(2.0));
+    assert_eq!(f.satellite.inner.last_configured_scale, Some(2.0));
 }
 
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3047,6 +3047,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // Multiple monitors with different scaling will select the lowest scale across monitors
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+    assert_eq!(f.satellite.inner.current_scale, 1.5);
 
     f.remove_output(output_ext);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3059,6 +3060,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // An fractional scale change done while the surface is on a removed output is ignored
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+    assert_eq!(f.satellite.inner.current_scale, 1.5);
 
     f.testwl.move_surface_to_output(id, &output_main);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3071,6 +3073,7 @@ fn disconnected_output_rescaling() {
     f.run();
     // After the output is disconnected, only the 2x scale output remains, so use that scale
     assert_eq!(f.satellite.inner.new_scale, Some(2.0));
+    assert_eq!(f.satellite.inner.current_scale, 2.0);
 }
 
 #[test]

--- a/src/xstate/settings.rs
+++ b/src/xstate/settings.rs
@@ -46,11 +46,13 @@ const DEFAULT_DPI: i32 = 96;
 /// I don't know why, but the DPI related xsettings seem to
 /// divide the DPI by 1024.
 const DPI_SCALE_FACTOR: i32 = 1024;
+const DEFAULT_CURSOR_SIZE: i32 = 24;
 const DEFAULT_CURSOR_THEME: &str = "default";
 
 const XFT_DPI: &str = "Xft/DPI";
 const GDK_WINDOW_SCALE: &str = "Gdk/WindowScalingFactor";
 const GDK_UNSCALED_DPI: &str = "Gdk/UnscaledDPI";
+const GTK_CURSOR_THEME_SIZE: &str = "Gtk/CursorThemeSize";
 const GTK_CURSOR_THEME_NAME: &str = "Gtk/CursorThemeName";
 
 pub(super) struct Settings {
@@ -121,6 +123,13 @@ impl Settings {
                     GDK_UNSCALED_DPI,
                     IntSetting {
                         value: DEFAULT_DPI * DPI_SCALE_FACTOR,
+                        last_change_serial: 0,
+                    },
+                ),
+                (
+                    GTK_CURSOR_THEME_SIZE,
+                    IntSetting {
+                        value: DEFAULT_CURSOR_SIZE,
                         last_change_serial: 0,
                     },
                 ),
@@ -228,6 +237,12 @@ impl Settings {
             .entry(GDK_WINDOW_SCALE)
             .insert_entry(IntSetting {
                 value: scale as i32,
+                last_change_serial: self.serial,
+            });
+        self.int_settings
+            .entry(GTK_CURSOR_THEME_SIZE)
+            .insert_entry(IntSetting {
+                value: (DEFAULT_CURSOR_SIZE as f64 * scale) as i32,
                 last_change_serial: self.serial,
             });
     }

--- a/src/xstate/settings.rs
+++ b/src/xstate/settings.rs
@@ -46,15 +46,18 @@ const DEFAULT_DPI: i32 = 96;
 /// I don't know why, but the DPI related xsettings seem to
 /// divide the DPI by 1024.
 const DPI_SCALE_FACTOR: i32 = 1024;
+const DEFAULT_CURSOR_THEME: &str = "default";
 
 const XFT_DPI: &str = "Xft/DPI";
 const GDK_WINDOW_SCALE: &str = "Gdk/WindowScalingFactor";
 const GDK_UNSCALED_DPI: &str = "Gdk/UnscaledDPI";
+const GTK_CURSOR_THEME_NAME: &str = "Gtk/CursorThemeName";
 
 pub(super) struct Settings {
     window: x::Window,
     serial: u32,
-    settings: HashMap<&'static str, IntSetting>,
+    int_settings: HashMap<&'static str, IntSetting>,
+    string_settings: HashMap<&'static str, StringSetting>,
 }
 
 #[derive(Copy, Clone)]
@@ -63,12 +66,22 @@ struct IntSetting {
     last_change_serial: u32,
 }
 
+#[derive(Clone)]
+struct StringSetting {
+    value: String,
+    last_change_serial: u32,
+}
+
 mod setting_type {
     pub const INTEGER: u8 = 0;
+    pub const STRING: u8 = 1;
 }
 
 impl Settings {
     pub(super) fn new(connection: &xcb::Connection, atoms: &super::Atoms, root: x::Window) -> Self {
+        // Is this a good place for reading this env var?
+        let cursor_theme =
+            std::env::var("XCURSOR_THEME").unwrap_or_else(|_| DEFAULT_CURSOR_THEME.to_string());
         let window = connection.generate_id();
         connection
             .send_and_check_request(&x::CreateWindow {
@@ -89,7 +102,7 @@ impl Settings {
         let s = Settings {
             window,
             serial: 0,
-            settings: HashMap::from([
+            int_settings: HashMap::from([
                 (
                     XFT_DPI,
                     IntSetting {
@@ -112,6 +125,13 @@ impl Settings {
                     },
                 ),
             ]),
+            string_settings: HashMap::from([(
+                GTK_CURSOR_THEME_NAME,
+                StringSetting {
+                    value: cursor_theme,
+                    last_change_serial: 0,
+                },
+            )]),
         };
 
         connection
@@ -141,7 +161,8 @@ impl Settings {
         ];
 
         data.extend_from_slice(&self.serial.to_le_bytes());
-        data.extend_from_slice(&(self.settings.len() as u32).to_le_bytes());
+        let num_settings = (self.int_settings.len() + self.string_settings.len()) as u32;
+        data.extend_from_slice(&num_settings.to_le_bytes());
 
         fn insert_with_padding(data: &[u8], out: &mut Vec<u8>) {
             out.extend_from_slice(data);
@@ -150,12 +171,35 @@ impl Settings {
             out.extend(std::iter::repeat_n(0, num_padding_bytes));
         }
 
-        for (name, setting) in &self.settings {
-            data.extend_from_slice(&[setting_type::INTEGER, 0]);
-            data.extend_from_slice(&(name.len() as u16).to_le_bytes());
-            insert_with_padding(name.as_bytes(), &mut data);
-            data.extend_from_slice(&setting.last_change_serial.to_le_bytes());
-            data.extend_from_slice(&setting.value.to_le_bytes());
+        fn insert_setting_header(
+            name: &str,
+            setting_type: u8,
+            last_change_serial: u32,
+            out: &mut Vec<u8>,
+        ) {
+            out.extend_from_slice(&[setting_type, 0]);
+            out.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            insert_with_padding(name.as_bytes(), out);
+            out.extend_from_slice(&last_change_serial.to_le_bytes());
+        }
+
+        fn insert_integer_setting(name: &str, setting: &IntSetting, out: &mut Vec<u8>) {
+            insert_setting_header(name, setting_type::INTEGER, setting.last_change_serial, out);
+            out.extend_from_slice(&setting.value.to_le_bytes());
+        }
+
+        fn insert_string_setting(name: &str, setting: &StringSetting, out: &mut Vec<u8>) {
+            insert_setting_header(name, setting_type::STRING, setting.last_change_serial, out);
+            out.extend_from_slice(&(setting.value.len() as u32).to_le_bytes());
+            insert_with_padding(setting.value.as_bytes(), out);
+        }
+
+        for (name, setting) in &self.int_settings {
+            insert_integer_setting(name, setting, &mut data);
+        }
+
+        for (name, setting) in &self.string_settings {
+            insert_string_setting(name, setting, &mut data);
         }
 
         data
@@ -165,20 +209,22 @@ impl Settings {
         self.serial += 1;
 
         let scale = scale.max(1.0);
+        let scaled_dpi = (scale * DEFAULT_DPI as f64 * DPI_SCALE_FACTOR as f64).round() as i32;
         let setting = IntSetting {
-            value: (scale * DEFAULT_DPI as f64 * DPI_SCALE_FACTOR as f64).round() as i32,
+            value: scaled_dpi,
             last_change_serial: self.serial,
         };
-        self.settings.entry(XFT_DPI).insert_entry(setting);
+
+        self.int_settings.entry(XFT_DPI).insert_entry(setting);
         // Gdk/WindowScalingFactor + Gdk/UnscaledDPI is identical to setting
         // GDK_SCALE = scale and then GDK_DPI_SCALE = 1 / scale.
-        self.settings
+        self.int_settings
             .entry(GDK_UNSCALED_DPI)
             .insert_entry(IntSetting {
-                value: setting.value / scale as i32,
+                value: scaled_dpi / scale as i32,
                 last_change_serial: self.serial,
             });
-        self.settings
+        self.int_settings
             .entry(GDK_WINDOW_SCALE)
             .insert_entry(IntSetting {
                 value: scale as i32,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -358,11 +358,42 @@ xcb::atoms_struct! {
 
 struct Settings {
     serial: u32,
-    data: HashMap<String, Setting>,
+    int_settings: HashMap<String, IntSetting>,
+    string_settings: HashMap<String, StringSetting>,
 }
-struct Setting {
+
+struct IntSetting {
     value: i32,
     last_change: u32,
+}
+
+struct StringSetting {
+    value: String,
+    last_change: u32,
+}
+
+struct EnvVarGuard {
+    name: String,
+    old_value: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: impl Into<String>, value: &str) -> Self {
+        let name = name.into();
+        let old_value = std::env::var(&name).ok();
+        unsafe { std::env::set_var(&name, value) };
+        Self { name, old_value }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(old_value) = self.old_value.take() {
+            unsafe { std::env::set_var(&self.name, old_value) };
+        } else {
+            unsafe { std::env::remove_var(&self.name) };
+        }
+    }
 }
 
 struct Connection {
@@ -648,9 +679,11 @@ impl Connection {
         let num_settings = u32::from_le_bytes(data[8..12].try_into().unwrap());
 
         let mut current_idx = 12;
-        let mut settings = HashMap::new();
+        let mut int_settings = HashMap::new();
+        let mut string_settings = HashMap::new();
         for _ in 0..num_settings {
-            assert_eq!(&data[current_idx..current_idx + 2], &[0, 0]);
+            let setting_type = data[current_idx];
+            assert_eq!(data[current_idx + 1], 0);
             let name_len =
                 u16::from_le_bytes(data[current_idx + 2..current_idx + 4].try_into().unwrap());
 
@@ -660,16 +693,30 @@ impl Connection {
             let data_start = padding_start + num_padding_bytes;
             let last_change =
                 u32::from_le_bytes(data[data_start..data_start + 4].try_into().unwrap());
-            let value =
-                i32::from_le_bytes(data[data_start + 4..data_start + 8].try_into().unwrap());
-
-            settings.insert(name, Setting { value, last_change });
-            current_idx = data_start + 8;
+            let value_or_len =
+                u32::from_le_bytes(data[data_start + 4..data_start + 8].try_into().unwrap());
+            current_idx = match setting_type {
+                0 => {
+                    let value = value_or_len as i32;
+                    int_settings.insert(name, IntSetting { value, last_change });
+                    data_start + 8
+                }
+                1 => {
+                    let start = data_start + 8;
+                    let end = start + value_or_len as usize;
+                    let value = String::from_utf8(data[start..end].to_vec()).unwrap();
+                    string_settings.insert(name, StringSetting { value, last_change });
+                    let padding = (4 - (value_or_len % 4)) % 4;
+                    end + padding as usize
+                }
+                other => panic!("Unexpected setting type: {other}"),
+            };
         }
 
         Settings {
             serial,
-            data: settings,
+            int_settings,
+            string_settings,
         }
     }
 }
@@ -2058,12 +2105,12 @@ fn xsettings_scale() {
 
     let settings = connection.get_xsettings();
     let settings_serial = settings.serial;
-    assert_eq!(settings.data["Xft/DPI"].value, 96 * 1024);
-    let dpi_serial = settings.data["Xft/DPI"].last_change;
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
-    let window_serial = settings.data["Gdk/WindowScalingFactor"].last_change;
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
-    let unscaled_serial = settings.data["Gdk/UnscaledDPI"].last_change;
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
+    let dpi_serial = settings.int_settings["Xft/DPI"].last_change;
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
+    let window_serial = settings.int_settings["Gdk/WindowScalingFactor"].last_change;
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    let unscaled_serial = settings.int_settings["Gdk/UnscaledDPI"].last_change;
 
     let output = f.testwl.get_output("WL-1").unwrap();
     output.scale(2);
@@ -2072,18 +2119,18 @@ fn xsettings_scale() {
 
     let settings = connection.get_xsettings();
     assert!(settings.serial > settings_serial);
-    assert_eq!(settings.data["Xft/DPI"].value, 2 * 96 * 1024);
-    assert!(settings.data["Xft/DPI"].last_change > dpi_serial);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
-    assert!(settings.data["Gdk/WindowScalingFactor"].last_change > window_serial);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
-    assert!(settings.data["Gdk/UnscaledDPI"].last_change > unscaled_serial);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
+    assert!(settings.int_settings["Xft/DPI"].last_change > dpi_serial);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
+    assert!(settings.int_settings["Gdk/WindowScalingFactor"].last_change > window_serial);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert!(settings.int_settings["Gdk/UnscaledDPI"].last_change > unscaled_serial);
 
     let output2 = f.create_output(0, 0);
     let settings = connection.get_xsettings();
-    assert_eq!(settings.data["Xft/DPI"].value, 96 * 1024);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
 
     output2.scale(2);
     output2.done();
@@ -2091,9 +2138,9 @@ fn xsettings_scale() {
     std::thread::sleep(Duration::from_millis(1));
 
     let settings = connection.get_xsettings();
-    assert_eq!(settings.data["Xft/DPI"].value, 2 * 96 * 1024);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
 }
 
 #[test]
@@ -2124,12 +2171,12 @@ fn xsettings_fractional_scale() {
     let settings = connection.get_xsettings();
 
     assert_eq!(
-        settings.data["Xft/DPI"].value,
+        settings.int_settings["Xft/DPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
     assert_eq!(
-        settings.data["Gdk/UnscaledDPI"].value,
+        settings.int_settings["Gdk/UnscaledDPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
 
@@ -2140,13 +2187,32 @@ fn xsettings_fractional_scale() {
 
     let settings = connection.get_xsettings();
     assert_eq!(
-        settings.data["Xft/DPI"].value,
+        settings.int_settings["Xft/DPI"].value,
         (2.5 * 96_f64 * 1024_f64).round() as i32
     );
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
     assert_eq!(
-        settings.data["Gdk/UnscaledDPI"].value,
+        settings.int_settings["Gdk/UnscaledDPI"].value,
         (2.5 / 2.0 * 96_f64 * 1024_f64).round() as i32
+    );
+}
+
+#[test]
+fn xsettings_cursor_theme_from_env() {
+    let _guard = EnvVarGuard::set("XCURSOR_THEME", "Adwaita");
+    let f = Fixture::new_preset(|testwl| {
+        testwl.new_output();
+    });
+    let connection = Connection::new(&f.display);
+
+    let settings = connection.get_xsettings();
+    assert_eq!(
+        settings.string_settings["Gtk/CursorThemeName"].value,
+        "Adwaita"
+    );
+    assert_eq!(
+        settings.string_settings["Gtk/CursorThemeName"].last_change,
+        0
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2111,6 +2111,8 @@ fn xsettings_scale() {
     let window_serial = settings.int_settings["Gdk/WindowScalingFactor"].last_change;
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
     let unscaled_serial = settings.int_settings["Gdk/UnscaledDPI"].last_change;
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 24);
+    let cursor_serial = settings.int_settings["Gtk/CursorThemeSize"].last_change;
 
     let output = f.testwl.get_output("WL-1").unwrap();
     output.scale(2);
@@ -2125,12 +2127,15 @@ fn xsettings_scale() {
     assert!(settings.int_settings["Gdk/WindowScalingFactor"].last_change > window_serial);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
     assert!(settings.int_settings["Gdk/UnscaledDPI"].last_change > unscaled_serial);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 2 * 24);
+    assert!(settings.int_settings["Gtk/CursorThemeSize"].last_change > cursor_serial);
 
     let output2 = f.create_output(0, 0);
     let settings = connection.get_xsettings();
     assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
     assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 24);
 
     output2.scale(2);
     output2.done();
@@ -2141,6 +2146,7 @@ fn xsettings_scale() {
     assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
     assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 2 * 24);
 }
 
 #[test]
@@ -2179,6 +2185,10 @@ fn xsettings_fractional_scale() {
         settings.int_settings["Gdk/UnscaledDPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
+    assert_eq!(
+        settings.int_settings["Gtk/CursorThemeSize"].value,
+        (1.5 * 24_f64).round() as i32
+    );
 
     let data = f.testwl.get_surface_data(surface).unwrap();
     let fractional = data.fractional.as_ref().unwrap();
@@ -2194,6 +2204,10 @@ fn xsettings_fractional_scale() {
     assert_eq!(
         settings.int_settings["Gdk/UnscaledDPI"].value,
         (2.5 / 2.0 * 96_f64 * 1024_f64).round() as i32
+    );
+    assert_eq!(
+        settings.int_settings["Gtk/CursorThemeSize"].value,
+        (2.5 * 24_f64).round() as i32
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2140,6 +2140,8 @@ fn xsettings_scale() {
     let window_serial = settings.int_settings["Gdk/WindowScalingFactor"].last_change;
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
     let unscaled_serial = settings.int_settings["Gdk/UnscaledDPI"].last_change;
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 24);
+    let cursor_serial = settings.int_settings["Gtk/CursorThemeSize"].last_change;
 
     let output = f.testwl.get_output("WL-1").unwrap();
     output.scale(2);
@@ -2154,12 +2156,15 @@ fn xsettings_scale() {
     assert!(settings.int_settings["Gdk/WindowScalingFactor"].last_change > window_serial);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
     assert!(settings.int_settings["Gdk/UnscaledDPI"].last_change > unscaled_serial);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 2 * 24);
+    assert!(settings.int_settings["Gtk/CursorThemeSize"].last_change > cursor_serial);
 
     let output2 = f.create_output(0, 0);
     let settings = connection.get_xsettings();
     assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
     assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 24);
 
     output2.scale(2);
     output2.done();
@@ -2170,6 +2175,7 @@ fn xsettings_scale() {
     assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
     assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
     assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gtk/CursorThemeSize"].value, 2 * 24);
 }
 
 #[test]
@@ -2208,6 +2214,10 @@ fn xsettings_fractional_scale() {
         settings.int_settings["Gdk/UnscaledDPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
+    assert_eq!(
+        settings.int_settings["Gtk/CursorThemeSize"].value,
+        (1.5 * 24_f64).round() as i32
+    );
 
     let data = f.testwl.get_surface_data(surface).unwrap();
     let fractional = data.fractional.as_ref().unwrap();
@@ -2223,6 +2233,10 @@ fn xsettings_fractional_scale() {
     assert_eq!(
         settings.int_settings["Gdk/UnscaledDPI"].value,
         (2.5 / 2.0 * 96_f64 * 1024_f64).round() as i32
+    );
+    assert_eq!(
+        settings.int_settings["Gtk/CursorThemeSize"].value,
+        (2.5 * 24_f64).round() as i32
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -387,11 +387,42 @@ xcb::atoms_struct! {
 
 struct Settings {
     serial: u32,
-    data: HashMap<String, Setting>,
+    int_settings: HashMap<String, IntSetting>,
+    string_settings: HashMap<String, StringSetting>,
 }
-struct Setting {
+
+struct IntSetting {
     value: i32,
     last_change: u32,
+}
+
+struct StringSetting {
+    value: String,
+    last_change: u32,
+}
+
+struct EnvVarGuard {
+    name: String,
+    old_value: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: impl Into<String>, value: &str) -> Self {
+        let name = name.into();
+        let old_value = std::env::var(&name).ok();
+        unsafe { std::env::set_var(&name, value) };
+        Self { name, old_value }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(old_value) = self.old_value.take() {
+            unsafe { std::env::set_var(&self.name, old_value) };
+        } else {
+            unsafe { std::env::remove_var(&self.name) };
+        }
+    }
 }
 
 struct Connection {
@@ -677,9 +708,11 @@ impl Connection {
         let num_settings = u32::from_le_bytes(data[8..12].try_into().unwrap());
 
         let mut current_idx = 12;
-        let mut settings = HashMap::new();
+        let mut int_settings = HashMap::new();
+        let mut string_settings = HashMap::new();
         for _ in 0..num_settings {
-            assert_eq!(&data[current_idx..current_idx + 2], &[0, 0]);
+            let setting_type = data[current_idx];
+            assert_eq!(data[current_idx + 1], 0);
             let name_len =
                 u16::from_le_bytes(data[current_idx + 2..current_idx + 4].try_into().unwrap());
 
@@ -689,16 +722,30 @@ impl Connection {
             let data_start = padding_start + num_padding_bytes;
             let last_change =
                 u32::from_le_bytes(data[data_start..data_start + 4].try_into().unwrap());
-            let value =
-                i32::from_le_bytes(data[data_start + 4..data_start + 8].try_into().unwrap());
-
-            settings.insert(name, Setting { value, last_change });
-            current_idx = data_start + 8;
+            let value_or_len =
+                u32::from_le_bytes(data[data_start + 4..data_start + 8].try_into().unwrap());
+            current_idx = match setting_type {
+                0 => {
+                    let value = value_or_len as i32;
+                    int_settings.insert(name, IntSetting { value, last_change });
+                    data_start + 8
+                }
+                1 => {
+                    let start = data_start + 8;
+                    let end = start + value_or_len as usize;
+                    let value = String::from_utf8(data[start..end].to_vec()).unwrap();
+                    string_settings.insert(name, StringSetting { value, last_change });
+                    let padding = (4 - (value_or_len % 4)) % 4;
+                    end + padding as usize
+                }
+                other => panic!("Unexpected setting type: {other}"),
+            };
         }
 
         Settings {
             serial,
-            data: settings,
+            int_settings,
+            string_settings,
         }
     }
 }
@@ -2087,12 +2134,12 @@ fn xsettings_scale() {
 
     let settings = connection.get_xsettings();
     let settings_serial = settings.serial;
-    assert_eq!(settings.data["Xft/DPI"].value, 96 * 1024);
-    let dpi_serial = settings.data["Xft/DPI"].last_change;
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
-    let window_serial = settings.data["Gdk/WindowScalingFactor"].last_change;
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
-    let unscaled_serial = settings.data["Gdk/UnscaledDPI"].last_change;
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
+    let dpi_serial = settings.int_settings["Xft/DPI"].last_change;
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
+    let window_serial = settings.int_settings["Gdk/WindowScalingFactor"].last_change;
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    let unscaled_serial = settings.int_settings["Gdk/UnscaledDPI"].last_change;
 
     let output = f.testwl.get_output("WL-1").unwrap();
     output.scale(2);
@@ -2101,18 +2148,18 @@ fn xsettings_scale() {
 
     let settings = connection.get_xsettings();
     assert!(settings.serial > settings_serial);
-    assert_eq!(settings.data["Xft/DPI"].value, 2 * 96 * 1024);
-    assert!(settings.data["Xft/DPI"].last_change > dpi_serial);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
-    assert!(settings.data["Gdk/WindowScalingFactor"].last_change > window_serial);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
-    assert!(settings.data["Gdk/UnscaledDPI"].last_change > unscaled_serial);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
+    assert!(settings.int_settings["Xft/DPI"].last_change > dpi_serial);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
+    assert!(settings.int_settings["Gdk/WindowScalingFactor"].last_change > window_serial);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert!(settings.int_settings["Gdk/UnscaledDPI"].last_change > unscaled_serial);
 
     let output2 = f.create_output(0, 0);
     let settings = connection.get_xsettings();
-    assert_eq!(settings.data["Xft/DPI"].value, 96 * 1024);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
 
     output2.scale(2);
     output2.done();
@@ -2120,9 +2167,9 @@ fn xsettings_scale() {
     std::thread::sleep(Duration::from_millis(1));
 
     let settings = connection.get_xsettings();
-    assert_eq!(settings.data["Xft/DPI"].value, 2 * 96 * 1024);
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
-    assert_eq!(settings.data["Gdk/UnscaledDPI"].value, 96 * 1024);
+    assert_eq!(settings.int_settings["Xft/DPI"].value, 2 * 96 * 1024);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
+    assert_eq!(settings.int_settings["Gdk/UnscaledDPI"].value, 96 * 1024);
 }
 
 #[test]
@@ -2153,12 +2200,12 @@ fn xsettings_fractional_scale() {
     let settings = connection.get_xsettings();
 
     assert_eq!(
-        settings.data["Xft/DPI"].value,
+        settings.int_settings["Xft/DPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 1);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 1);
     assert_eq!(
-        settings.data["Gdk/UnscaledDPI"].value,
+        settings.int_settings["Gdk/UnscaledDPI"].value,
         (1.5 * 96_f64 * 1024_f64).round() as i32
     );
 
@@ -2169,13 +2216,32 @@ fn xsettings_fractional_scale() {
 
     let settings = connection.get_xsettings();
     assert_eq!(
-        settings.data["Xft/DPI"].value,
+        settings.int_settings["Xft/DPI"].value,
         (2.5 * 96_f64 * 1024_f64).round() as i32
     );
-    assert_eq!(settings.data["Gdk/WindowScalingFactor"].value, 2);
+    assert_eq!(settings.int_settings["Gdk/WindowScalingFactor"].value, 2);
     assert_eq!(
-        settings.data["Gdk/UnscaledDPI"].value,
+        settings.int_settings["Gdk/UnscaledDPI"].value,
         (2.5 / 2.0 * 96_f64 * 1024_f64).round() as i32
+    );
+}
+
+#[test]
+fn xsettings_cursor_theme_from_env() {
+    let _guard = EnvVarGuard::set("XCURSOR_THEME", "Adwaita");
+    let f = Fixture::new_preset(|testwl| {
+        testwl.new_output();
+    });
+    let connection = Connection::new(&f.display);
+
+    let settings = connection.get_xsettings();
+    assert_eq!(
+        settings.string_settings["Gtk/CursorThemeName"].value,
+        "Adwaita"
+    );
+    assert_eq!(
+        settings.string_settings["Gtk/CursorThemeName"].last_change,
+        0
     );
 }
 


### PR DESCRIPTION
Just basic drafts with rough workaround for two issues - #421 and #194.
I checked them with Steam and Proton in Niri in CachyOS.

## Update cursor texture #421
Set the cursor texture/theme in Xwayland from `XCURSOR_THEME` environment variable in `settings.rs`; it's value is set to `Gtk/CursorThemeSize` xsetting. Since it's done based on environment variable, changing it requires restarting entire xwayland-satellite.

## HiDPI cursor scaling #194
**This workaround only works for integer scaling.**

The issue seems to be caused by lower resolution cursor texture scaled up, so this workaround scales the cursor size *down* through `set_buffer_scale`. Now the cursor size actually matches the used texture resolution. To get the cursor to correct size you need to set `XCURSOR_SIZE` environment variable to double of your actual cursor size.

The cursor "hotspot" is also scaled, so the new *scaled* cursor actually points in the correct place.

The `Gtk/CursorThemeSize` xsetting value is also set to match scaled cursor size, but it's mostly for completion's sake; this doesn't actually seem to do anything in Steam/Proton.

---

I'm not sure if this is a "proper" solution for either issue, but perhaps it will be useful as a workaround.