### PR TITLE
fix: remove WM_HINTS popup heuristic

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -635,7 +635,6 @@ impl XState {
         let class = self.get_wm_class(window);
         let size_hints = self.get_wm_size_hints(window);
         let motif_wm_hints = self.get_motif_wm_hints(window);
-        let wm_hints = self.get_wm_hints(window);
         let mut title = name.resolve()?;
         if title.is_none() {
             title = self.get_wm_name(window).resolve()?;
@@ -650,7 +649,6 @@ impl XState {
         if let Some(hints) = size_hints.resolve()? {
             server_state.set_size_hints(window, hints);
         }
-        let wmhints = wm_hints.resolve()?;
         let motif_hints = motif_wm_hints.resolve()?;
         if let Some(decorations) = motif_hints.as_ref().and_then(|m| m.decorations) {
             server_state.set_win_decorations(window, decorations);
@@ -667,8 +665,7 @@ impl XState {
             .resolve()?
             .flatten();
 
-        let is_popup =
-            self.guess_is_popup(window, motif_hints, wmhints, transient_for.is_some())?;
+        let is_popup = self.guess_is_popup(window, motif_hints, transient_for.is_some())?;
         server_state.set_popup(window, is_popup);
         if let Some(parent) = transient_for.and_then(|t| (!is_popup).then_some(t)) {
             server_state.set_transient_for(window, parent);
@@ -696,11 +693,9 @@ impl XState {
         &self,
         window: x::Window,
         motif_hints: Option<motif::Hints>,
-        wm_hints: Option<WmHints>,
         has_transient_for: bool,
     ) -> XResult<bool> {
         let mut motif_popup = false;
-        let mut wmhint_popup = false;
         let mut has_skip_taskbar = None;
 
         let attrs = self
@@ -722,22 +717,7 @@ impl XState {
             has_skip_taskbar = Some(states.contains(&self.atoms.skip_taskbar));
         }
         if let Some(hints) = motif_hints {
-            // If MOTIF_WM_HINTS provides no decorations for client assume its a popup
             motif_popup = hints.decorations.is_some_and(|d| d.is_clientside());
-            // WMHINTS is considered popup only if client is not decorated && client does not
-            // accept input focus
-            // Sometimes popup is false-positive meaning both MOTIF Decorations and WM_HINTS input indicates its a popup
-            // but MOTIF has function flags that toplevel window should do
-            wmhint_popup = motif_popup
-                && wm_hints.is_some_and(|h| !h.acquire_input_via_wm)
-                && !hints.functions.as_ref().is_some_and(|f| {
-                    f.intersects(
-                        motif::Functions::Minimize
-                            | motif::Functions::Maximize
-                            | motif::Functions::Resize
-                            | motif::Functions::All,
-                    )
-                });
             // If the motif hints indicate the user shouldn't be able to do anything
             // to the window at all, it stands to reason it's probably a popup.
             if hints.functions.is_some_and(|f| f.is_empty()) {
@@ -770,7 +750,7 @@ impl XState {
         let mut known_window_type = false;
         for ty in window_types {
             match ty {
-                x if x == self.window_atoms.normal => is_popup = override_redirect || wmhint_popup,
+                x if x == self.window_atoms.normal => is_popup = override_redirect,
                 x if x == self.window_atoms.dialog => is_popup = override_redirect,
                 x if x == self.window_atoms.utility => is_popup = override_redirect || motif_popup,
                 x if [

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2130,7 +2130,7 @@ fn popup_heuristics() {
         connection.atoms.net_wm_state,
         &[connection.atoms.skip_taskbar],
     );
-    f.map_as_popup(&mut connection, yabridge_popup);
+    f.map_as_toplevel(&mut connection, yabridge_popup);
 
     let steam = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(
@@ -2173,6 +2173,27 @@ fn popup_heuristics() {
         &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
     );
     f.map_as_toplevel(&mut connection, battle_net);
+
+    let steam_game = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    connection.set_property(
+        steam_game,
+        x::ATOM_ATOM,
+        connection.atoms.win_type,
+        &[connection.atoms.win_type_normal],
+    );
+    connection.set_property(
+        steam_game,
+        connection.atoms.motif_wm_hints,
+        connection.atoms.motif_wm_hints,
+        &[0x3_u32, 0x24, 0x0, 0x0, 0x0],
+    );
+    connection.set_property(
+        steam_game,
+        connection.atoms.wm_hints,
+        connection.atoms.wm_hints,
+        &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
+    );
+    f.map_as_toplevel(&mut connection, steam_game);
 
     let wallpaper_engine = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2105,32 +2105,32 @@ fn popup_heuristics() {
     );
     f.map_as_toplevel(&mut connection, ardour_toplevel);
 
-    let yabridge_popup = connection.new_window(connection.root, 10, 10, 50, 50, false);
+    let normal_skip_taskbar_window = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(
-        yabridge_popup,
+        normal_skip_taskbar_window,
         x::ATOM_ATOM,
         connection.atoms.win_type,
         &[connection.atoms.win_type_normal],
     );
     connection.set_property(
-        yabridge_popup,
+        normal_skip_taskbar_window,
         connection.atoms.motif_wm_hints,
         connection.atoms.motif_wm_hints,
         &[0x2_u32, 0, 0, 0, 0],
     );
     connection.set_property(
-        yabridge_popup,
+        normal_skip_taskbar_window,
         connection.atoms.wm_hints,
         connection.atoms.wm_hints,
         &[0x1_u32, 0, 0, 0, 0, 0, 0, 0, 0],
     );
     connection.set_property(
-        yabridge_popup,
+        normal_skip_taskbar_window,
         x::ATOM_ATOM,
         connection.atoms.net_wm_state,
         &[connection.atoms.skip_taskbar],
     );
-    f.map_as_toplevel(&mut connection, yabridge_popup);
+    f.map_as_toplevel(&mut connection, normal_skip_taskbar_window);
 
     let steam = connection.new_window(connection.root, 10, 10, 50, 50, false);
     connection.set_property(


### PR DESCRIPTION
## Summary

Remove the broad `WM_HINTS` popup heuristic for `_NET_WM_WINDOW_TYPE_NORMAL` windows.

Windows with `WM_HINTS` input focus set to false and client-side/no Motif decorations are not reliably popups. Steam/Proton game windows and launchers can expose the same shape, which causes them to be embedded into the last focused Xwayland window.

This keeps the simpler/stronger popup signals intact:
- `override_redirect`
- explicit popup window types
- Motif no-functions hint
- existing utility/no-decoration behavior

## Notes

This intentionally stops treating the `NORMAL + WM_HINTS input=false + no decorations` property shape as a generic popup signal. If a specific application still needs popup behavior for this shape, it should probably be handled as a narrow exception rather than a core heuristic.

Fixes #392
Supersedes #417

## Test plan

- [x] `cargo test popup_heuristics --test integration` fails before the production change
- [x] `cargo test popup_heuristics --test integration`
- [x] `cargo build --all-targets --profile ci --locked`
- [x] `cargo test --profile ci --locked -- --test-threads 1`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --profile ci --locked --workspace`

Note: a later local rerun of the full integration suite showed two unrelated-looking flaky failures (`client_init_move`, `wayland_then_x11_clipboard_owner`) that both passed when rerun individually.
