### PR TITLE
fix: handle late scale events for removed outputs

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -1026,7 +1026,10 @@ fn update_output_scale(
     mut output_scale: hecs::QueryOne<&mut OutputScaleFactor>,
     factor: OutputScaleFactor,
 ) -> bool {
-    let output_scale = output_scale.get().unwrap();
+    let Some(output_scale) = output_scale.get() else {
+        return false;
+    };
+
     if matches!(output_scale, OutputScaleFactor::Fractional(..))
         && matches!(factor, OutputScaleFactor::Output(..))
     {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1886,6 +1886,19 @@ fn remove_all_outputs() {
 }
 
 #[test]
+fn late_output_scale_after_remove_output() {
+    let (mut f, _) = TestFixture::new_with_compositor();
+
+    let (_, output) = f.new_output(0, 0);
+    f.run();
+
+    f.remove_output(output.clone());
+    output.scale(2);
+    output.done();
+    f.run();
+}
+
+#[test]
 fn output_offset_surface_positioning() {
     let (mut f, comp) = TestFixture::new_with_compositor();
 


### PR DESCRIPTION
Compositor output reconfiguration can remove an output global while events for the old `wl_output` object are still queued. During removal we strip `OutputScaleFactor` from the output entity, but a later `wl_output.scale` event still tried to update that component and unwrapped the missing query result.

Treat a missing `OutputScaleFactor` as a stale output event and ignore it instead of panicking. Add a regression test that removes an output and then delivers a late scale event for the same `wl_output`.