### PR TITLE
feat: `-enable-ei-portal` flag for XWayland emulated input support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             &xsock_xwl.as_raw_fd().to_string(),
             "-displayfd",
             &ready_tx.as_raw_fd().to_string(),
+            "-enable-ei-portal",
         ])
         .args(data.flags())
         .env("WAYLAND_DISPLAY", socket.socket_name().unwrap())


### PR DESCRIPTION
closes #432

i figured i would follow the pattern you've got for other flags of making them user-configurable and generally pass-through. if you'd prefer it just always being on or being opt-out, i can make that change.