### PR TITLE
selection: bridge via ext-data-control-v1

### DIFF
--- a/src/server/clientside.rs
+++ b/src/server/clientside.rs
@@ -4,17 +4,8 @@ use super::{GlobalName, ObjectEvent};
 use hecs::{Entity, World};
 use smithay_client_toolkit::{
     activation::{ActivationHandler, RequestData, RequestDataExt},
-    data_device_manager::{
-        data_device::{DataDeviceData, DataDeviceHandler},
-        data_offer::{DataOfferHandler, SelectionOffer},
-        data_source::DataSourceHandler,
-    },
-    delegate_activation, delegate_data_device, delegate_primary_selection,
-    primary_selection::{
-        device::{PrimarySelectionDeviceData, PrimarySelectionDeviceHandler},
-        offer::PrimarySelectionOffer,
-        selection::PrimarySelectionSourceHandler,
-    },
+    data_device_manager::WritePipe,
+    delegate_activation,
 };
 use std::sync::{Mutex, OnceLock, mpsc};
 use wayland_client::protocol::{
@@ -48,11 +39,6 @@ use wayland_protocols::{
             zwp_confined_pointer_v1::ZwpConfinedPointerV1,
             zwp_locked_pointer_v1::ZwpLockedPointerV1,
             zwp_pointer_constraints_v1::ZwpPointerConstraintsV1,
-        },
-        primary_selection::zv1::client::{
-            zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1,
-            zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
-            zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
         },
         relative_pointer::zv1::client::{
             zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
@@ -88,27 +74,23 @@ use wayland_protocols::{
         },
     },
 };
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1::{self, EVT_DATA_OFFER_OPCODE, ExtDataControlDeviceV1},
+    ext_data_control_manager_v1::ExtDataControlManagerV1,
+    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
+    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
+};
 use wayland_server::protocol as server;
 use wl_drm::client::wl_drm::WlDrm;
 use xcb::x;
 
-pub(super) struct SelectionEvents<T> {
-    pub offer: Option<T>,
-    pub requests: Vec<(
-        String,
-        smithay_client_toolkit::data_device_manager::WritePipe,
-    )>,
-    pub cancelled: bool,
-}
+use super::selection::SourceKind;
 
-impl<T> Default for SelectionEvents<T> {
-    fn default() -> Self {
-        Self {
-            offer: None,
-            requests: Default::default(),
-            cancelled: false,
-        }
-    }
+#[derive(Default)]
+pub(super) struct SelectionEvents {
+    pub offer: Option<ExtDataControlOfferV1>,
+    pub requests: Vec<(String, WritePipe)>,
+    pub cancelled: bool,
 }
 
 pub(super) struct MyWorld {
@@ -118,8 +100,8 @@ pub(super) struct MyWorld {
     pub removed_globals: Vec<GlobalName>,
     events: Vec<(Entity, ObjectEvent)>,
     queued_events: Vec<mpsc::Receiver<(Entity, ObjectEvent)>>,
-    pub clipboard: SelectionEvents<SelectionOffer>,
-    pub primary: SelectionEvents<PrimarySelectionOffer>,
+    pub clipboard: SelectionEvents,
+    pub primary: SelectionEvents,
     pub pending_activations: Vec<(xcb::x::Window, String)>,
 }
 
@@ -191,7 +173,6 @@ delegate_noop!(MyWorld: ZwpTabletManagerV2);
 delegate_noop!(MyWorld: XdgActivationV1);
 delegate_noop!(MyWorld: ZxdgDecorationManagerV1);
 delegate_noop!(MyWorld: WpFractionalScaleManagerV1);
-delegate_noop!(MyWorld: ZwpPrimarySelectionDeviceManagerV1);
 delegate_noop!(MyWorld: WlSubsurface);
 delegate_noop!(MyWorld: WpLinuxDrmSyncobjManagerV1);
 delegate_noop!(MyWorld: WpLinuxDrmSyncobjSurfaceV1);
@@ -435,131 +416,84 @@ impl Dispatch<ZwpTabletPadGroupV2, LateInitObjectKey<ZwpTabletPadGroupV2>> for M
     ]);
 }
 
-delegate_data_device!(MyWorld);
+delegate_noop!(MyWorld: ExtDataControlManagerV1);
 
-impl DataDeviceHandler for MyWorld {
-    fn selection(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        data_device: &wayland_client::protocol::wl_data_device::WlDataDevice,
-    ) {
-        let data: &DataDeviceData = data_device.data().unwrap();
-        self.clipboard.offer = data.selection_offer();
-    }
-
-    fn drop_performed(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
-    ) {
-    }
-
-    fn motion(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
-        _: f64,
-        _: f64,
-    ) {
-    }
-
-    fn leave(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
-    ) {
-    }
-
-    fn enter(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
-        _: f64,
-        _: f64,
-        _: &wayland_client::protocol::wl_surface::WlSurface,
-    ) {
+fn set_offer(events: &mut SelectionEvents, offer: Option<ExtDataControlOfferV1>) {
+    if let Some(old) = std::mem::replace(&mut events.offer, offer) {
+        old.destroy();
     }
 }
 
-impl DataSourceHandler for MyWorld {
-    fn send_request(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-        mime: String,
-        fd: smithay_client_toolkit::data_device_manager::WritePipe,
+impl Dispatch<ExtDataControlSourceV1, SourceKind> for MyWorld {
+    fn event(
+        state: &mut Self,
+        _: &ExtDataControlSourceV1,
+        event: <ExtDataControlSourceV1 as Proxy>::Event,
+        kind: &SourceKind,
+        _: &Connection,
+        _: &QueueHandle<Self>,
     ) {
-        self.clipboard.requests.push((mime, fd));
-    }
-
-    fn cancelled(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-    ) {
-        self.clipboard.cancelled = true;
-    }
-
-    fn action(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-        _: wayland_client::protocol::wl_data_device_manager::DndAction,
-    ) {
-    }
-
-    fn dnd_finished(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-    ) {
-    }
-
-    fn dnd_dropped(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-    ) {
-    }
-
-    fn accept_mime(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_data_source::WlDataSource,
-        _: Option<String>,
-    ) {
+        let events = match kind {
+            SourceKind::Clipboard => &mut state.clipboard,
+            SourceKind::Primary => &mut state.primary,
+        };
+        match event {
+            ext_data_control_source_v1::Event::Send { mime_type, fd } => {
+                events.requests.push((mime_type, WritePipe::from(fd)));
+            }
+            ext_data_control_source_v1::Event::Cancelled => {
+                events.cancelled = true;
+            }
+            _ => {}
+        }
     }
 }
 
-impl DataOfferHandler for MyWorld {
-    fn selected_action(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
-        _: wayland_client::protocol::wl_data_device_manager::DndAction,
+impl Dispatch<ExtDataControlOfferV1, Mutex<Vec<String>>> for MyWorld {
+    fn event(
+        _: &mut Self,
+        _: &ExtDataControlOfferV1,
+        event: <ExtDataControlOfferV1 as Proxy>::Event,
+        mimes: &Mutex<Vec<String>>,
+        _: &Connection,
+        _: &QueueHandle<Self>,
     ) {
+        if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
+            mimes.lock().unwrap().push(mime_type);
+        }
+    }
+}
+
+impl Dispatch<ExtDataControlDeviceV1, ()> for MyWorld {
+    fn event(
+        state: &mut Self,
+        _: &ExtDataControlDeviceV1,
+        event: <ExtDataControlDeviceV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_device_v1::Event::DataOffer { .. } => {
+                // The new offer resource is initialised through event_created_child! with an
+                // empty mimes Vec as its user data; that Vec is appended to by the offer's own
+                // Offer event. We don't need to do anything else until Selection /
+                // PrimarySelection arrives.
+            }
+            ext_data_control_device_v1::Event::Selection { id } => {
+                set_offer(&mut state.clipboard, id);
+            }
+            ext_data_control_device_v1::Event::PrimarySelection { id } => {
+                set_offer(&mut state.primary, id);
+            }
+            ext_data_control_device_v1::Event::Finished => {}
+            _ => {}
+        }
     }
 
-    fn source_actions(
-        &mut self,
-        _: &wayland_client::Connection,
-        _: &wayland_client::QueueHandle<Self>,
-        _: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
-        _: wayland_client::protocol::wl_data_device_manager::DndAction,
-    ) {
-    }
+    event_created_child!(MyWorld, ExtDataControlDeviceV1, [
+        EVT_DATA_OFFER_OPCODE => (ExtDataControlOfferV1, Mutex::new(Vec::<String>::new())),
+    ]);
 }
 
 delegate_activation!(MyWorld, ActivationData);
@@ -597,41 +531,3 @@ impl ActivationHandler for MyWorld {
     }
 }
 
-delegate_primary_selection!(MyWorld);
-
-impl PrimarySelectionDeviceHandler for MyWorld {
-    fn selection(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        primary_selection_device: &ZwpPrimarySelectionDeviceV1,
-    ) {
-        let Some(data) = primary_selection_device.data::<PrimarySelectionDeviceData>() else {
-            return;
-        };
-
-        self.primary.offer = data.selection_offer();
-    }
-}
-
-impl PrimarySelectionSourceHandler for MyWorld {
-    fn send_request(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        _: &ZwpPrimarySelectionSourceV1,
-        mime: String,
-        write_pipe: smithay_client_toolkit::data_device_manager::WritePipe,
-    ) {
-        self.primary.requests.push((mime, write_pipe));
-    }
-
-    fn cancelled(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        _: &ZwpPrimarySelectionSourceV1,
-    ) {
-        self.primary.cancelled = true;
-    }
-}

--- a/src/server/clientside.rs
+++ b/src/server/clientside.rs
@@ -4,8 +4,17 @@ use super::{GlobalName, ObjectEvent};
 use hecs::{Entity, World};
 use smithay_client_toolkit::{
     activation::{ActivationHandler, RequestData, RequestDataExt},
-    data_device_manager::WritePipe,
-    delegate_activation,
+    data_device_manager::{
+        data_device::{DataDeviceData, DataDeviceHandler},
+        data_offer::{DataOfferHandler, SelectionOffer},
+        data_source::DataSourceHandler,
+    },
+    delegate_activation, delegate_data_device, delegate_primary_selection,
+    primary_selection::{
+        device::{PrimarySelectionDeviceData, PrimarySelectionDeviceHandler},
+        offer::PrimarySelectionOffer,
+        selection::PrimarySelectionSourceHandler,
+    },
 };
 use std::sync::{Mutex, OnceLock, mpsc};
 use wayland_client::protocol::{
@@ -18,6 +27,12 @@ use wayland_client::protocol::{
 use wayland_client::{
     Connection, Dispatch, Proxy, QueueHandle, delegate_noop, event_created_child,
     globals::{Global, GlobalList, GlobalListContents},
+};
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1::{self, EVT_DATA_OFFER_OPCODE, ExtDataControlDeviceV1},
+    ext_data_control_manager_v1::ExtDataControlManagerV1,
+    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
+    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
 };
 use wayland_protocols::{
     wp::{
@@ -39,6 +54,11 @@ use wayland_protocols::{
             zwp_confined_pointer_v1::ZwpConfinedPointerV1,
             zwp_locked_pointer_v1::ZwpLockedPointerV1,
             zwp_pointer_constraints_v1::ZwpPointerConstraintsV1,
+        },
+        primary_selection::zv1::client::{
+            zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1,
+            zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1,
+            zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1,
         },
         relative_pointer::zv1::client::{
             zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
@@ -74,23 +94,40 @@ use wayland_protocols::{
         },
     },
 };
-use wayland_protocols::ext::data_control::v1::client::{
-    ext_data_control_device_v1::{self, EVT_DATA_OFFER_OPCODE, ExtDataControlDeviceV1},
-    ext_data_control_manager_v1::ExtDataControlManagerV1,
-    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
-    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
-};
 use wayland_server::protocol as server;
 use wl_drm::client::wl_drm::WlDrm;
 use xcb::x;
 
 use super::selection::SourceKind;
 
+pub(super) struct SelectionEvents<T> {
+    pub offer: Option<T>,
+    pub requests: Vec<(
+        wayland_client::backend::ObjectId,
+        String,
+        smithay_client_toolkit::data_device_manager::WritePipe,
+    )>,
+    pub cancelled: Vec<wayland_client::backend::ObjectId>,
+}
+
+impl<T> Default for SelectionEvents<T> {
+    fn default() -> Self {
+        Self {
+            offer: None,
+            requests: Default::default(),
+            cancelled: Default::default(),
+        }
+    }
+}
+
 #[derive(Default)]
-pub(super) struct SelectionEvents {
-    pub offer: Option<ExtDataControlOfferV1>,
-    pub requests: Vec<(String, WritePipe)>,
-    pub cancelled: bool,
+pub(super) struct ControlSourceEvents {
+    pub requests: Vec<(
+        ExtDataControlSourceV1,
+        String,
+        smithay_client_toolkit::data_device_manager::WritePipe,
+    )>,
+    pub cancelled: Vec<ExtDataControlSourceV1>,
 }
 
 pub(super) struct MyWorld {
@@ -100,8 +137,10 @@ pub(super) struct MyWorld {
     pub removed_globals: Vec<GlobalName>,
     events: Vec<(Entity, ObjectEvent)>,
     queued_events: Vec<mpsc::Receiver<(Entity, ObjectEvent)>>,
-    pub clipboard: SelectionEvents,
-    pub primary: SelectionEvents,
+    pub clipboard: SelectionEvents<SelectionOffer>,
+    pub primary: SelectionEvents<PrimarySelectionOffer>,
+    pub control_clipboard: ControlSourceEvents,
+    pub control_primary: ControlSourceEvents,
     pub pending_activations: Vec<(xcb::x::Window, String)>,
 }
 
@@ -116,6 +155,8 @@ impl MyWorld {
             queued_events: Vec::new(),
             clipboard: Default::default(),
             primary: Default::default(),
+            control_clipboard: Default::default(),
+            control_primary: Default::default(),
             pending_activations: Vec::new(),
         }
     }
@@ -173,6 +214,7 @@ delegate_noop!(MyWorld: ZwpTabletManagerV2);
 delegate_noop!(MyWorld: XdgActivationV1);
 delegate_noop!(MyWorld: ZxdgDecorationManagerV1);
 delegate_noop!(MyWorld: WpFractionalScaleManagerV1);
+delegate_noop!(MyWorld: ZwpPrimarySelectionDeviceManagerV1);
 delegate_noop!(MyWorld: WlSubsurface);
 delegate_noop!(MyWorld: WpLinuxDrmSyncobjManagerV1);
 delegate_noop!(MyWorld: WpLinuxDrmSyncobjSurfaceV1);
@@ -416,84 +458,131 @@ impl Dispatch<ZwpTabletPadGroupV2, LateInitObjectKey<ZwpTabletPadGroupV2>> for M
     ]);
 }
 
-delegate_noop!(MyWorld: ExtDataControlManagerV1);
+delegate_data_device!(MyWorld);
 
-fn set_offer(events: &mut SelectionEvents, offer: Option<ExtDataControlOfferV1>) {
-    if let Some(old) = std::mem::replace(&mut events.offer, offer) {
-        old.destroy();
+impl DataDeviceHandler for MyWorld {
+    fn selection(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        data_device: &wayland_client::protocol::wl_data_device::WlDataDevice,
+    ) {
+        let data: &DataDeviceData = data_device.data().unwrap();
+        self.clipboard.offer = data.selection_offer();
+    }
+
+    fn drop_performed(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
+    ) {
+    }
+
+    fn motion(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
+        _: f64,
+        _: f64,
+    ) {
+    }
+
+    fn leave(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
+    ) {
+    }
+
+    fn enter(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_device::WlDataDevice,
+        _: f64,
+        _: f64,
+        _: &wayland_client::protocol::wl_surface::WlSurface,
+    ) {
     }
 }
 
-impl Dispatch<ExtDataControlSourceV1, SourceKind> for MyWorld {
-    fn event(
-        state: &mut Self,
-        _: &ExtDataControlSourceV1,
-        event: <ExtDataControlSourceV1 as Proxy>::Event,
-        kind: &SourceKind,
-        _: &Connection,
-        _: &QueueHandle<Self>,
+impl DataSourceHandler for MyWorld {
+    fn send_request(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        source: &wayland_client::protocol::wl_data_source::WlDataSource,
+        mime: String,
+        fd: smithay_client_toolkit::data_device_manager::WritePipe,
     ) {
-        let events = match kind {
-            SourceKind::Clipboard => &mut state.clipboard,
-            SourceKind::Primary => &mut state.primary,
-        };
-        match event {
-            ext_data_control_source_v1::Event::Send { mime_type, fd } => {
-                events.requests.push((mime_type, WritePipe::from(fd)));
-            }
-            ext_data_control_source_v1::Event::Cancelled => {
-                events.cancelled = true;
-            }
-            _ => {}
-        }
+        self.clipboard.requests.push((source.id(), mime, fd));
+    }
+
+    fn cancelled(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        source: &wayland_client::protocol::wl_data_source::WlDataSource,
+    ) {
+        self.clipboard.cancelled.push(source.id());
+    }
+
+    fn action(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_source::WlDataSource,
+        _: wayland_client::protocol::wl_data_device_manager::DndAction,
+    ) {
+    }
+
+    fn dnd_finished(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_source::WlDataSource,
+    ) {
+    }
+
+    fn dnd_dropped(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_source::WlDataSource,
+    ) {
+    }
+
+    fn accept_mime(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &wayland_client::protocol::wl_data_source::WlDataSource,
+        _: Option<String>,
+    ) {
     }
 }
 
-impl Dispatch<ExtDataControlOfferV1, Mutex<Vec<String>>> for MyWorld {
-    fn event(
-        _: &mut Self,
-        _: &ExtDataControlOfferV1,
-        event: <ExtDataControlOfferV1 as Proxy>::Event,
-        mimes: &Mutex<Vec<String>>,
-        _: &Connection,
-        _: &QueueHandle<Self>,
+impl DataOfferHandler for MyWorld {
+    fn selected_action(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
+        _: wayland_client::protocol::wl_data_device_manager::DndAction,
     ) {
-        if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
-            mimes.lock().unwrap().push(mime_type);
-        }
-    }
-}
-
-impl Dispatch<ExtDataControlDeviceV1, ()> for MyWorld {
-    fn event(
-        state: &mut Self,
-        _: &ExtDataControlDeviceV1,
-        event: <ExtDataControlDeviceV1 as Proxy>::Event,
-        _: &(),
-        _: &Connection,
-        _: &QueueHandle<Self>,
-    ) {
-        match event {
-            ext_data_control_device_v1::Event::DataOffer { .. } => {
-                // The new offer resource is initialised through event_created_child! with an
-                // empty mimes Vec as its user data; that Vec is appended to by the offer's own
-                // Offer event. We don't need to do anything else until Selection /
-                // PrimarySelection arrives.
-            }
-            ext_data_control_device_v1::Event::Selection { id } => {
-                set_offer(&mut state.clipboard, id);
-            }
-            ext_data_control_device_v1::Event::PrimarySelection { id } => {
-                set_offer(&mut state.primary, id);
-            }
-            ext_data_control_device_v1::Event::Finished => {}
-            _ => {}
-        }
     }
 
-    event_created_child!(MyWorld, ExtDataControlDeviceV1, [
-        EVT_DATA_OFFER_OPCODE => (ExtDataControlOfferV1, Mutex::new(Vec::<String>::new())),
-    ]);
+    fn source_actions(
+        &mut self,
+        _: &wayland_client::Connection,
+        _: &wayland_client::QueueHandle<Self>,
+        _: &mut smithay_client_toolkit::data_device_manager::data_offer::DragOffer,
+        _: wayland_client::protocol::wl_data_device_manager::DndAction,
+    ) {
+    }
 }
 
 delegate_activation!(MyWorld, ActivationData);
@@ -531,3 +620,112 @@ impl ActivationHandler for MyWorld {
     }
 }
 
+delegate_primary_selection!(MyWorld);
+
+impl PrimarySelectionDeviceHandler for MyWorld {
+    fn selection(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        primary_selection_device: &ZwpPrimarySelectionDeviceV1,
+    ) {
+        let Some(data) = primary_selection_device.data::<PrimarySelectionDeviceData>() else {
+            return;
+        };
+
+        self.primary.offer = data.selection_offer();
+    }
+}
+
+impl PrimarySelectionSourceHandler for MyWorld {
+    fn send_request(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        source: &ZwpPrimarySelectionSourceV1,
+        mime: String,
+        write_pipe: smithay_client_toolkit::data_device_manager::WritePipe,
+    ) {
+        self.primary.requests.push((source.id(), mime, write_pipe));
+    }
+
+    fn cancelled(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        source: &ZwpPrimarySelectionSourceV1,
+    ) {
+        self.primary.cancelled.push(source.id());
+    }
+}
+
+delegate_noop!(MyWorld: ExtDataControlManagerV1);
+
+impl Dispatch<ExtDataControlSourceV1, SourceKind> for MyWorld {
+    fn event(
+        state: &mut Self,
+        source: &ExtDataControlSourceV1,
+        event: <ExtDataControlSourceV1 as Proxy>::Event,
+        kind: &SourceKind,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let events = match kind {
+            SourceKind::Clipboard => &mut state.control_clipboard,
+            SourceKind::Primary => &mut state.control_primary,
+        };
+        match event {
+            ext_data_control_source_v1::Event::Send { mime_type, fd } => {
+                events.requests.push((
+                    source.clone(),
+                    mime_type,
+                    smithay_client_toolkit::data_device_manager::WritePipe::from(fd),
+                ));
+            }
+            ext_data_control_source_v1::Event::Cancelled => {
+                events.cancelled.push(source.clone());
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtDataControlOfferV1, ()> for MyWorld {
+    fn event(
+        _: &mut Self,
+        _: &ExtDataControlOfferV1,
+        event: <ExtDataControlOfferV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let ext_data_control_offer_v1::Event::Offer { .. } = event {}
+    }
+}
+
+impl Dispatch<ExtDataControlDeviceV1, ()> for MyWorld {
+    fn event(
+        _: &mut Self,
+        device: &ExtDataControlDeviceV1,
+        event: <ExtDataControlDeviceV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_device_v1::Event::Selection { id }
+            | ext_data_control_device_v1::Event::PrimarySelection { id } => {
+                if let Some(offer) = id {
+                    offer.destroy();
+                }
+            }
+            ext_data_control_device_v1::Event::Finished => device.destroy(),
+            ext_data_control_device_v1::Event::DataOffer { .. } => {}
+            _ => {}
+        }
+    }
+
+    event_created_child!(MyWorld, ExtDataControlDeviceV1, [
+        EVT_DATA_OFFER_OPCODE => (ExtDataControlOfferV1, ()),
+    ]);
+}

--- a/src/server/selection.rs
+++ b/src/server/selection.rs
@@ -1,288 +1,265 @@
-use super::clientside::SelectionEvents;
-use super::{InnerServerState, MyWorld, ServerState};
+use super::clientside::MyWorld;
+use super::{InnerServerState, ServerState};
 use crate::{X11Selection, XConnection};
-use log::{info, warn};
-use smithay_client_toolkit::data_device_manager::ReadPipe;
+use log::info;
+use rustix::pipe::{PipeFlags, pipe_with};
+use std::io::Read;
+use std::marker::PhantomData;
+use std::os::fd::{AsFd, OwnedFd};
+use std::rc::{Rc, Weak};
+use std::sync::Mutex;
+use wayland_client::Proxy;
+use wayland_client::QueueHandle;
 use wayland_client::globals::GlobalList;
 use wayland_client::protocol::wl_seat::WlSeat;
-use wayland_client::{Proxy, QueueHandle};
 
-use smithay_client_toolkit::data_device_manager::{
-    DataDeviceManagerState, data_device::DataDevice,
-    data_offer::SelectionOffer as WlSelectionOffer, data_source::CopyPasteSource,
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1::ExtDataControlDeviceV1,
+    ext_data_control_manager_v1::ExtDataControlManagerV1,
+    ext_data_control_offer_v1::ExtDataControlOfferV1,
+    ext_data_control_source_v1::ExtDataControlSourceV1,
 };
-use smithay_client_toolkit::primary_selection::PrimarySelectionManagerState;
-use smithay_client_toolkit::primary_selection::device::PrimarySelectionDevice;
-use smithay_client_toolkit::primary_selection::offer::PrimarySelectionOffer;
-use smithay_client_toolkit::primary_selection::selection::PrimarySelectionSource;
-use std::io::Read;
-use std::rc::{Rc, Weak};
+
+#[derive(Copy, Clone, Debug)]
+pub(super) enum SourceKind {
+    Clipboard,
+    Primary,
+}
+
+pub(crate) fn offer_mimes(offer: &ExtDataControlOfferV1) -> Vec<String> {
+    let data: &Mutex<Vec<String>> = offer.data().unwrap();
+    data.lock().unwrap().clone()
+}
 
 pub(super) struct SelectionStates<S: X11Selection> {
-    clipboard: Option<SelectionState<S, Clipboard>>,
-    primary: Option<SelectionState<S, Primary>>,
+    manager: Option<ExtDataControlManagerV1>,
+    device: Option<ExtDataControlDeviceV1>,
+    clipboard: SlotState<S>,
+    primary: SlotState<S>,
+}
+
+struct SlotState<S: X11Selection> {
+    source: Option<SlotSource<S>>,
+}
+
+impl<S: X11Selection> Default for SlotState<S> {
+    fn default() -> Self {
+        Self { source: None }
+    }
+}
+
+enum SlotSource<S: X11Selection> {
+    X11 {
+        inner: ExtDataControlSourceV1,
+        data: Weak<S>,
+    },
+    Foreign(AnyForeignSelection),
+}
+
+// Not a `Drop` impl: `new_selection` partial-moves the inner offer out of `AnyForeignSelection`
+// into `ForeignSelection`, which has its own Drop. Anywhere we drop an `AnyForeignSelection`
+// without transferring its offer first goes through `destroy_slot` instead.
+struct AnyForeignSelection {
+    mime_types: Box<[String]>,
+    inner: ExtDataControlOfferV1,
+}
+
+fn destroy_slot<S: X11Selection>(s: Option<SlotSource<S>>) {
+    match s {
+        Some(SlotSource::X11 { inner, .. }) => inner.destroy(),
+        Some(SlotSource::Foreign(f)) => f.inner.destroy(),
+        None => {}
+    }
 }
 
 impl<S: X11Selection> SelectionStates<S> {
     pub fn new(global_list: &GlobalList, qh: &QueueHandle<MyWorld>) -> Self {
+        let manager = global_list
+            .bind::<ExtDataControlManagerV1, _, _>(qh, 1..=1, ())
+            .ok();
+        if manager.is_none() {
+            info!(
+                "compositor does not expose ext-data-control-v1; X11 selection bridge disabled"
+            );
+        }
         Self {
-            clipboard: DataDeviceManagerState::bind(global_list, qh)
-                .inspect_err(|e| {
-                    warn!("Could not bind data device manager ({e:?}). Clipboard will not work.")
-                })
-                .ok()
-                .map(SelectionState::new),
-            primary: PrimarySelectionManagerState::bind(global_list, qh)
-                .inspect_err(|_| info!("Primary selection unsupported."))
-                .ok()
-                .map(SelectionState::new),
+            manager,
+            device: None,
+            clipboard: SlotState::default(),
+            primary: SlotState::default(),
         }
     }
 
     pub fn seat_created(&mut self, qh: &QueueHandle<MyWorld>, seat: &WlSeat) {
-        if let Some(c) = &mut self.clipboard {
-            c.device = Some(c.manager.get_data_device(qh, seat));
+        let Some(m) = self.manager.as_ref() else {
+            return;
+        };
+        let device = m.get_data_device(seat, qh, ());
+        // Push any pending X11 selections to the new device. set_selection_source may have
+        // been called before the wl_seat global arrived (during startup).
+        if let Some(SlotSource::X11 { inner, .. }) = &self.clipboard.source {
+            device.set_selection(Some(inner));
         }
-
-        if let Some(d) = &mut self.primary {
-            d.device = Some(d.manager.get_selection_device(qh, seat));
+        if let Some(SlotSource::X11 { inner, .. }) = &self.primary.source {
+            device.set_primary_selection(Some(inner));
         }
+        self.device = Some(device);
     }
-}
 
-enum SelectionData<S: X11Selection, T: SelectionType> {
-    X11 { inner: T::Source, data: Weak<S> },
-    Foreign(ForeignSelection<T>),
-}
-
-struct SelectionState<S: X11Selection, T: SelectionType> {
-    manager: T::Manager,
-    device: Option<T::DataDevice>,
-    source: Option<SelectionData<S, T>>,
-}
-
-impl<S: X11Selection, T: SelectionType> SelectionState<S, T> {
-    fn new(manager: T::Manager) -> Self {
-        Self {
-            manager,
-            device: None,
-            source: None,
+    fn slot_mut(&mut self, kind: SourceKind) -> &mut SlotState<S> {
+        match kind {
+            SourceKind::Clipboard => &mut self.clipboard,
+            SourceKind::Primary => &mut self.primary,
         }
     }
 }
 
 impl<S: X11Selection> InnerServerState<S> {
     pub(super) fn handle_selection_events(&mut self) {
-        self.handle_impl::<Clipboard>();
-        self.handle_impl::<Primary>();
+        self.handle_impl(SourceKind::Clipboard);
+        self.handle_impl(SourceKind::Primary);
     }
 
-    fn handle_impl<T: SelectionType>(&mut self) {
-        let Some(state) = T::selection_state(&mut self.selection_states) else {
+    fn handle_impl(&mut self, kind: SourceKind) {
+        if self.selection_states.manager.is_none() {
             return;
+        }
+
+        let events = match kind {
+            SourceKind::Clipboard => &mut self.world.clipboard,
+            SourceKind::Primary => &mut self.world.primary,
         };
 
-        let events = T::get_events(&mut self.world);
+        let requests = std::mem::take(&mut events.requests);
+        let cancelled = std::mem::replace(&mut events.cancelled, false);
+        let offer_taken = events.offer.take();
+        let slot = self.selection_states.slot_mut(kind);
 
-        for (mime_type, fd) in std::mem::take(&mut events.requests) {
-            let SelectionData::X11 { data, .. } = state.source.as_ref().unwrap() else {
-                unreachable!("Got selection request without having set the selection?")
-            };
-            if let Some(data) = data.upgrade() {
-                data.write_to(&mime_type, fd);
+        for (mime_type, fd) in requests {
+            if let Some(SlotSource::X11 { data, .. }) = slot.source.as_ref() {
+                if let Some(data) = data.upgrade() {
+                    data.write_to(&mime_type, fd);
+                }
             }
         }
 
-        if events.cancelled {
-            state.source = None;
-            events.cancelled = false;
+        if cancelled {
+            destroy_slot(slot.source.take());
         }
 
-        if state.source.is_none() {
-            if let Some(offer) = T::take_offer(&mut events.offer) {
-                let mime_types = T::get_mimes(&offer);
-                let foreign = ForeignSelection {
-                    mime_types,
-                    inner: offer,
-                };
-                state.source = Some(SelectionData::Foreign(foreign));
+        if let Some(offer) = offer_taken {
+            match slot.source.as_ref() {
+                Some(SlotSource::X11 { .. }) => {
+                    // Our X11-owned source is still active; the compositor will deliver a
+                    // Cancelled to it shortly. Drop this incoming foreign offer.
+                    offer.destroy();
+                }
+                _ => {
+                    // None or stale Foreign: replace with the new offer.
+                    destroy_slot(slot.source.take());
+                    let mime_types = offer_mimes(&offer);
+                    slot.source = Some(SlotSource::Foreign(AnyForeignSelection {
+                        mime_types: mime_types.into_boxed_slice(),
+                        inner: offer,
+                    }));
+                }
             }
         }
     }
 
     pub(crate) fn set_selection_source<T: SelectionType>(&mut self, selection: &Rc<S>) {
-        if let Some(state) = T::selection_state(&mut self.selection_states) {
-            let src = T::create_source(&state.manager, &self.qh, selection.mime_types());
-            let data = SelectionData::X11 {
-                inner: src,
-                data: Rc::downgrade(selection),
-            };
-            let SelectionData::X11 { inner, .. } = state.source.insert(data) else {
-                unreachable!();
-            };
-            if let Some(serial) = self
-                .last_kb_serial
-                .as_ref()
-                .map(|(_seat, serial)| serial)
-                .copied()
-            {
-                T::set_selection(inner, state.device.as_ref().unwrap(), serial);
-            }
+        let Some(manager) = self.selection_states.manager.as_ref() else {
+            return;
+        };
+        let kind = T::KIND;
+        let src = manager.create_data_source(&self.qh, kind);
+        for mime in selection.mime_types() {
+            src.offer(mime.to_owned());
         }
+        if let Some(device) = self.selection_states.device.as_ref() {
+            T::set_on_device(device, Some(&src));
+        }
+        let slot = self.selection_states.slot_mut(kind);
+        destroy_slot(slot.source.take());
+        slot.source = Some(SlotSource::X11 {
+            inner: src,
+            data: Rc::downgrade(selection),
+        });
     }
 
     pub(crate) fn new_selection<T: SelectionType>(&mut self) -> Option<ForeignSelection<T>> {
-        T::selection_state(&mut self.selection_states)
-            .as_mut()
-            .and_then(|state| {
-                state.source.take().and_then(|s| match s {
-                    SelectionData::Foreign(f) => Some(f),
-                    SelectionData::X11 { .. } => {
-                        state.source = Some(s);
-                        None
-                    }
-                })
-            })
+        let slot = self.selection_states.slot_mut(T::KIND);
+        match slot.source.take()? {
+            SlotSource::Foreign(f) => Some(ForeignSelection {
+                mime_types: f.mime_types,
+                inner: f.inner,
+                _kind: PhantomData,
+            }),
+            other => {
+                slot.source = Some(other);
+                None
+            }
+        }
     }
 }
 
 pub struct ForeignSelection<T: SelectionType> {
     pub mime_types: Box<[String]>,
-    inner: T::Offer,
+    inner: ExtDataControlOfferV1,
+    _kind: PhantomData<fn() -> T>,
 }
 
-#[allow(private_bounds)]
 impl<T: SelectionType> ForeignSelection<T> {
     pub(crate) fn receive(
         &self,
         mime_type: String,
         state: &ServerState<impl XConnection>,
     ) -> Vec<u8> {
-        let mut pipe = T::receive_offer(&self.inner, mime_type).unwrap();
+        let (read, write) = pipe_with(PipeFlags::CLOEXEC).unwrap();
+        self.inner.receive(mime_type, OwnedFd::from(write).as_fd());
         state.queue.flush().unwrap();
         let mut data = Vec::new();
-        pipe.read_to_end(&mut data).unwrap();
+        let mut read = std::fs::File::from(OwnedFd::from(read));
+        read.read_to_end(&mut data).unwrap();
         data
     }
 }
 
-#[allow(private_bounds, private_interfaces)]
-pub trait SelectionType: Sized {
-    type Source;
-    type Offer;
-    type Manager;
-    type DataDevice;
-
-    // The methods in this trait shouldn't be used outside of this file.
-
-    fn selection_state<S: X11Selection>(
-        state: &mut SelectionStates<S>,
-    ) -> &mut Option<SelectionState<S, Self>>;
-
-    fn create_source(
-        manager: &Self::Manager,
-        qh: &QueueHandle<MyWorld>,
-        mime_types: Vec<&str>,
-    ) -> Self::Source;
-
-    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32);
-
-    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer>;
-
-    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe>;
-
-    fn take_offer(offer: &mut Option<Self::Offer>) -> Option<Self::Offer> {
-        offer.take()
+impl<T: SelectionType> Drop for ForeignSelection<T> {
+    fn drop(&mut self) {
+        self.inner.destroy();
     }
+}
 
-    fn get_mimes(offer: &Self::Offer) -> Box<[String]>;
+#[allow(private_bounds, private_interfaces)]
+pub trait SelectionType: sealed::Sealed {
+    const KIND: SourceKind;
+    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>);
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Clipboard {}
+    impl Sealed for super::Primary {}
 }
 
 pub enum Clipboard {}
 pub enum Primary {}
 
-#[allow(private_bounds, private_interfaces)]
+#[allow(private_interfaces)]
 impl SelectionType for Clipboard {
-    type Source = CopyPasteSource;
-    type Offer = WlSelectionOffer;
-    type Manager = DataDeviceManagerState;
-    type DataDevice = DataDevice;
+    const KIND: SourceKind = SourceKind::Clipboard;
 
-    fn selection_state<S: X11Selection>(
-        state: &mut SelectionStates<S>,
-    ) -> &mut Option<SelectionState<S, Self>> {
-        &mut state.clipboard
-    }
-
-    fn create_source(
-        manager: &Self::Manager,
-        qh: &QueueHandle<MyWorld>,
-        mime_types: Vec<&str>,
-    ) -> Self::Source {
-        manager.create_copy_paste_source(qh, mime_types)
-    }
-
-    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32) {
-        source.set_selection(device, serial);
-    }
-
-    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer> {
-        &mut world.clipboard
-    }
-
-    fn take_offer(offer: &mut Option<Self::Offer>) -> Option<Self::Offer> {
-        offer.take().filter(|offer| offer.inner().is_alive())
-    }
-
-    fn get_mimes(offer: &Self::Offer) -> Box<[String]> {
-        offer.with_mime_types(|mimes| mimes.into())
-    }
-
-    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe> {
-        offer.receive(mime_type).map_err(|e| {
-            use smithay_client_toolkit::data_device_manager::data_offer::DataOfferError;
-            match e {
-                DataOfferError::InvalidReceive => std::io::Error::from(std::io::ErrorKind::Other),
-                DataOfferError::Io(e) => e,
-            }
-        })
+    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>) {
+        device.set_selection(source);
     }
 }
 
-#[allow(private_bounds, private_interfaces)]
+#[allow(private_interfaces)]
 impl SelectionType for Primary {
-    type Source = PrimarySelectionSource;
-    type Offer = PrimarySelectionOffer;
-    type Manager = PrimarySelectionManagerState;
-    type DataDevice = PrimarySelectionDevice;
+    const KIND: SourceKind = SourceKind::Primary;
 
-    fn selection_state<S: X11Selection>(
-        state: &mut SelectionStates<S>,
-    ) -> &mut Option<SelectionState<S, Self>> {
-        &mut state.primary
-    }
-
-    fn create_source(
-        manager: &Self::Manager,
-        qh: &QueueHandle<MyWorld>,
-        mime_types: Vec<&str>,
-    ) -> Self::Source {
-        manager.create_selection_source(qh, mime_types)
-    }
-
-    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32) {
-        source.set_selection(device, serial);
-    }
-
-    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer> {
-        &mut world.primary
-    }
-
-    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe> {
-        offer.receive(mime_type)
-    }
-
-    fn get_mimes(offer: &Self::Offer) -> Box<[String]> {
-        offer.with_mime_types(|mimes| mimes.into())
+    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>) {
+        device.set_primary_selection(source);
     }
 }

--- a/src/server/selection.rs
+++ b/src/server/selection.rs
@@ -1,22 +1,25 @@
-use super::clientside::MyWorld;
-use super::{InnerServerState, ServerState};
+use super::clientside::SelectionEvents;
+use super::{InnerServerState, MyWorld, ServerState};
 use crate::{X11Selection, XConnection};
-use log::info;
-use rustix::pipe::{PipeFlags, pipe_with};
-use std::io::Read;
-use std::marker::PhantomData;
-use std::os::fd::{AsFd, OwnedFd};
-use std::rc::{Rc, Weak};
-use std::sync::Mutex;
-use wayland_client::Proxy;
-use wayland_client::QueueHandle;
+use log::{info, warn};
+use smithay_client_toolkit::data_device_manager::ReadPipe;
 use wayland_client::globals::GlobalList;
 use wayland_client::protocol::wl_seat::WlSeat;
+use wayland_client::{Proxy, QueueHandle};
 
+use smithay_client_toolkit::data_device_manager::{
+    DataDeviceManagerState, data_device::DataDevice,
+    data_offer::SelectionOffer as WlSelectionOffer, data_source::CopyPasteSource,
+};
+use smithay_client_toolkit::primary_selection::PrimarySelectionManagerState;
+use smithay_client_toolkit::primary_selection::device::PrimarySelectionDevice;
+use smithay_client_toolkit::primary_selection::offer::PrimarySelectionOffer;
+use smithay_client_toolkit::primary_selection::selection::PrimarySelectionSource;
+use std::io::Read;
+use std::rc::{Rc, Weak};
 use wayland_protocols::ext::data_control::v1::client::{
     ext_data_control_device_v1::ExtDataControlDeviceV1,
     ext_data_control_manager_v1::ExtDataControlManagerV1,
-    ext_data_control_offer_v1::ExtDataControlOfferV1,
     ext_data_control_source_v1::ExtDataControlSourceV1,
 };
 
@@ -26,240 +29,469 @@ pub(super) enum SourceKind {
     Primary,
 }
 
-pub(crate) fn offer_mimes(offer: &ExtDataControlOfferV1) -> Vec<String> {
-    let data: &Mutex<Vec<String>> = offer.data().unwrap();
-    data.lock().unwrap().clone()
-}
-
 pub(super) struct SelectionStates<S: X11Selection> {
-    manager: Option<ExtDataControlManagerV1>,
+    clipboard: Option<SelectionState<S, Clipboard>>,
+    primary: Option<SelectionState<S, Primary>>,
+    control: Option<DataControlState>,
+}
+
+struct DataControlState {
+    manager: ExtDataControlManagerV1,
     device: Option<ExtDataControlDeviceV1>,
-    clipboard: SlotState<S>,
-    primary: SlotState<S>,
-}
-
-struct SlotState<S: X11Selection> {
-    source: Option<SlotSource<S>>,
-}
-
-impl<S: X11Selection> Default for SlotState<S> {
-    fn default() -> Self {
-        Self { source: None }
-    }
-}
-
-enum SlotSource<S: X11Selection> {
-    X11 {
-        inner: ExtDataControlSourceV1,
-        data: Weak<S>,
-    },
-    Foreign(AnyForeignSelection),
-}
-
-// Not a `Drop` impl: `new_selection` partial-moves the inner offer out of `AnyForeignSelection`
-// into `ForeignSelection`, which has its own Drop. Anywhere we drop an `AnyForeignSelection`
-// without transferring its offer first goes through `destroy_slot` instead.
-struct AnyForeignSelection {
-    mime_types: Box<[String]>,
-    inner: ExtDataControlOfferV1,
-}
-
-fn destroy_slot<S: X11Selection>(s: Option<SlotSource<S>>) {
-    match s {
-        Some(SlotSource::X11 { inner, .. }) => inner.destroy(),
-        Some(SlotSource::Foreign(f)) => f.inner.destroy(),
-        None => {}
-    }
 }
 
 impl<S: X11Selection> SelectionStates<S> {
     pub fn new(global_list: &GlobalList, qh: &QueueHandle<MyWorld>) -> Self {
-        let manager = global_list
-            .bind::<ExtDataControlManagerV1, _, _>(qh, 1..=1, ())
-            .ok();
-        if manager.is_none() {
-            info!(
-                "compositor does not expose ext-data-control-v1; X11 selection bridge disabled"
-            );
-        }
         Self {
-            manager,
-            device: None,
-            clipboard: SlotState::default(),
-            primary: SlotState::default(),
+            clipboard: DataDeviceManagerState::bind(global_list, qh)
+                .inspect_err(|e| {
+                    warn!("Could not bind data device manager ({e:?}). Clipboard will not work.")
+                })
+                .ok()
+                .map(SelectionState::new),
+            primary: PrimarySelectionManagerState::bind(global_list, qh)
+                .inspect_err(|_| info!("Primary selection unsupported."))
+                .ok()
+                .map(SelectionState::new),
+            control: global_list
+                .bind::<ExtDataControlManagerV1, _, _>(qh, 1..=1, ())
+                .ok()
+                .map(|manager| DataControlState {
+                    manager,
+                    device: None,
+                }),
         }
     }
 
     pub fn seat_created(&mut self, qh: &QueueHandle<MyWorld>, seat: &WlSeat) {
-        let Some(m) = self.manager.as_ref() else {
+        if let Some(c) = &mut self.clipboard {
+            c.device = Some(c.manager.get_data_device(qh, seat));
+        }
+
+        if let Some(d) = &mut self.primary {
+            d.device = Some(d.manager.get_selection_device(qh, seat));
+        }
+
+        let Some(control) = &mut self.control else {
             return;
         };
-        let device = m.get_data_device(seat, qh, ());
-        // Push any pending X11 selections to the new device. set_selection_source may have
-        // been called before the wl_seat global arrived (during startup).
-        if let Some(SlotSource::X11 { inner, .. }) = &self.clipboard.source {
-            device.set_selection(Some(inner));
-        }
-        if let Some(SlotSource::X11 { inner, .. }) = &self.primary.source {
-            device.set_primary_selection(Some(inner));
-        }
-        self.device = Some(device);
-    }
+        let device = control.manager.get_data_device(seat, qh, ());
 
-    fn slot_mut(&mut self, kind: SourceKind) -> &mut SlotState<S> {
-        match kind {
-            SourceKind::Clipboard => &mut self.clipboard,
-            SourceKind::Primary => &mut self.primary,
+        if let Some(SelectionData::X11 {
+            inner: SelectionSource::Control { inner, published },
+            ..
+        }) = self
+            .clipboard
+            .as_mut()
+            .and_then(|state| state.source.as_mut())
+        {
+            if !*published {
+                device.set_selection(Some(inner));
+                *published = true;
+            }
+        }
+        if let Some(SelectionData::X11 {
+            inner: SelectionSource::Control { inner, published },
+            ..
+        }) = self
+            .primary
+            .as_mut()
+            .and_then(|state| state.source.as_mut())
+        {
+            if !*published {
+                device.set_primary_selection(Some(inner));
+                *published = true;
+            }
+        }
+
+        control.device = Some(device);
+    }
+}
+
+enum SelectionData<S: X11Selection, T: SelectionType> {
+    X11 {
+        inner: SelectionSource<T::Source>,
+        data: Weak<S>,
+    },
+    Foreign(ForeignSelection<T>),
+}
+
+enum SelectionSource<T> {
+    Core(T),
+    Control {
+        inner: ExtDataControlSourceV1,
+        published: bool,
+    },
+}
+
+fn destroy_selection<S: X11Selection, T: SelectionType>(selection: SelectionData<S, T>) {
+    if let SelectionData::X11 {
+        inner: SelectionSource::Control { inner, .. },
+        ..
+    } = selection
+    {
+        inner.destroy();
+    }
+}
+
+struct SelectionState<S: X11Selection, T: SelectionType> {
+    manager: T::Manager,
+    device: Option<T::DataDevice>,
+    source: Option<SelectionData<S, T>>,
+}
+
+impl<S: X11Selection, T: SelectionType> SelectionState<S, T> {
+    fn new(manager: T::Manager) -> Self {
+        Self {
+            manager,
+            device: None,
+            source: None,
         }
     }
 }
 
 impl<S: X11Selection> InnerServerState<S> {
     pub(super) fn handle_selection_events(&mut self) {
-        self.handle_impl(SourceKind::Clipboard);
-        self.handle_impl(SourceKind::Primary);
+        self.handle_impl::<Clipboard>();
+        self.handle_impl::<Primary>();
     }
 
-    fn handle_impl(&mut self, kind: SourceKind) {
-        if self.selection_states.manager.is_none() {
-            return;
-        }
-
-        let events = match kind {
-            SourceKind::Clipboard => &mut self.world.clipboard,
-            SourceKind::Primary => &mut self.world.primary,
+    fn handle_impl<T: SelectionType>(&mut self) {
+        let (requests, cancelled) = {
+            let events = T::get_events(&mut self.world);
+            (
+                std::mem::take(&mut events.requests),
+                std::mem::take(&mut events.cancelled),
+            )
+        };
+        let (control_requests, control_cancelled) = {
+            let events = T::get_control_events(&mut self.world);
+            (
+                std::mem::take(&mut events.requests),
+                std::mem::take(&mut events.cancelled),
+            )
         };
 
-        let requests = std::mem::take(&mut events.requests);
-        let cancelled = std::mem::replace(&mut events.cancelled, false);
-        let offer_taken = events.offer.take();
-        let slot = self.selection_states.slot_mut(kind);
+        let Some(state) = T::selection_state(&mut self.selection_states) else {
+            return;
+        };
 
-        for (mime_type, fd) in requests {
-            if let Some(SlotSource::X11 { data, .. }) = slot.source.as_ref() {
+        if let Some(SelectionData::X11 {
+            inner: SelectionSource::Core(inner),
+            data,
+        }) = state.source.as_ref()
+        {
+            let source_id = T::source_id(inner);
+            for (request_source, mime_type, fd) in requests {
+                if request_source == source_id {
+                    if let Some(data) = data.upgrade() {
+                        data.write_to(&mime_type, fd);
+                    }
+                }
+            }
+        }
+
+        let core_cancelled = matches!(
+            state.source.as_ref(),
+            Some(SelectionData::X11 {
+                inner: SelectionSource::Core(inner),
+                ..
+            }) if cancelled.contains(&T::source_id(inner))
+        );
+        if core_cancelled {
+            state.source = None;
+        }
+
+        for (source, mime_type, fd) in control_requests {
+            let Some(SelectionData::X11 {
+                inner: SelectionSource::Control { inner, .. },
+                data,
+            }) = state.source.as_ref()
+            else {
+                continue;
+            };
+            if source == *inner {
                 if let Some(data) = data.upgrade() {
                     data.write_to(&mime_type, fd);
                 }
             }
         }
 
-        if cancelled {
-            destroy_slot(slot.source.take());
+        for source in control_cancelled {
+            let is_current = matches!(
+                state.source.as_ref(),
+                Some(SelectionData::X11 {
+                    inner: SelectionSource::Control { inner, .. },
+                    ..
+                }) if source == *inner
+            );
+            if is_current {
+                let old = state.source.take().unwrap();
+                destroy_selection(old);
+            }
         }
 
-        if let Some(offer) = offer_taken {
-            match slot.source.as_ref() {
-                Some(SlotSource::X11 { .. }) => {
-                    // Our X11-owned source is still active; the compositor will deliver a
-                    // Cancelled to it shortly. Drop this incoming foreign offer.
-                    offer.destroy();
-                }
-                _ => {
-                    // None or stale Foreign: replace with the new offer.
-                    destroy_slot(slot.source.take());
-                    let mime_types = offer_mimes(&offer);
-                    slot.source = Some(SlotSource::Foreign(AnyForeignSelection {
-                        mime_types: mime_types.into_boxed_slice(),
-                        inner: offer,
-                    }));
-                }
+        if state.source.is_none() {
+            let events = T::get_events(&mut self.world);
+            if let Some(offer) = T::take_offer(&mut events.offer) {
+                let mime_types = T::get_mimes(&offer);
+                let foreign = ForeignSelection {
+                    mime_types,
+                    inner: offer,
+                };
+                state.source = Some(SelectionData::Foreign(foreign));
             }
         }
     }
 
     pub(crate) fn set_selection_source<T: SelectionType>(&mut self, selection: &Rc<S>) {
-        let Some(manager) = self.selection_states.manager.as_ref() else {
+        let serial = self.last_kb_serial.as_ref().map(|(_seat, serial)| *serial);
+        let control = self.selection_states.control.as_ref().map(|control| {
+            (
+                control.manager.clone(),
+                control.device.clone().filter(Proxy::is_alive),
+            )
+        });
+
+        let Some(state) = T::selection_state(&mut self.selection_states) else {
             return;
         };
-        let kind = T::KIND;
-        let src = manager.create_data_source(&self.qh, kind);
-        for mime in selection.mime_types() {
-            src.offer(mime.to_owned());
+
+        let inner = if let Some(serial) = serial {
+            let src = T::create_source(&state.manager, &self.qh, selection.mime_types());
+            T::set_selection(&src, state.device.as_ref().unwrap(), serial);
+            SelectionSource::Core(src)
+        } else if let Some((manager, device)) = control {
+            let src = manager.create_data_source(&self.qh, T::KIND);
+            for mime in selection.mime_types() {
+                src.offer(mime.to_owned());
+            }
+            let published = if let Some(device) = device.as_ref() {
+                T::set_control_selection(device, Some(&src));
+                true
+            } else {
+                false
+            };
+            SelectionSource::Control {
+                inner: src,
+                published,
+            }
+        } else {
+            // Preserve the core-only behavior when ext-data-control is unavailable. The source
+            // is retained, but cannot be published until the client has an input serial.
+            SelectionSource::Core(T::create_source(
+                &state.manager,
+                &self.qh,
+                selection.mime_types(),
+            ))
+        };
+
+        if let Some(old) = state.source.take() {
+            destroy_selection(old);
         }
-        if let Some(device) = self.selection_states.device.as_ref() {
-            T::set_on_device(device, Some(&src));
-        }
-        let slot = self.selection_states.slot_mut(kind);
-        destroy_slot(slot.source.take());
-        slot.source = Some(SlotSource::X11 {
-            inner: src,
+        state.source = Some(SelectionData::X11 {
+            inner,
             data: Rc::downgrade(selection),
         });
     }
 
     pub(crate) fn new_selection<T: SelectionType>(&mut self) -> Option<ForeignSelection<T>> {
-        let slot = self.selection_states.slot_mut(T::KIND);
-        match slot.source.take()? {
-            SlotSource::Foreign(f) => Some(ForeignSelection {
-                mime_types: f.mime_types,
-                inner: f.inner,
-                _kind: PhantomData,
-            }),
-            other => {
-                slot.source = Some(other);
-                None
-            }
-        }
+        T::selection_state(&mut self.selection_states)
+            .as_mut()
+            .and_then(|state| {
+                state.source.take().and_then(|s| match s {
+                    SelectionData::Foreign(f) => Some(f),
+                    SelectionData::X11 { .. } => {
+                        state.source = Some(s);
+                        None
+                    }
+                })
+            })
     }
 }
 
 pub struct ForeignSelection<T: SelectionType> {
     pub mime_types: Box<[String]>,
-    inner: ExtDataControlOfferV1,
-    _kind: PhantomData<fn() -> T>,
+    inner: T::Offer,
 }
 
+#[allow(private_bounds)]
 impl<T: SelectionType> ForeignSelection<T> {
     pub(crate) fn receive(
         &self,
         mime_type: String,
         state: &ServerState<impl XConnection>,
     ) -> Vec<u8> {
-        let (read, write) = pipe_with(PipeFlags::CLOEXEC).unwrap();
-        self.inner.receive(mime_type, OwnedFd::from(write).as_fd());
+        let mut pipe = T::receive_offer(&self.inner, mime_type).unwrap();
         state.queue.flush().unwrap();
         let mut data = Vec::new();
-        let mut read = std::fs::File::from(OwnedFd::from(read));
-        read.read_to_end(&mut data).unwrap();
+        pipe.read_to_end(&mut data).unwrap();
         data
     }
 }
 
-impl<T: SelectionType> Drop for ForeignSelection<T> {
-    fn drop(&mut self) {
-        self.inner.destroy();
-    }
-}
-
 #[allow(private_bounds, private_interfaces)]
-pub trait SelectionType: sealed::Sealed {
-    const KIND: SourceKind;
-    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>);
-}
+pub trait SelectionType: Sized {
+    type Source;
+    type Offer;
+    type Manager;
+    type DataDevice;
 
-mod sealed {
-    pub trait Sealed {}
-    impl Sealed for super::Clipboard {}
-    impl Sealed for super::Primary {}
+    const KIND: SourceKind;
+
+    // The methods in this trait shouldn't be used outside of this file.
+
+    fn selection_state<S: X11Selection>(
+        state: &mut SelectionStates<S>,
+    ) -> &mut Option<SelectionState<S, Self>>;
+
+    fn create_source(
+        manager: &Self::Manager,
+        qh: &QueueHandle<MyWorld>,
+        mime_types: Vec<&str>,
+    ) -> Self::Source;
+
+    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32);
+
+    fn source_id(source: &Self::Source) -> wayland_client::backend::ObjectId;
+
+    fn set_control_selection(
+        device: &ExtDataControlDeviceV1,
+        source: Option<&ExtDataControlSourceV1>,
+    );
+
+    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer>;
+
+    fn get_control_events(world: &mut MyWorld) -> &mut super::clientside::ControlSourceEvents;
+
+    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe>;
+
+    fn take_offer(offer: &mut Option<Self::Offer>) -> Option<Self::Offer> {
+        offer.take()
+    }
+
+    fn get_mimes(offer: &Self::Offer) -> Box<[String]>;
 }
 
 pub enum Clipboard {}
 pub enum Primary {}
 
-#[allow(private_interfaces)]
+#[allow(private_bounds, private_interfaces)]
 impl SelectionType for Clipboard {
+    type Source = CopyPasteSource;
+    type Offer = WlSelectionOffer;
+    type Manager = DataDeviceManagerState;
+    type DataDevice = DataDevice;
+
     const KIND: SourceKind = SourceKind::Clipboard;
 
-    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>) {
+    fn selection_state<S: X11Selection>(
+        state: &mut SelectionStates<S>,
+    ) -> &mut Option<SelectionState<S, Self>> {
+        &mut state.clipboard
+    }
+
+    fn create_source(
+        manager: &Self::Manager,
+        qh: &QueueHandle<MyWorld>,
+        mime_types: Vec<&str>,
+    ) -> Self::Source {
+        manager.create_copy_paste_source(qh, mime_types)
+    }
+
+    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32) {
+        source.set_selection(device, serial);
+    }
+
+    fn source_id(source: &Self::Source) -> wayland_client::backend::ObjectId {
+        source.inner().id()
+    }
+
+    fn set_control_selection(
+        device: &ExtDataControlDeviceV1,
+        source: Option<&ExtDataControlSourceV1>,
+    ) {
         device.set_selection(source);
+    }
+
+    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer> {
+        &mut world.clipboard
+    }
+
+    fn get_control_events(world: &mut MyWorld) -> &mut super::clientside::ControlSourceEvents {
+        &mut world.control_clipboard
+    }
+
+    fn take_offer(offer: &mut Option<Self::Offer>) -> Option<Self::Offer> {
+        offer.take().filter(|offer| offer.inner().is_alive())
+    }
+
+    fn get_mimes(offer: &Self::Offer) -> Box<[String]> {
+        offer.with_mime_types(|mimes| mimes.into())
+    }
+
+    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe> {
+        offer.receive(mime_type).map_err(|e| {
+            use smithay_client_toolkit::data_device_manager::data_offer::DataOfferError;
+            match e {
+                DataOfferError::InvalidReceive => std::io::Error::from(std::io::ErrorKind::Other),
+                DataOfferError::Io(e) => e,
+            }
+        })
     }
 }
 
-#[allow(private_interfaces)]
+#[allow(private_bounds, private_interfaces)]
 impl SelectionType for Primary {
+    type Source = PrimarySelectionSource;
+    type Offer = PrimarySelectionOffer;
+    type Manager = PrimarySelectionManagerState;
+    type DataDevice = PrimarySelectionDevice;
+
     const KIND: SourceKind = SourceKind::Primary;
 
-    fn set_on_device(device: &ExtDataControlDeviceV1, source: Option<&ExtDataControlSourceV1>) {
+    fn selection_state<S: X11Selection>(
+        state: &mut SelectionStates<S>,
+    ) -> &mut Option<SelectionState<S, Self>> {
+        &mut state.primary
+    }
+
+    fn create_source(
+        manager: &Self::Manager,
+        qh: &QueueHandle<MyWorld>,
+        mime_types: Vec<&str>,
+    ) -> Self::Source {
+        manager.create_selection_source(qh, mime_types)
+    }
+
+    fn set_selection(source: &Self::Source, device: &Self::DataDevice, serial: u32) {
+        source.set_selection(device, serial);
+    }
+
+    fn source_id(source: &Self::Source) -> wayland_client::backend::ObjectId {
+        source.inner().id()
+    }
+
+    fn set_control_selection(
+        device: &ExtDataControlDeviceV1,
+        source: Option<&ExtDataControlSourceV1>,
+    ) {
         device.set_primary_selection(source);
+    }
+
+    fn get_events(world: &mut MyWorld) -> &mut SelectionEvents<Self::Offer> {
+        &mut world.primary
+    }
+
+    fn get_control_events(world: &mut MyWorld) -> &mut super::clientside::ControlSourceEvents {
+        &mut world.control_primary
+    }
+
+    fn receive_offer(offer: &Self::Offer, mime_type: String) -> std::io::Result<ReadPipe> {
+        offer.receive(mime_type)
+    }
+
+    fn get_mimes(offer: &Self::Offer) -> Box<[String]> {
+        offer.with_mime_types(|mimes| mimes.into())
     }
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1388,6 +1388,11 @@ macro_rules! selection_tests {
             }
 
             #[test]
+            fn copy_from_x11_without_x11_focus() {
+                super::copy_from_x11_without_x11_focus::<$selection_type>();
+            }
+
+            #[test]
             fn copy_from_wayland() {
                 super::copy_from_wayland::<$selection_type>();
             }
@@ -1444,6 +1449,26 @@ fn copy_from_x11<T: SelectionTest>() {
         true
     });
     assert_eq!(*mimes, data);
+}
+
+fn copy_from_x11_without_x11_focus<T: SelectionTest>() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+
+    let mimes = std::rc::Rc::new(vec![testwl::PasteData {
+        mime_type: "text".to_string(),
+        data: b"abc".to_vec(),
+    }]);
+
+    f.satellite.set_selection_source::<T::SelectionType>(&mimes);
+    f.run();
+
+    let win = Window::new(1);
+    let (_surface, _id) = f.create_toplevel(&comp, win);
+
+    let server_mimes = T::mimes(&mut f.testwl);
+    for mime in mimes.iter() {
+        assert!(server_mimes.contains(&mime.mime_type));
+    }
 }
 
 fn copy_from_wayland<T: SelectionTest>() {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1359,11 +1359,26 @@ trait SelectionTest {
         testwl: &mut testwl::Server,
         send_data: impl SendDataForMimeFn,
     ) -> Vec<testwl::PasteData>;
+    fn control_mimes(testwl: &mut testwl::Server) -> Vec<String>;
+    fn control_paste_data(
+        testwl: &mut testwl::Server,
+        send_data: impl SendDataForMimeFn,
+    ) -> Vec<testwl::PasteData>;
+    fn backend(testwl: &testwl::Server) -> Option<testwl::SelectionBackend>;
     fn create_offer(testwl: &mut testwl::Server, data: Vec<testwl::PasteData>);
 }
 
 macro_rules! selection_tests {
-    ($name:ident, $selection_type:ty, $get_mime_fn:ident, $get_paste_data_fn:ident, $create_offer_fn:ident) => {
+    (
+        $name:ident,
+        $selection_type:ty,
+        $get_mime_fn:ident,
+        $get_paste_data_fn:ident,
+        $get_control_mime_fn:ident,
+        $get_control_paste_data_fn:ident,
+        $get_backend_fn:ident,
+        $create_offer_fn:ident
+    ) => {
         impl SelectionTest for $selection_type {
             type SelectionType = $selection_type;
             fn mimes(testwl: &mut testwl::Server) -> Vec<String> {
@@ -1374,6 +1389,18 @@ macro_rules! selection_tests {
                 send_data: impl SendDataForMimeFn,
             ) -> Vec<testwl::PasteData> {
                 testwl.$get_paste_data_fn(send_data)
+            }
+            fn control_mimes(testwl: &mut testwl::Server) -> Vec<String> {
+                testwl.$get_control_mime_fn()
+            }
+            fn control_paste_data(
+                testwl: &mut testwl::Server,
+                send_data: impl SendDataForMimeFn,
+            ) -> Vec<testwl::PasteData> {
+                testwl.$get_control_paste_data_fn(send_data)
+            }
+            fn backend(testwl: &testwl::Server) -> Option<testwl::SelectionBackend> {
+                testwl.$get_backend_fn()
             }
             fn create_offer(testwl: &mut testwl::Server, data: Vec<testwl::PasteData>) {
                 testwl.$create_offer_fn(data);
@@ -1390,6 +1417,16 @@ macro_rules! selection_tests {
             #[test]
             fn copy_from_x11_without_x11_focus() {
                 super::copy_from_x11_without_x11_focus::<$selection_type>();
+            }
+
+            #[test]
+            fn copy_from_x11_without_ext_data_control() {
+                super::copy_from_x11_without_ext_data_control::<$selection_type>();
+            }
+
+            #[test]
+            fn selection_ext_then_core() {
+                super::selection_ext_then_core::<$selection_type>();
             }
 
             #[test]
@@ -1410,6 +1447,9 @@ selection_tests!(
     Clipboard,
     data_source_mimes,
     clipboard_paste_data,
+    control_data_source_mimes,
+    control_clipboard_paste_data,
+    clipboard_source_backend,
     create_data_offer
 );
 selection_tests!(
@@ -1417,6 +1457,9 @@ selection_tests!(
     Primary,
     primary_source_mimes,
     primary_paste_data,
+    control_primary_source_mimes,
+    control_primary_paste_data,
+    primary_source_backend,
     create_primary_offer
 );
 
@@ -1439,6 +1482,8 @@ fn copy_from_x11<T: SelectionTest>() {
     f.satellite.set_selection_source::<T::SelectionType>(&mimes);
     f.run();
 
+    assert_eq!(T::backend(&f.testwl), Some(testwl::SelectionBackend::Core));
+
     let server_mimes = T::mimes(&mut f.testwl);
     for mime in mimes.iter() {
         assert!(server_mimes.contains(&mime.mime_type));
@@ -1452,7 +1497,7 @@ fn copy_from_x11<T: SelectionTest>() {
 }
 
 fn copy_from_x11_without_x11_focus<T: SelectionTest>() {
-    let (mut f, comp) = TestFixture::new_with_compositor();
+    let (mut f, _comp) = TestFixture::new_with_compositor();
 
     let mimes = std::rc::Rc::new(vec![testwl::PasteData {
         mime_type: "text".to_string(),
@@ -1462,13 +1507,68 @@ fn copy_from_x11_without_x11_focus<T: SelectionTest>() {
     f.satellite.set_selection_source::<T::SelectionType>(&mimes);
     f.run();
 
-    let win = Window::new(1);
-    let (_surface, _id) = f.create_toplevel(&comp, win);
+    assert_eq!(
+        T::backend(&f.testwl),
+        Some(testwl::SelectionBackend::ExtDataControl)
+    );
 
-    let server_mimes = T::mimes(&mut f.testwl);
+    let server_mimes = T::control_mimes(&mut f.testwl);
     for mime in mimes.iter() {
         assert!(server_mimes.contains(&mime.mime_type));
     }
+
+    let data = T::control_paste_data(&mut f.testwl, |_, _| {
+        f.satellite.run();
+        true
+    });
+    assert_eq!(*mimes, data);
+}
+
+fn copy_from_x11_without_ext_data_control<T: SelectionTest>() {
+    let mut f = TestFixture::new_pre_connect(|testwl| {
+        testwl.disable_ext_data_control_global();
+    });
+    let comp = f.compositor();
+    let win = Window::new(1);
+    let (_surface, _id) = f.create_toplevel(&comp, win);
+    let mimes = std::rc::Rc::new(vec![testwl::PasteData {
+        mime_type: "text".to_string(),
+        data: b"abc".to_vec(),
+    }]);
+
+    f.satellite.set_selection_source::<T::SelectionType>(&mimes);
+    f.run();
+
+    assert_eq!(T::backend(&f.testwl), Some(testwl::SelectionBackend::Core));
+    assert_eq!(T::mimes(&mut f.testwl), vec!["text"]);
+}
+
+fn selection_ext_then_core<T: SelectionTest>() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let initial = std::rc::Rc::new(vec![testwl::PasteData {
+        mime_type: "initial".to_string(),
+        data: b"ext".to_vec(),
+    }]);
+    f.satellite
+        .set_selection_source::<T::SelectionType>(&initial);
+    f.run();
+    assert_eq!(
+        T::backend(&f.testwl),
+        Some(testwl::SelectionBackend::ExtDataControl)
+    );
+
+    let win = Window::new(1);
+    let (_surface, _id) = f.create_toplevel(&comp, win);
+    let replacement = std::rc::Rc::new(vec![testwl::PasteData {
+        mime_type: "replacement".to_string(),
+        data: b"core".to_vec(),
+    }]);
+    f.satellite
+        .set_selection_source::<T::SelectionType>(&replacement);
+    f.run();
+
+    assert_eq!(T::backend(&f.testwl), Some(testwl::SelectionBackend::Core));
+    assert_eq!(T::mimes(&mut f.testwl), vec!["replacement"]);
 }
 
 fn copy_from_wayland<T: SelectionTest>() {

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -6,11 +6,13 @@ use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
+use wayland_protocols::ext::data_control::v1::server::{
+    ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
+    ext_data_control_manager_v1::{self, ExtDataControlManagerV1},
+    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
+    ext_data_control_source_v1::{self, ExtDataControlSourceV1},
+};
 use wayland_protocols::wp::linux_drm_syncobj::v1::server::wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1;
-use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1;
-use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1;
-use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
-use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1;
 use wayland_protocols::{
     wp::{
         fractional_scale::v1::server::{
@@ -73,10 +75,6 @@ use wayland_server::{
         wl_buffer::WlBuffer,
         wl_callback::WlCallback,
         wl_compositor::WlCompositor,
-        wl_data_device::{self, WlDataDevice},
-        wl_data_device_manager::{self, WlDataDeviceManager},
-        wl_data_offer::{self, WlDataOffer},
-        wl_data_source::{self, WlDataSource},
         wl_keyboard::{self, WlKeyboard},
         wl_output::{self, WlOutput},
         wl_pointer::{self, WlPointer},
@@ -277,12 +275,10 @@ struct State {
     tablet: Option<ZwpTabletV2>,
     tablet_tool: Option<ZwpTabletToolV2>,
     configure_serial: u32,
-    clipboard: Option<WlDataSource>,
-    primary: Option<ZwpPrimarySelectionSourceV1>,
-    data_device_man: Option<WlDataDeviceManager>,
-    data_device: Option<WlDataDevice>,
-    primary_man: Option<ZwpPrimarySelectionDeviceManagerV1>,
-    primary_device: Option<ZwpPrimarySelectionDeviceV1>,
+    clipboard: Option<ExtDataControlSourceV1>,
+    primary: Option<ExtDataControlSourceV1>,
+    data_device_man: Option<ExtDataControlManagerV1>,
+    data_device: Option<ExtDataControlDeviceV1>,
     xdg_activation: Option<XdgActivationV1>,
     valid_tokens: HashSet<String>,
     token_counter: u32,
@@ -311,8 +307,6 @@ impl Default for State {
             configure_serial: 0,
             clipboard: None,
             primary: None,
-            primary_man: None,
-            primary_device: None,
             data_device_man: None,
             data_device: None,
             xdg_activation: None,
@@ -473,8 +467,7 @@ impl Server {
         dh.create_global::<State, WlShm, _>(1, ());
         dh.create_global::<State, XdgWmBase, _>(6, ());
         dh.create_global::<State, WlSeat, _>(5, ());
-        dh.create_global::<State, WlDataDeviceManager, _>(3, ());
-        dh.create_global::<State, ZwpPrimarySelectionDeviceManagerV1, _>(1, ());
+        dh.create_global::<State, ExtDataControlManagerV1, _>(1, ());
         dh.create_global::<State, ZwpTabletManagerV2, _>(1, ());
         dh.create_global::<State, XdgActivationV1, _>(1, ());
         let decorations_global = dh.create_global::<State, ZxdgDecorationManagerV1, _>(1, ());
@@ -780,35 +773,10 @@ impl Server {
     #[track_caller]
     pub fn create_data_offer(&mut self, data: Vec<PasteData>) {
         let Some(dev) = &self.state.data_device else {
-            panic!("No data device created");
+            panic!("No data control device created");
         };
 
         if let Some(selection) = self.state.clipboard.take() {
-            selection.cancelled();
-        }
-
-        let mimes: Vec<_> = data.iter().map(|m| m.mime_type.clone()).collect();
-        let offer = self
-            .client
-            .as_ref()
-            .unwrap()
-            .create_resource::<_, _, State>(&self.dh, 3, data)
-            .unwrap();
-        dev.data_offer(&offer);
-        for mime in mimes {
-            offer.offer(mime);
-        }
-        dev.selection(Some(&offer));
-        self.display.flush_clients().unwrap();
-    }
-
-    #[track_caller]
-    pub fn create_primary_offer(&mut self, data: Vec<PasteData>) {
-        let Some(dev) = &self.state.primary_device else {
-            panic!("No primary device created");
-        };
-
-        if let Some(selection) = self.state.primary.take() {
             selection.cancelled();
         }
 
@@ -828,9 +796,34 @@ impl Server {
     }
 
     #[track_caller]
+    pub fn create_primary_offer(&mut self, data: Vec<PasteData>) {
+        let Some(dev) = &self.state.data_device else {
+            panic!("No data control device created");
+        };
+
+        if let Some(selection) = self.state.primary.take() {
+            selection.cancelled();
+        }
+
+        let mimes: Vec<_> = data.iter().map(|m| m.mime_type.clone()).collect();
+        let offer = self
+            .client
+            .as_ref()
+            .unwrap()
+            .create_resource::<_, _, State>(&self.dh, 1, data)
+            .unwrap();
+        dev.data_offer(&offer);
+        for mime in mimes {
+            offer.offer(mime);
+        }
+        dev.primary_selection(Some(&offer));
+        self.display.flush_clients().unwrap();
+    }
+
+    #[track_caller]
     pub fn empty_data_offer(&mut self) {
         let Some(dev) = &self.state.data_device else {
-            panic!("No data device created");
+            panic!("No data control device created");
         };
 
         if let Some(selection) = self.state.clipboard.take() {
@@ -1171,123 +1164,12 @@ impl Dispatch<WlOutput, ()> for State {
     }
 }
 
-impl GlobalDispatch<ZwpPrimarySelectionDeviceManagerV1, ()> for State {
+impl GlobalDispatch<ExtDataControlManagerV1, ()> for State {
     fn bind(
         state: &mut Self,
         _: &DisplayHandle,
         _: &Client,
-        resource: wayland_server::New<ZwpPrimarySelectionDeviceManagerV1>,
-        _: &(),
-        data_init: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        state.primary_man = Some(data_init.init(resource, ()));
-    }
-}
-
-impl Dispatch<ZwpPrimarySelectionDeviceManagerV1, ()> for State {
-    fn request(
-        state: &mut Self,
-        _: &Client,
-        _: &ZwpPrimarySelectionDeviceManagerV1,
-        request: <ZwpPrimarySelectionDeviceManagerV1 as Resource>::Request,
-        _: &(),
-        _: &DisplayHandle,
-        data_init: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::Request;
-        match request {
-            Request::CreateSource { id } => {
-                data_init.init(id, DataSourceData::default().into());
-            }
-            Request::GetDevice { id, seat } => {
-                state.primary_device = Some(data_init.init(id, seat));
-            }
-            Request::Destroy => {
-                state.primary_man = None;
-            }
-            _ => todo!("{request:?}"),
-        }
-    }
-}
-
-impl Dispatch<ZwpPrimarySelectionOfferV1, Vec<PasteData>> for State {
-    fn request(
-        _: &mut Self,
-        _: &Client,
-        _: &ZwpPrimarySelectionOfferV1,
-        request: <ZwpPrimarySelectionOfferV1 as Resource>::Request,
-        data: &Vec<PasteData>,
-        _: &DisplayHandle,
-        _: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_offer_v1::Request;
-        match request {
-            Request::Receive { mime_type, fd } => {
-                let pos = data
-                    .iter()
-                    .position(|data| data.mime_type == mime_type)
-                    .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
-
-                TransferFd::from(fd).write_all(&data[pos].data).unwrap();
-            }
-            Request::Destroy => {}
-            other => todo!("{other:?}"),
-        }
-    }
-}
-
-impl Dispatch<ZwpPrimarySelectionSourceV1, Mutex<DataSourceData>> for State {
-    fn request(
-        state: &mut Self,
-        _: &Client,
-        _: &ZwpPrimarySelectionSourceV1,
-        request: <ZwpPrimarySelectionSourceV1 as Resource>::Request,
-        data: &Mutex<DataSourceData>,
-        _: &DisplayHandle,
-        _: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::Request;
-        match request {
-            Request::Offer { mime_type } => {
-                data.lock().unwrap().mimes.push(mime_type);
-            }
-            Request::Destroy => {
-                state.primary = None;
-            }
-            _ => todo!("{request:?}"),
-        }
-    }
-}
-
-impl Dispatch<ZwpPrimarySelectionDeviceV1, WlSeat> for State {
-    fn request(
-        state: &mut Self,
-        _: &Client,
-        _: &ZwpPrimarySelectionDeviceV1,
-        request: <ZwpPrimarySelectionDeviceV1 as Resource>::Request,
-        _: &WlSeat,
-        _: &DisplayHandle,
-        _: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::Request;
-        match request {
-            Request::SetSelection { source, .. } => {
-                state.primary = source;
-            }
-            Request::Destroy => {
-                state.primary_device = None;
-            }
-            other => todo!("unhandled request {other:?}"),
-        }
-    }
-}
-
-impl GlobalDispatch<WlDataDeviceManager, ()> for State {
-    fn bind(
-        state: &mut Self,
-        _: &DisplayHandle,
-        _: &Client,
-        resource: wayland_server::New<WlDataDeviceManager>,
+        resource: wayland_server::New<ExtDataControlManagerV1>,
         _: &(),
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
@@ -1295,18 +1177,43 @@ impl GlobalDispatch<WlDataDeviceManager, ()> for State {
     }
 }
 
-impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
+impl Dispatch<ExtDataControlManagerV1, ()> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &ExtDataControlManagerV1,
+        request: <ExtDataControlManagerV1 as Resource>::Request,
+        _: &(),
+        _: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_data_control_manager_v1::Request::CreateDataSource { id } => {
+                data_init.init(id, DataSourceData::default().into());
+            }
+            ext_data_control_manager_v1::Request::GetDataDevice { id, seat } => {
+                state.data_device = Some(data_init.init(id, seat));
+            }
+            ext_data_control_manager_v1::Request::Destroy => {
+                state.data_device_man = None;
+            }
+            _ => todo!("{request:?}"),
+        }
+    }
+}
+
+impl Dispatch<ExtDataControlOfferV1, Vec<PasteData>> for State {
     fn request(
         _: &mut Self,
         _: &Client,
-        _: &WlDataOffer,
-        request: <WlDataOffer as Resource>::Request,
+        _: &ExtDataControlOfferV1,
+        request: <ExtDataControlOfferV1 as Resource>::Request,
         data: &Vec<PasteData>,
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
         match request {
-            wl_data_offer::Request::Receive { mime_type, fd } => {
+            ext_data_control_offer_v1::Request::Receive { mime_type, fd } => {
                 let pos = data
                     .iter()
                     .position(|data| data.mime_type == mime_type)
@@ -1314,75 +1221,60 @@ impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
 
                 TransferFd::from(fd).write_all(&data[pos].data).unwrap();
             }
-            wl_data_offer::Request::Destroy => {}
-            other => todo!("unhandled request: {other:?}"),
+            ext_data_control_offer_v1::Request::Destroy => {}
+            other => todo!("{other:?}"),
         }
     }
 }
 
-impl Dispatch<WlDataSource, Mutex<DataSourceData>> for State {
+impl Dispatch<ExtDataControlSourceV1, Mutex<DataSourceData>> for State {
     fn request(
         state: &mut Self,
         _: &Client,
-        _: &WlDataSource,
-        request: <WlDataSource as Resource>::Request,
+        source: &ExtDataControlSourceV1,
+        request: <ExtDataControlSourceV1 as Resource>::Request,
         data: &Mutex<DataSourceData>,
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        let mut data = data.lock().unwrap();
         match request {
-            wl_data_source::Request::Offer { mime_type } => {
-                data.mimes.push(mime_type);
+            ext_data_control_source_v1::Request::Offer { mime_type } => {
+                data.lock().unwrap().mimes.push(mime_type);
             }
-            wl_data_source::Request::Destroy => {
-                state.clipboard = None;
+            ext_data_control_source_v1::Request::Destroy => {
+                if state.clipboard.as_ref() == Some(source) {
+                    state.clipboard = None;
+                }
+                if state.primary.as_ref() == Some(source) {
+                    state.primary = None;
+                }
             }
-            other => todo!("unhandled request {other:?}"),
+            _ => todo!("{request:?}"),
         }
     }
 }
 
-impl Dispatch<WlDataDevice, WlSeat> for State {
+impl Dispatch<ExtDataControlDeviceV1, WlSeat> for State {
     fn request(
         state: &mut Self,
         _: &Client,
-        _: &WlDataDevice,
-        request: <WlDataDevice as Resource>::Request,
+        _: &ExtDataControlDeviceV1,
+        request: <ExtDataControlDeviceV1 as Resource>::Request,
         _: &WlSeat,
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
         match request {
-            wl_data_device::Request::SetSelection { source, .. } => {
+            ext_data_control_device_v1::Request::SetSelection { source } => {
                 state.clipboard = source;
             }
-            wl_data_device::Request::Release => {
+            ext_data_control_device_v1::Request::SetPrimarySelection { source } => {
+                state.primary = source;
+            }
+            ext_data_control_device_v1::Request::Destroy => {
                 state.data_device = None;
             }
             other => todo!("unhandled request {other:?}"),
-        }
-    }
-}
-
-impl Dispatch<WlDataDeviceManager, ()> for State {
-    fn request(
-        state: &mut Self,
-        _: &Client,
-        _: &WlDataDeviceManager,
-        request: <WlDataDeviceManager as Resource>::Request,
-        _: &(),
-        _: &DisplayHandle,
-        data_init: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        match request {
-            wl_data_device_manager::Request::CreateDataSource { id } => {
-                data_init.init(id, DataSourceData::default().into());
-            }
-            wl_data_device_manager::Request::GetDataDevice { id, seat } => {
-                state.data_device = Some(data_init.init(id, seat));
-            }
-            other => todo!("unhandled request: {other:?}"),
         }
     }
 }

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -9,10 +9,13 @@ use std::time::Instant;
 use wayland_protocols::ext::data_control::v1::server::{
     ext_data_control_device_v1::{self, ExtDataControlDeviceV1},
     ext_data_control_manager_v1::{self, ExtDataControlManagerV1},
-    ext_data_control_offer_v1::{self, ExtDataControlOfferV1},
     ext_data_control_source_v1::{self, ExtDataControlSourceV1},
 };
 use wayland_protocols::wp::linux_drm_syncobj::v1::server::wp_linux_drm_syncobj_manager_v1::WpLinuxDrmSyncobjManagerV1;
+use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::ZwpPrimarySelectionDeviceManagerV1;
+use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::ZwpPrimarySelectionDeviceV1;
+use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_offer_v1::ZwpPrimarySelectionOfferV1;
+use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::ZwpPrimarySelectionSourceV1;
 use wayland_protocols::{
     wp::{
         fractional_scale::v1::server::{
@@ -75,6 +78,10 @@ use wayland_server::{
         wl_buffer::WlBuffer,
         wl_callback::WlCallback,
         wl_compositor::WlCompositor,
+        wl_data_device::{self, WlDataDevice},
+        wl_data_device_manager::{self, WlDataDeviceManager},
+        wl_data_offer::{self, WlDataOffer},
+        wl_data_source::{self, WlDataSource},
         wl_keyboard::{self, WlKeyboard},
         wl_output::{self, WlOutput},
         wl_pointer::{self, WlPointer},
@@ -275,10 +282,16 @@ struct State {
     tablet: Option<ZwpTabletV2>,
     tablet_tool: Option<ZwpTabletToolV2>,
     configure_serial: u32,
-    clipboard: Option<ExtDataControlSourceV1>,
-    primary: Option<ExtDataControlSourceV1>,
-    data_device_man: Option<ExtDataControlManagerV1>,
-    data_device: Option<ExtDataControlDeviceV1>,
+    clipboard: Option<WlDataSource>,
+    primary: Option<ZwpPrimarySelectionSourceV1>,
+    data_device_man: Option<WlDataDeviceManager>,
+    data_device: Option<WlDataDevice>,
+    primary_man: Option<ZwpPrimarySelectionDeviceManagerV1>,
+    primary_device: Option<ZwpPrimarySelectionDeviceV1>,
+    control_clipboard: Option<ExtDataControlSourceV1>,
+    control_primary: Option<ExtDataControlSourceV1>,
+    control_data_device_man: Option<ExtDataControlManagerV1>,
+    control_data_device: Option<ExtDataControlDeviceV1>,
     xdg_activation: Option<XdgActivationV1>,
     valid_tokens: HashSet<String>,
     token_counter: u32,
@@ -307,8 +320,14 @@ impl Default for State {
             configure_serial: 0,
             clipboard: None,
             primary: None,
+            primary_man: None,
+            primary_device: None,
             data_device_man: None,
             data_device: None,
+            control_clipboard: None,
+            control_primary: None,
+            control_data_device_man: None,
+            control_data_device: None,
             xdg_activation: None,
             valid_tokens: HashSet::new(),
             token_counter: 0,
@@ -430,6 +449,7 @@ pub struct Server {
     state: State,
     client: Option<Client>,
     decorations_global: GlobalId,
+    control_global: GlobalId,
 }
 
 pub trait SendDataForMimeFn: FnMut(&str, &mut Server) -> bool {}
@@ -467,7 +487,9 @@ impl Server {
         dh.create_global::<State, WlShm, _>(1, ());
         dh.create_global::<State, XdgWmBase, _>(6, ());
         dh.create_global::<State, WlSeat, _>(5, ());
-        dh.create_global::<State, ExtDataControlManagerV1, _>(1, ());
+        dh.create_global::<State, WlDataDeviceManager, _>(3, ());
+        dh.create_global::<State, ZwpPrimarySelectionDeviceManagerV1, _>(1, ());
+        let control_global = dh.create_global::<State, ExtDataControlManagerV1, _>(1, ());
         dh.create_global::<State, ZwpTabletManagerV2, _>(1, ());
         dh.create_global::<State, XdgActivationV1, _>(1, ());
         let decorations_global = dh.create_global::<State, ZxdgDecorationManagerV1, _>(1, ());
@@ -532,6 +554,7 @@ impl Server {
             state: State::default(),
             client: None,
             decorations_global,
+            control_global,
         }
     }
 
@@ -670,6 +693,46 @@ impl Server {
         data.mimes.to_vec()
     }
 
+    #[track_caller]
+    pub fn control_data_source_mimes(&self) -> Vec<String> {
+        let Some(selection) = &self.state.control_clipboard else {
+            panic!("No selection set on ext data control device");
+        };
+
+        let data: &Mutex<DataSourceData> = selection.data().unwrap();
+        data.lock().unwrap().mimes.to_vec()
+    }
+
+    #[track_caller]
+    pub fn control_primary_source_mimes(&self) -> Vec<String> {
+        let Some(selection) = &self.state.control_primary else {
+            panic!("No primary selection set on ext data control device");
+        };
+
+        let data: &Mutex<DataSourceData> = selection.data().unwrap();
+        data.lock().unwrap().mimes.to_vec()
+    }
+
+    pub fn clipboard_source_backend(&self) -> Option<SelectionBackend> {
+        if self.state.clipboard.is_some() {
+            Some(SelectionBackend::Core)
+        } else if self.state.control_clipboard.is_some() {
+            Some(SelectionBackend::ExtDataControl)
+        } else {
+            None
+        }
+    }
+
+    pub fn primary_source_backend(&self) -> Option<SelectionBackend> {
+        if self.state.primary.is_some() {
+            Some(SelectionBackend::Core)
+        } else if self.state.control_primary.is_some() {
+            Some(SelectionBackend::ExtDataControl)
+        } else {
+            None
+        }
+    }
+
     fn paste_impl(
         &mut self,
         data: &Mutex<DataSourceData>,
@@ -766,6 +829,42 @@ impl Server {
         ret
     }
 
+    #[track_caller]
+    pub fn control_clipboard_paste_data(
+        &mut self,
+        send_data_for_mime: impl SendDataForMimeFn,
+    ) -> Vec<PasteData> {
+        let Some(selection) = self.state.control_clipboard.take() else {
+            panic!("No selection set on ext data control device");
+        };
+
+        let ret = self.paste_impl(
+            selection.data().unwrap(),
+            send_data_for_mime,
+            |mime_type, fd| selection.send(mime_type, fd),
+        );
+        self.state.control_clipboard = Some(selection);
+        ret
+    }
+
+    #[track_caller]
+    pub fn control_primary_paste_data(
+        &mut self,
+        send_data_for_mime: impl SendDataForMimeFn,
+    ) -> Vec<PasteData> {
+        let Some(selection) = self.state.control_primary.take() else {
+            panic!("No primary selection set on ext data control device");
+        };
+
+        let ret = self.paste_impl(
+            selection.data().unwrap(),
+            send_data_for_mime,
+            |mime_type, fd| selection.send(mime_type, fd),
+        );
+        self.state.control_primary = Some(selection);
+        ret
+    }
+
     pub fn data_source_exists(&self) -> bool {
         self.state.clipboard.is_none()
     }
@@ -773,10 +872,41 @@ impl Server {
     #[track_caller]
     pub fn create_data_offer(&mut self, data: Vec<PasteData>) {
         let Some(dev) = &self.state.data_device else {
-            panic!("No data control device created");
+            panic!("No data device created");
         };
 
         if let Some(selection) = self.state.clipboard.take() {
+            selection.cancelled();
+        }
+        if let Some(selection) = self.state.control_clipboard.take() {
+            selection.cancelled();
+        }
+
+        let mimes: Vec<_> = data.iter().map(|m| m.mime_type.clone()).collect();
+        let offer = self
+            .client
+            .as_ref()
+            .unwrap()
+            .create_resource::<_, _, State>(&self.dh, 3, data)
+            .unwrap();
+        dev.data_offer(&offer);
+        for mime in mimes {
+            offer.offer(mime);
+        }
+        dev.selection(Some(&offer));
+        self.display.flush_clients().unwrap();
+    }
+
+    #[track_caller]
+    pub fn create_primary_offer(&mut self, data: Vec<PasteData>) {
+        let Some(dev) = &self.state.primary_device else {
+            panic!("No primary device created");
+        };
+
+        if let Some(selection) = self.state.primary.take() {
+            selection.cancelled();
+        }
+        if let Some(selection) = self.state.control_primary.take() {
             selection.cancelled();
         }
 
@@ -796,37 +926,15 @@ impl Server {
     }
 
     #[track_caller]
-    pub fn create_primary_offer(&mut self, data: Vec<PasteData>) {
-        let Some(dev) = &self.state.data_device else {
-            panic!("No data control device created");
-        };
-
-        if let Some(selection) = self.state.primary.take() {
-            selection.cancelled();
-        }
-
-        let mimes: Vec<_> = data.iter().map(|m| m.mime_type.clone()).collect();
-        let offer = self
-            .client
-            .as_ref()
-            .unwrap()
-            .create_resource::<_, _, State>(&self.dh, 1, data)
-            .unwrap();
-        dev.data_offer(&offer);
-        for mime in mimes {
-            offer.offer(mime);
-        }
-        dev.primary_selection(Some(&offer));
-        self.display.flush_clients().unwrap();
-    }
-
-    #[track_caller]
     pub fn empty_data_offer(&mut self) {
         let Some(dev) = &self.state.data_device else {
-            panic!("No data control device created");
+            panic!("No data device created");
         };
 
         if let Some(selection) = self.state.clipboard.take() {
+            selection.cancelled();
+        }
+        if let Some(selection) = self.state.control_clipboard.take() {
             selection.cancelled();
         }
 
@@ -945,6 +1053,12 @@ impl Server {
             .remove_global::<State>(self.decorations_global.clone());
     }
 
+    pub fn disable_ext_data_control_global(&self) {
+        self.display
+            .handle()
+            .remove_global::<State>(self.control_global.clone());
+    }
+
     #[track_caller]
     pub fn get_buffer_dimensions(&self, buffer: &WlBuffer) -> Vec2 {
         *self
@@ -953,6 +1067,12 @@ impl Server {
             .get(buffer)
             .expect("buffer does not exist!")
     }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum SelectionBackend {
+    Core,
+    ExtDataControl,
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -1164,6 +1284,232 @@ impl Dispatch<WlOutput, ()> for State {
     }
 }
 
+impl GlobalDispatch<ZwpPrimarySelectionDeviceManagerV1, ()> for State {
+    fn bind(
+        state: &mut Self,
+        _: &DisplayHandle,
+        _: &Client,
+        resource: wayland_server::New<ZwpPrimarySelectionDeviceManagerV1>,
+        _: &(),
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        state.primary_man = Some(data_init.init(resource, ()));
+    }
+}
+
+impl Dispatch<ZwpPrimarySelectionDeviceManagerV1, ()> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &ZwpPrimarySelectionDeviceManagerV1,
+        request: <ZwpPrimarySelectionDeviceManagerV1 as Resource>::Request,
+        _: &(),
+        _: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_manager_v1::Request;
+        match request {
+            Request::CreateSource { id } => {
+                data_init.init(id, DataSourceData::default().into());
+            }
+            Request::GetDevice { id, seat } => {
+                state.primary_device = Some(data_init.init(id, seat));
+            }
+            Request::Destroy => {
+                state.primary_man = None;
+            }
+            _ => todo!("{request:?}"),
+        }
+    }
+}
+
+impl Dispatch<ZwpPrimarySelectionOfferV1, Vec<PasteData>> for State {
+    fn request(
+        _: &mut Self,
+        _: &Client,
+        _: &ZwpPrimarySelectionOfferV1,
+        request: <ZwpPrimarySelectionOfferV1 as Resource>::Request,
+        data: &Vec<PasteData>,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_offer_v1::Request;
+        match request {
+            Request::Receive { mime_type, fd } => {
+                let pos = data
+                    .iter()
+                    .position(|data| data.mime_type == mime_type)
+                    .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
+
+                TransferFd::from(fd).write_all(&data[pos].data).unwrap();
+            }
+            Request::Destroy => {}
+            other => todo!("{other:?}"),
+        }
+    }
+}
+
+impl Dispatch<ZwpPrimarySelectionSourceV1, Mutex<DataSourceData>> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        source: &ZwpPrimarySelectionSourceV1,
+        request: <ZwpPrimarySelectionSourceV1 as Resource>::Request,
+        data: &Mutex<DataSourceData>,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_source_v1::Request;
+        match request {
+            Request::Offer { mime_type } => {
+                data.lock().unwrap().mimes.push(mime_type);
+            }
+            Request::Destroy => {
+                if state.primary.as_ref() == Some(source) {
+                    state.primary = None;
+                }
+            }
+            _ => todo!("{request:?}"),
+        }
+    }
+}
+
+impl Dispatch<ZwpPrimarySelectionDeviceV1, WlSeat> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &ZwpPrimarySelectionDeviceV1,
+        request: <ZwpPrimarySelectionDeviceV1 as Resource>::Request,
+        _: &WlSeat,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        use wayland_protocols::wp::primary_selection::zv1::server::zwp_primary_selection_device_v1::Request;
+        match request {
+            Request::SetSelection { source, .. } => {
+                if let Some(selection) = state.control_primary.take() {
+                    selection.cancelled();
+                }
+                state.primary = source;
+            }
+            Request::Destroy => {
+                state.primary_device = None;
+            }
+            other => todo!("unhandled request {other:?}"),
+        }
+    }
+}
+
+impl GlobalDispatch<WlDataDeviceManager, ()> for State {
+    fn bind(
+        state: &mut Self,
+        _: &DisplayHandle,
+        _: &Client,
+        resource: wayland_server::New<WlDataDeviceManager>,
+        _: &(),
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        state.data_device_man = Some(data_init.init(resource, ()));
+    }
+}
+
+impl Dispatch<WlDataOffer, Vec<PasteData>> for State {
+    fn request(
+        _: &mut Self,
+        _: &Client,
+        _: &WlDataOffer,
+        request: <WlDataOffer as Resource>::Request,
+        data: &Vec<PasteData>,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            wl_data_offer::Request::Receive { mime_type, fd } => {
+                let pos = data
+                    .iter()
+                    .position(|data| data.mime_type == mime_type)
+                    .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
+
+                TransferFd::from(fd).write_all(&data[pos].data).unwrap();
+            }
+            wl_data_offer::Request::Destroy => {}
+            other => todo!("unhandled request: {other:?}"),
+        }
+    }
+}
+
+impl Dispatch<WlDataSource, Mutex<DataSourceData>> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        source: &WlDataSource,
+        request: <WlDataSource as Resource>::Request,
+        data: &Mutex<DataSourceData>,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        let mut data = data.lock().unwrap();
+        match request {
+            wl_data_source::Request::Offer { mime_type } => {
+                data.mimes.push(mime_type);
+            }
+            wl_data_source::Request::Destroy => {
+                if state.clipboard.as_ref() == Some(source) {
+                    state.clipboard = None;
+                }
+            }
+            other => todo!("unhandled request {other:?}"),
+        }
+    }
+}
+
+impl Dispatch<WlDataDevice, WlSeat> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &WlDataDevice,
+        request: <WlDataDevice as Resource>::Request,
+        _: &WlSeat,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            wl_data_device::Request::SetSelection { source, .. } => {
+                if let Some(selection) = state.control_clipboard.take() {
+                    selection.cancelled();
+                }
+                state.clipboard = source;
+            }
+            wl_data_device::Request::Release => {
+                state.data_device = None;
+            }
+            other => todo!("unhandled request {other:?}"),
+        }
+    }
+}
+
+impl Dispatch<WlDataDeviceManager, ()> for State {
+    fn request(
+        state: &mut Self,
+        _: &Client,
+        _: &WlDataDeviceManager,
+        request: <WlDataDeviceManager as Resource>::Request,
+        _: &(),
+        _: &DisplayHandle,
+        data_init: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            wl_data_device_manager::Request::CreateDataSource { id } => {
+                data_init.init(id, DataSourceData::default().into());
+            }
+            wl_data_device_manager::Request::GetDataDevice { id, seat } => {
+                state.data_device = Some(data_init.init(id, seat));
+            }
+            other => todo!("unhandled request: {other:?}"),
+        }
+    }
+}
+
 impl GlobalDispatch<ExtDataControlManagerV1, ()> for State {
     fn bind(
         state: &mut Self,
@@ -1173,7 +1519,7 @@ impl GlobalDispatch<ExtDataControlManagerV1, ()> for State {
         _: &(),
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        state.data_device_man = Some(data_init.init(resource, ()));
+        state.control_data_device_man = Some(data_init.init(resource, ()));
     }
 }
 
@@ -1192,37 +1538,12 @@ impl Dispatch<ExtDataControlManagerV1, ()> for State {
                 data_init.init(id, DataSourceData::default().into());
             }
             ext_data_control_manager_v1::Request::GetDataDevice { id, seat } => {
-                state.data_device = Some(data_init.init(id, seat));
+                state.control_data_device = Some(data_init.init(id, seat));
             }
             ext_data_control_manager_v1::Request::Destroy => {
-                state.data_device_man = None;
+                state.control_data_device_man = None;
             }
-            _ => todo!("{request:?}"),
-        }
-    }
-}
-
-impl Dispatch<ExtDataControlOfferV1, Vec<PasteData>> for State {
-    fn request(
-        _: &mut Self,
-        _: &Client,
-        _: &ExtDataControlOfferV1,
-        request: <ExtDataControlOfferV1 as Resource>::Request,
-        data: &Vec<PasteData>,
-        _: &DisplayHandle,
-        _: &mut wayland_server::DataInit<'_, Self>,
-    ) {
-        match request {
-            ext_data_control_offer_v1::Request::Receive { mime_type, fd } => {
-                let pos = data
-                    .iter()
-                    .position(|data| data.mime_type == mime_type)
-                    .unwrap_or_else(|| panic!("Invalid mime type: {mime_type}"));
-
-                TransferFd::from(fd).write_all(&data[pos].data).unwrap();
-            }
-            ext_data_control_offer_v1::Request::Destroy => {}
-            other => todo!("{other:?}"),
+            _ => unreachable!(),
         }
     }
 }
@@ -1242,14 +1563,14 @@ impl Dispatch<ExtDataControlSourceV1, Mutex<DataSourceData>> for State {
                 data.lock().unwrap().mimes.push(mime_type);
             }
             ext_data_control_source_v1::Request::Destroy => {
-                if state.clipboard.as_ref() == Some(source) {
-                    state.clipboard = None;
+                if state.control_clipboard.as_ref() == Some(source) {
+                    state.control_clipboard = None;
                 }
-                if state.primary.as_ref() == Some(source) {
-                    state.primary = None;
+                if state.control_primary.as_ref() == Some(source) {
+                    state.control_primary = None;
                 }
             }
-            _ => todo!("{request:?}"),
+            _ => unreachable!(),
         }
     }
 }
@@ -1266,15 +1587,27 @@ impl Dispatch<ExtDataControlDeviceV1, WlSeat> for State {
     ) {
         match request {
             ext_data_control_device_v1::Request::SetSelection { source } => {
-                state.clipboard = source;
+                if let Some(selection) = state.clipboard.take() {
+                    selection.cancelled();
+                }
+                if let Some(old) = state.control_clipboard.take() {
+                    old.cancelled();
+                }
+                state.control_clipboard = source;
             }
             ext_data_control_device_v1::Request::SetPrimarySelection { source } => {
-                state.primary = source;
+                if let Some(selection) = state.primary.take() {
+                    selection.cancelled();
+                }
+                if let Some(old) = state.control_primary.take() {
+                    old.cancelled();
+                }
+                state.control_primary = source;
             }
             ext_data_control_device_v1::Request::Destroy => {
-                state.data_device = None;
+                state.control_data_device = None;
             }
-            other => todo!("unhandled request {other:?}"),
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
## Symptom

X11 apps that set the clipboard before any of their X11 windows have received Wayland keyboard focus end up with their data source created on the Wayland side but never registered with the compositor — Wayland clients see an empty clipboard.

The triggering case is Electron run with `--ozone-platform=wayland`. Its windows are Wayland-native (so satellite never sees their keyboard focus) but Chromium still keeps the X11 connection open and routes `clipboard.writeText` through it. `xwayland_satellite::xstate::selection::handle_target_list` fires and calls `server_state.set_selection_source`, but `last_kb_serial` is `None` so the `wl_data_device.set_selection` call is silently skipped.

Reproducer: QQ NT on niri 25.08 + xwayland-satellite 0.8.1. `xclip -selection clipboard -o` (X11) returns the copied content, `wl-paste` (Wayland) returns nothing, X11-only apps like WeChat can paste it fine.

## Why an input serial isn't the right answer

`wl_data_device.set_selection` needs a recent input event serial because the protocol gates "background clients changing the clipboard" behind "user just interacted with you". For a clipboard bridge that's the wrong layer — there is no user interaction to point at, and `ext-data-control-v1` was added precisely to give privileged clients (clipboard managers, X11 bridges, …) a serial-free path. One device handles both regular selection and primary selection, and the `set_selection` / `set_primary_selection` requests take no serial.

## Change

Replace satellite's `wl_data_device` + `zwp_primary_selection_device_v1` use with `ext-data-control-v1`. On compositors that don't expose the protocol (Mutter, Weston) the bridge is disabled with a log message — those compositors all have their own built-in Xwayland integration and xwayland-satellite sees little use there.

Mechanically:

- Drop the smithay-client-toolkit `data_device` / `primary_selection` delegates and hand-write the four `Dispatch` impls (manager, device, source, offer).
- Selection slots no longer carry a per-protocol Source/Offer type. Clipboard vs Primary is picked at the device call site (`set_selection` vs `set_primary_selection`).
- Drop the keyboard-serial path on the X11→Wayland side. `last_kb_serial` stays around because xdg_activation still uses it; it's just no longer load-bearing for selection.
- testwl now serves ext-data-control instead of wl_data_device + zwp_primary_selection. The existing selection tests exercise the new wire path unchanged.

## Test

`copy_from_x11_without_x11_focus` (one variant per selection type, six lines in `tests.rs`) reproduces the bug: it calls `set_selection_source` before `create_toplevel` and then asserts the mimes show up. On main it panics with `No selection set on data device` (and `No selection set on primary device` for the primary variant). On this branch it passes, alongside the 48 pre-existing selection tests.

If you'd like to confirm the bug exists on main, the new test in `src/server/tests.rs` is self-contained — cherry-pick that test function plus the two macro lines onto main and `cargo test --lib copy_from_x11_without_x11_focus` will panic with `No selection set on data device` / `No selection set on primary device`.

## Compositor coverage

`ext-data-control-v1` is supported on the compositors that are satellite's actual audience — niri, COSMIC, recent sway / hyprland, and so on. Older wlroots-based versions that only ship `wlr-data-control-unstable-v1` lose the bridge until they pick up `ext-`; a fallback path is straightforward to add in a follow-up if that matters. KDE Plasma, GNOME Mutter, and Weston also don't expose `ext-data-control-v1`, but they all have built-in Xwayland integration of their own, so xwayland-satellite sees little use there in practice.
