### PR TITLE
fix: guarantee `wl_output::geometry` is sent on global bind 

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -1272,7 +1272,6 @@ impl OutputEvent {
                     state,
                 );
                 let global_output_offset = state.global_output_offset;
-                let global_offset_updated = state.global_offset_updated;
 
                 let Ok((output, dimensions, xdg)) = state.world.query_one_mut::<(
                     &WlOutput,
@@ -1282,18 +1281,16 @@ impl OutputEvent {
                     return;
                 };
 
-                if !global_offset_updated {
-                    output.geometry(
-                        x - global_output_offset.x.value,
-                        y - global_output_offset.y.value,
-                        physical_width,
-                        physical_height,
-                        convert_wenum(subpixel),
-                        make,
-                        model,
-                        convert_wenum(transform),
-                    );
-                }
+                output.geometry(
+                    x - global_output_offset.x.value,
+                    y - global_output_offset.y.value,
+                    physical_width,
+                    physical_height,
+                    convert_wenum(subpixel),
+                    make,
+                    model,
+                    convert_wenum(transform),
+                );
                 dimensions.rotated_90 = transform.into_result().is_ok_and(|t| {
                     matches!(
                         t,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -505,7 +505,7 @@ impl<C: XConnection> TestFixture<C> {
         TestObject<WlOutput>,
         wayland_server::protocol::wl_output::WlOutput,
     ) {
-        self.testwl.new_output(x, y);
+        self.testwl.new_output();
         self.run();
         self.run();
         let mut events = std::mem::take(&mut *self.registry.data.events.lock().unwrap());
@@ -530,7 +530,7 @@ impl<C: XConnection> TestFixture<C> {
         );
         self.run();
         self.run();
-        (output, self.testwl.finalize_output())
+        (output, self.testwl.finalize_output(x, y))
     }
 
     fn remove_output(&mut self, output_s: wayland_server::protocol::wl_output::WlOutput) {
@@ -1056,7 +1056,7 @@ fn pass_through_globals() {
     use wayland_client::protocol::wl_output::WlOutput;
 
     let mut f = TestFixture::new();
-    f.testwl.new_output(0, 0);
+    f.testwl.new_output();
     f.testwl.enable_xdg_output_manager();
     f.run();
     f.run();
@@ -1717,6 +1717,7 @@ fn popup_no_focus_input_hint_wm_take_focus() {
 #[track_caller]
 fn check_output_position_event(output: &TestObject<WlOutput>, pos: (i32, i32)) {
     let mut geo = None;
+    let mut done = false;
     let events = std::mem::take(&mut *output.data.events.lock().unwrap());
     log::debug!("events: {events:?}");
     for event in events {
@@ -1725,19 +1726,16 @@ fn check_output_position_event(output: &TestObject<WlOutput>, pos: (i32, i32)) {
                 geo = Some((x, y));
             }
             wl_output::Event::Done => {
-                if let Some(geo) = geo {
-                    assert_eq!(geo, pos);
-                    return;
-                }
+                done = true;
             }
             _ => {}
         }
     }
-    if geo.is_none() {
+    assert!(done, "Did not receive a done event");
+    let Some(geo) = geo else {
         panic!("Did not receive any geometry events");
-    } else {
-        panic!("Did not receive a done event");
-    }
+    };
+    assert_eq!(geo, pos);
 }
 
 #[track_caller]
@@ -1802,6 +1800,7 @@ fn output_offset_multi_output() {
 
     let (output_obj_2, _) = f.new_output(0, 1000);
     f.run();
+    f.run();
     check_output_position_event(&output_obj_1, (1000, 0));
     check_output_position_event(&output_obj_2, (0, 1000));
 
@@ -1825,18 +1824,18 @@ fn output_offset_multi_output_xdg() {
     let man = f.enable_xdg_output();
 
     let (output_obj_1, output_1) = f.new_output(0, 0);
+    let output_xdg_1 = f.create_xdg_output(&man, output_obj_1.obj.clone());
     f.run();
     std::mem::take(&mut *output_obj_1.data.events.lock().unwrap());
-    let output_xdg_1 = f.create_xdg_output(&man, output_obj_1.obj.clone());
     f.testwl.move_xdg_output(&output_1, 1000, 0);
     f.run();
     f.run();
     check_output_position_event_xdg(&output_xdg_1, &output_obj_1, (0, 0), true);
 
     let (output_obj_2, output_2) = f.new_output(1000, 1000);
+    let output_xdg_2 = f.create_xdg_output(&man, output_obj_2.obj.clone());
     f.run();
     std::mem::take(&mut *output_obj_2.data.events.lock().unwrap());
-    let output_xdg_2 = f.create_xdg_output(&man, output_obj_2.obj.clone());
     f.testwl.move_xdg_output(&output_2, 0, 1000);
     f.run();
     f.run();
@@ -1863,6 +1862,7 @@ fn output_offset_remove_output() {
 
     let (output_ext_c, output_ext) = f.new_output(0, 0);
     let (output_main_c, _) = f.new_output(1000, 500);
+    f.run();
     f.run();
 
     check_output_position_event(&output_ext_c, (0, 0));
@@ -1980,7 +1980,8 @@ fn output_offset_xdg_override() {
 
     let man = f.enable_xdg_output();
     f.create_xdg_output(&man, output_obj.obj.clone());
-    // testwl inits xdg output position to 0, and it should take priority over wl_output position
+    f.testwl.move_xdg_output(&output, 0, 0);
+    f.run();
     test_position(&f, 0, 0);
 
     f.testwl.move_xdg_output(&output, 1000, 22);
@@ -2059,9 +2060,9 @@ fn output_offset_negative_position_update_xdg() {
     check_output_position_event(&output, (0, 0));
 
     let (output2, output_s) = f.new_output(0, 0);
+    let xdg_output = f.create_xdg_output(&xdg, output2.obj.clone());
     f.run();
     std::mem::take(&mut *output2.data.events.lock().unwrap());
-    let xdg_output = f.create_xdg_output(&xdg, output2.obj.clone());
     f.testwl.move_xdg_output(&output_s, 0, -1000);
     f.run();
     f.run();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -316,9 +316,9 @@ impl Fixture {
     }
 
     fn create_output(&mut self, x: i32, y: i32) -> wayland_server::protocol::wl_output::WlOutput {
-        self.testwl.new_output(x, y);
+        self.testwl.new_output();
         self.wait_and_dispatch();
-        self.testwl.finalize_output()
+        self.testwl.finalize_output(x, y)
     }
 }
 
@@ -1501,8 +1501,8 @@ fn close_window() {
 #[test]
 fn primary_output() {
     let mut f = Fixture::new_preset(|testwl| {
-        testwl.new_output(0, 0); // WL-1
-        testwl.new_output(500, 500); // WL-2
+        testwl.new_output(); // WL-1
+        testwl.new_output(); // WL-2
     });
     let mut conn = Connection::new(&f.display);
 
@@ -1971,6 +1971,9 @@ fn forced_1x_scale_consistent_x11_size() {
     let mut f = Fixture::new();
     f.testwl.enable_xdg_output_manager();
     let output = f.create_output(0, 0);
+    let xdg_out = f.testwl.get_xdg_output(&output).unwrap();
+    xdg_out.logical_position(0, 0);
+    xdg_out.logical_size(1000, 1000);
     output.scale(2);
     output.done();
 
@@ -2290,9 +2293,8 @@ fn popup_heuristics() {
 
 #[test]
 fn xsettings_scale() {
-    let mut f = Fixture::new_preset(|testwl| {
-        testwl.new_output(0, 0); // WL-1
-    });
+    let mut f = Fixture::new();
+    f.create_output(0, 0);
     let connection = Connection::new(&f.display);
     f.testwl.enable_xdg_output_manager();
 
@@ -2339,13 +2341,11 @@ fn xsettings_scale() {
 #[test]
 fn xsettings_fractional_scale() {
     let mut f = Fixture::new_preset(|testwl| {
-        testwl.new_output(0, 0); // WL-1
         testwl.enable_fractional_scale();
     });
     let mut connection = Connection::new(&f.display);
     f.testwl.enable_xdg_output_manager();
-
-    let output = f.testwl.finalize_output();
+    let output = f.create_output(0, 0); // WL-1
 
     let window = connection.new_window(connection.root, 0, 0, 20, 20, false);
     let surface = f.map_as_toplevel(&mut connection, window);
@@ -2476,7 +2476,7 @@ fn xsettings_switch_owner() {
 fn rotated_output() {
     let mut f = Fixture::new_preset(|testwl| {
         testwl.enable_xdg_output_manager();
-        testwl.new_output(0, 0);
+        testwl.new_output();
     });
     let mut connection = Connection::new(&f.display);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1823,6 +1823,98 @@ fn negative_output_coordinates() {
 }
 
 #[test]
+fn output_offset_xdg_matches_crtcs() {
+    let mut f = Fixture::new_preset(|testwl| {
+        testwl.enable_xdg_output_manager();
+    });
+    let connection = Connection::new(&f.display);
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct OutputInfo {
+        name: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+    let mut outputs = vec![
+        OutputInfo {
+            name: "WL-1".into(),
+            x: 2560,
+            y: 0,
+            width: 1920,
+            height: 1080,
+        },
+        OutputInfo {
+            name: "WL-2".into(),
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1440,
+        },
+    ];
+
+    // WL-1 is added first, then WL-2. They are positioned so the addition of WL-2 triggers a
+    // global output offset change. Additionally, they specify wl_output and zxdg_output
+    // simultaneously, meaning when the global offset change code is ran, they will always use the
+    // Xdg output codepath. This leaves only the required wl_output::geometry event sent at global
+    // binding to be forwarded to Xwayland.
+    for info in outputs.iter() {
+        let out = f.create_output(info.x, info.y);
+        out.geometry(
+            info.x,
+            info.y,
+            16,
+            9,
+            wl_output::Subpixel::Unknown,
+            "satellite".into(),
+            info.name.clone(),
+            wl_output::Transform::Normal,
+        );
+        out.mode(wl_output::Mode::Current, info.width, info.height, 60);
+        out.name(info.name.clone());
+        out.done();
+        let out_xdg = f.testwl.get_xdg_output(&out).unwrap();
+        out_xdg.logical_position(info.x, info.y);
+        out_xdg.logical_size(info.width, info.height);
+        out_xdg.done();
+        f.testwl.dispatch();
+    }
+
+    // Give Xwayland time to respond to all of the events
+    std::thread::sleep(Duration::from_millis(50));
+    // If the required wl_output::geometry event on binding is not sent, Xwayland will leave the
+    // cathode-ray tube controller (CRTC; a representation of the area to be sent to output(s) in
+    // RandR) with an uninitialized rotation, which swaps the width and height of the CRTC.
+    let resources = connection.get_reply(&xcb::randr::GetScreenResources {
+        window: connection.root,
+    });
+    assert_eq!(resources.outputs().len(), 2);
+    for output in resources.outputs().iter().copied() {
+        let output_reply = connection.get_reply(&xcb::randr::GetOutputInfo {
+            output,
+            config_timestamp: resources.config_timestamp(),
+        });
+        let name = std::str::from_utf8(output_reply.name()).unwrap();
+        let info_idx = outputs.iter().position(|o| o.name == name).unwrap();
+        let crtc_reply = connection.get_reply(&xcb::randr::GetCrtcInfo {
+            crtc: output_reply.crtc(),
+            config_timestamp: resources.config_timestamp(),
+        });
+        let crtc_info = OutputInfo {
+            name: name.into(),
+            x: crtc_reply.x() as _,
+            y: crtc_reply.y() as _,
+            width: crtc_reply.width() as _,
+            height: crtc_reply.height() as _,
+        };
+        assert_eq!(crtc_info, outputs[info_idx]);
+        assert_eq!(crtc_reply.rotation(), xcb::randr::Rotation::ROTATE_0);
+        outputs.swap_remove(info_idx);
+    }
+}
+
+#[test]
 fn xdg_decorations() {
     let mut f = Fixture::new();
     let mut connection = Connection::new(&f.display);

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -581,10 +581,23 @@ impl Server {
     /// This function must be called after the globals have been dispatched in order to use the
     /// output on the server side created by `new_output` (this function's return value).
     #[track_caller]
-    pub fn finalize_output(&mut self) -> WlOutput {
+    pub fn finalize_output(&mut self, x: i32, y: i32) -> WlOutput {
         let output_s = self.state.last_output.take().expect("No new outputs");
         let output_data = self.state.outputs.get_mut(&output_s).unwrap();
         output_data.global_id = self.state.last_output_global.take();
+        output_s.geometry(
+            x,
+            y,
+            0,
+            0,
+            wl_output::Subpixel::None,
+            "xwls".to_string(),
+            "fake monitor".to_string(),
+            wl_output::Transform::Normal,
+        );
+        output_s.mode(wl_output::Mode::Current, 1000, 1000, 0);
+        output_s.done();
+        self.dispatch();
         output_s
     }
 
@@ -851,9 +864,8 @@ impl Server {
         self.display.flush_clients().unwrap();
     }
 
-    pub fn new_output(&mut self, x: i32, y: i32) {
-        self.state.last_output_global =
-            Some(self.dh.create_global::<State, WlOutput, _>(4, (x, y)));
+    pub fn new_output(&mut self) {
+        self.state.last_output_global = Some(self.dh.create_global::<State, WlOutput, _>(4, ()));
         self.display.flush_clients().unwrap();
     }
 
@@ -1121,18 +1133,20 @@ impl Dispatch<ZxdgOutputV1, WlOutput> for State {
     }
 }
 
-impl GlobalDispatch<WlOutput, (i32, i32)> for State {
+impl GlobalDispatch<WlOutput, ()> for State {
     fn bind(
         state: &mut Self,
         _: &DisplayHandle,
         _: &Client,
         resource: wayland_server::New<WlOutput>,
-        &(_x, _y): &(i32, i32),
+        _: &(),
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         let output = data_init.init(resource, ());
         state.output_counter += 1;
         let name = format!("WL-{}", state.output_counter);
+        output.name(name.clone());
+        output.done();
         state.outputs.insert(
             output.clone(),
             Output {

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -864,6 +864,10 @@ impl Server {
             .find_map(|(output, data)| (data.name == name).then_some(output.clone()))
     }
 
+    pub fn get_xdg_output(&mut self, output: &WlOutput) -> Option<ZxdgOutputV1> {
+        self.state.outputs[output].xdg.clone()
+    }
+
     pub fn move_output(&mut self, output: &WlOutput, x: i32, y: i32) {
         output.geometry(
             x,
@@ -1091,9 +1095,6 @@ impl Dispatch<ZxdgOutputManagerV1, ()> for State {
         match request {
             zxdg_output_manager_v1::Request::GetXdgOutput { id, output } => {
                 let xdg = data_init.init(id, output.clone());
-                xdg.logical_position(0, 0);
-                xdg.logical_size(1000, 1000);
-                xdg.done();
                 state.outputs.get_mut(&output).unwrap().xdg = Some(xdg);
             }
             other => todo!("unhandled request: {other:?}"),
@@ -1126,25 +1127,12 @@ impl GlobalDispatch<WlOutput, (i32, i32)> for State {
         _: &DisplayHandle,
         _: &Client,
         resource: wayland_server::New<WlOutput>,
-        &(x, y): &(i32, i32),
+        &(_x, _y): &(i32, i32),
         data_init: &mut wayland_server::DataInit<'_, Self>,
     ) {
         let output = data_init.init(resource, ());
-        output.geometry(
-            x,
-            y,
-            0,
-            0,
-            wl_output::Subpixel::None,
-            "xwls".to_string(),
-            "fake monitor".to_string(),
-            wl_output::Transform::Normal,
-        );
         state.output_counter += 1;
         let name = format!("WL-{}", state.output_counter);
-        output.name(name.clone());
-        output.mode(wl_output::Mode::Current, 1000, 1000, 0);
-        output.done();
         state.outputs.insert(
             output.clone(),
             Output {


### PR DESCRIPTION
Although this could manifest as the "early mouse border" bug, this is not a fix to #66 it was introduced in 33c344fe, which that issue is older than.