### PR TITLE
fix: don't override RANDR primary output on focus change

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -223,11 +223,6 @@ impl SurfaceEvents {
                         },
                         connection,
                     );
-                    if state.last_focused_toplevel == Some(*window) {
-                        let output = get_output_name(Some(&on_output), &state.world);
-                        debug!("focused window changed outputs - resetting primary output");
-                        connection.focus_window(*window, output);
-                    }
 
                     if state.fractional_scale.is_none() {
                         let output_scale = output_data.get::<&OutputScaleFactor>().unwrap().get();

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -1437,35 +1437,6 @@ impl XConnection for RealConnection {
         }) {
             debug!("ChangeProperty failed ({window:?}: {e:?})");
         }
-
-        if let Some(name) = output_name {
-            let Some(output) = self.outputs.get(&name).copied() else {
-                warn!("Couldn't find output {name}, primary output will be wrong");
-                return;
-            };
-            if output == self.primary_output {
-                debug!("primary output is already {name}");
-                return;
-            }
-
-            if let Err(e) = self
-                .connection
-                .send_and_check_request(&xcb::randr::SetOutputPrimary { window, output })
-            {
-                warn!("Couldn't set output {name} as primary: {e:?}");
-            } else {
-                debug!("set {name} as primary output");
-                self.primary_output = output;
-            }
-        } else {
-            let _ = self
-                .connection
-                .send_and_check_request(&xcb::randr::SetOutputPrimary {
-                    window,
-                    output: Xid::none(),
-                });
-            self.primary_output = Xid::none();
-        }
     }
 
     fn close_window(&mut self, window: x::Window) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1535,30 +1535,41 @@ fn primary_output() {
     assert_ne!(surface1, surface2);
     f.wait_and_dispatch();
 
+    // satellite must no longer drive the RANDR primary output from focus (#209):
+    // focusing windows, including across outputs, must leave the primary untouched.
     f.testwl.focus_toplevel(surface1);
     std::thread::sleep(std::time::Duration::from_millis(10));
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
-    assert_eq!(reply.output(), output1);
+    assert_eq!(
+        reply.output(),
+        Xid::none(),
+        "focusing a window must not set the primary output"
+    );
 
     f.testwl.focus_toplevel(surface2);
     std::thread::sleep(std::time::Duration::from_millis(10));
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
-    assert_eq!(reply.output(), output2);
+    assert_eq!(
+        reply.output(),
+        Xid::none(),
+        "focusing a window on another output must not set the primary output"
+    );
 
-    let wl_output3 = f.create_output(24, 46);
-    f.testwl.move_surface_to_output(surface2, &wl_output3);
+    // A primary chosen explicitly (as `xrandr --primary` does) must persist across
+    // focus changes instead of being overwritten on the next focus.
+    conn.send_and_check_request(&xcb::randr::SetOutputPrimary {
+        window: conn.root,
+        output: output1,
+    })
+    .unwrap();
+    f.testwl.focus_toplevel(surface2); // surface2 lives on output2
     std::thread::sleep(std::time::Duration::from_millis(10));
-
-    let reply = conn.get_reply(&xcb::randr::GetScreenResources { window: conn.root });
-    assert_eq!(reply.outputs().len(), 3);
-    let output3 = reply
-        .outputs()
-        .iter()
-        .copied()
-        .find(|o| ![output1, output2].contains(o))
-        .unwrap();
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
-    assert_eq!(reply.output(), output3);
+    assert_eq!(
+        reply.output(),
+        output1,
+        "an explicitly set primary must not be overridden by focusing a window on {output2:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`focus_window()` called RANDR `SetOutputPrimary` on every cross-output focus change (the "primary follows focus" behavior from #80). Each call emits `RRScreenChangeNotify`, and under focus-follows-mouse with windows on multiple monitors it fires on every pointer hover — so apps that rebuild or hide their windows on that event (xfreerdp, Sierra Chart under Wine) flicker or vanish. Tracked as #209.

This PR stops satellite from driving the primary at all. The primary is now the user's to set: `xrandr --primary <output>` sticks instead of being overwritten on the next focus change, matching a bare Xorg/sway session.

## Behavior change

- Primary no longer follows focus — no more `RRScreenChangeNotify` churn (#209).
- An explicit `xrandr --primary <output>` persists.
- The automatic behavior from #80 is dropped; those users set the primary once (the #80 reporter already confirmed `xrandr --output X --primary` fixes their game).

## Notes

Per the discussion this replaces the earlier env-var opt-out with simply removing the focus-following, which @Supreeeme was open to testing. I kept the RANDR output tracking (`update_outputs`, the output map) in place, so a later "set once at startup" or "defer to xrandr" refinement can build on it without re-adding anything.

The `primary_output` integration test is rewritten to assert the new contract: focus does not set the primary, and an explicitly set primary is not overridden by a subsequent focus.
