### PR TITLE
fix: allow WM_CLASS with multiple trailing \0 bytes

### DIFF
--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -8,7 +8,6 @@ use crate::XConnection;
 use bitflags::bitflags;
 use log::{debug, trace, warn};
 use std::collections::HashMap;
-use std::ffi::CString;
 use std::os::fd::BorrowedFd;
 use std::rc::Rc;
 use xcb::{Xid, XidNew, x};
@@ -835,18 +834,11 @@ impl XState {
             let data: &[u8] = reply.value();
             trace!("wm class data: {data:?}");
             // wm class (normally) is instance + class - ignore instance
-            let class_start = if let Some(p) = data.iter().copied().position(|b| b == 0u8) {
-                p + 1
-            } else {
-                0
-            };
-            let mut data = data[class_start..].to_vec();
-            if data.last().copied() != Some(0) {
-                data.push(0);
-            }
-            let class = CString::from_vec_with_nul(data).unwrap();
+            let mut fields = data.split(|b| *b == 0u8).filter(|s| !s.is_empty());
+            let instance = fields.next();
+            let class = fields.next().or(instance).unwrap_or(&[]);
             trace!("{window:?} class: {class:?}");
-            class.to_string_lossy().to_string()
+            String::from_utf8_lossy(class).to_string()
         };
         PropertyCookieWrapper {
             connection: &self.connection,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1440,13 +1440,19 @@ fn bad_clipboard_data() {
     assert!(data.data.is_empty(), "Unexpected data: {:?}", data.data);
 }
 
-// issue #42
+// issue #42 for title + #441 for class
 #[test]
-fn funny_window_title() {
+fn funny_window_title_class() {
     let mut f = Fixture::new();
     let mut connection = Connection::new(&f.display);
     let window = connection.new_window(connection.root, 0, 0, 20, 20, false);
     connection.set_property(window, x::ATOM_STRING, x::ATOM_WM_NAME, b"title\0\0\0\0");
+    connection.set_property(
+        window,
+        x::ATOM_STRING,
+        x::ATOM_WM_CLASS,
+        b"instance\0class\0\0\0\0",
+    );
     connection.map_window(window);
     f.wait_and_dispatch();
 
@@ -1457,6 +1463,7 @@ fn funny_window_title() {
     f.configure_and_verify_new_toplevel(&mut connection, window, surface);
     let data = f.testwl.get_surface_data(surface).unwrap();
     assert_eq!(data.toplevel().title, Some("title".into()));
+    assert_eq!(data.toplevel().app_id, Some("class".into()));
 
     connection.set_property(
         window,


### PR DESCRIPTION
A user found a program which sets `WM_CLASS` atoms with multiple '\0' bytes. `get_wm_class` used `CString::from_vec_with_nil` which errors when multiple trailing '\0' bytes are at the end of the input, and this error was `unwrap`ed.

I decided the closure as a whole was clunky so I took the time to rewrite it rather than add a superfluous null-terminator remover. Added an assert for the fix in an integration test. Fixes #441.

Also, I found the comment `// wm class (normally) is instance + class - ignore instance` strange, Isn't `WM_CLASS` required by the [ICCCM section 4.1.2.5](https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.2.5) to be a double null-terminated string? I guess I've seen programs violate ICCCM conventions in the wild...

Also also, this will conflict with the heuristics refactor aaaaaaaaaaaaa....