### PR TITLE
fix: allow unsetting min/max size hints after a WM_NORMAL_HINTS PropertyNotify

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1008,12 +1008,16 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                         (min_size.width as f64 / scale_factor.0) as i32,
                         (min_size.height as f64 / scale_factor.0) as i32 + decorations_height,
                     );
+                } else {
+                    data.toplevel.set_min_size(0, 0);
                 }
                 if let Some(max_size) = &hints.max_size {
                     data.toplevel.set_max_size(
                         (max_size.width as f64 / scale_factor.0) as i32,
                         (max_size.height as f64 / scale_factor.0) as i32 + decorations_height,
                     );
+                } else {
+                    data.toplevel.set_max_size(0, 0);
                 }
             }
             win.attrs.size_hints = Some(hints);

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2639,6 +2639,36 @@ fn toplevel_size_limits_scaled() {
     let toplevel = data.toplevel();
     assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
     assert_eq!(toplevel.max_size, Some(testwl::Vec2 { x: 100, y: 125 }));
+
+    // Try unsetting size hints one after another
+    f.satellite.set_size_hints(
+        window,
+        super::WmNormalHints {
+            min_size: Some(WinSize {
+                width: 40,
+                height: 40,
+            }),
+            max_size: None,
+        },
+    );
+    f.run();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let toplevel = data.toplevel();
+    assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
+    assert_eq!(toplevel.max_size, None);
+
+    f.satellite.set_size_hints(
+        window,
+        super::WmNormalHints {
+            min_size: None,
+            max_size: None,
+        },
+    );
+    f.run();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let toplevel = data.toplevel();
+    assert_eq!(toplevel.min_size, None);
+    assert_eq!(toplevel.max_size, None);
 }
 
 #[test]

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -1544,20 +1544,28 @@ impl Dispatch<XdgToplevel, SurfaceId> for State {
                 let Some(SurfaceRole::Toplevel(toplevel)) = &mut data.role else {
                     unreachable!();
                 };
-                toplevel.min_size = Some(Vec2 {
-                    x: width,
-                    y: height,
-                });
+                toplevel.min_size = if width > 0 || height > 0 {
+                    Some(Vec2 {
+                        x: width,
+                        y: height,
+                    })
+                } else {
+                    None
+                };
             }
             xdg_toplevel::Request::SetMaxSize { width, height } => {
                 let data = state.surfaces.get_mut(surface_id).unwrap();
                 let Some(SurfaceRole::Toplevel(toplevel)) = &mut data.role else {
                     unreachable!();
                 };
-                toplevel.max_size = Some(Vec2 {
-                    x: width,
-                    y: height,
-                });
+                toplevel.max_size = if width > 0 || height > 0 {
+                    Some(Vec2 {
+                        x: width,
+                        y: height,
+                    })
+                } else {
+                    None
+                };
             }
             xdg_toplevel::Request::SetFullscreen { .. } => {
                 let data = state.surfaces.get_mut(surface_id).unwrap();


### PR DESCRIPTION
The latest version of Webex would have a locked size window because of this issue, while it worked as expected in Gnome and Sway.

The xdg_toplevel protocol for set_min_size and set_max_size states: "As a result, a client wishing to reset the maximum size to an unspecified state can use zero for width and height in the request."