### PR TITLE
fix: round up popup size under fractional scaling

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1118,8 +1118,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                     ((event.y() as i32 - win.output_offset.y) as f64 / scale_factor.0) as i32,
                 );
                 popup.positioner.set_size(
-                    1.max((event.width() as f64 / scale_factor.0) as i32),
-                    1.max((event.height() as f64 / scale_factor.0) as i32),
+                    1.max((event.width() as f64 / scale_factor.0).ceil() as i32),
+                    1.max((event.height() as f64 / scale_factor.0).ceil() as i32),
                 );
                 popup.popup.reposition(&popup.positioner, 0);
             }
@@ -1614,8 +1614,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
         let positioner = self.xdg_wm_base.create_positioner(&self.qh, ());
         positioner.set_size(
-            1.max((window.attrs.dims.width as f64 / initial_scale) as i32),
-            1.max((window.attrs.dims.height as f64 / initial_scale) as i32),
+            1.max((window.attrs.dims.width as f64 / initial_scale).ceil() as i32),
+            1.max((window.attrs.dims.height as f64 / initial_scale).ceil() as i32),
         );
         let x = ((window.attrs.dims.x - parent_dims.x) as f64 / initial_scale) as i32;
         let y = ((window.attrs.dims.y - parent_dims.y) as f64 / initial_scale) as i32;
@@ -1625,8 +1625,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         positioner.set_anchor_rect(
             0,
             0,
-            1.max((parent_window.attrs.dims.width as f64 / initial_scale) as i32),
-            1.max((parent_window.attrs.dims.height as f64 / initial_scale) as i32),
+            1.max((parent_window.attrs.dims.width as f64 / initial_scale).ceil() as i32),
+            1.max((parent_window.attrs.dims.height as f64 / initial_scale).ceil() as i32),
         );
         positioner
             .set_constraint_adjustment(ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1625,8 +1625,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         positioner.set_anchor_rect(
             0,
             0,
-            (parent_window.attrs.dims.width as f64 / initial_scale) as i32,
-            (parent_window.attrs.dims.height as f64 / initial_scale) as i32,
+            1.max((parent_window.attrs.dims.width as f64 / initial_scale) as i32),
+            1.max((parent_window.attrs.dims.height as f64 / initial_scale) as i32),
         );
         positioner
             .set_constraint_adjustment(ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1625,8 +1625,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         positioner.set_anchor_rect(
             0,
             0,
-            1.max((parent_window.attrs.dims.width as f64 / initial_scale).ceil() as i32),
-            1.max((parent_window.attrs.dims.height as f64 / initial_scale).ceil() as i32),
+            (parent_window.attrs.dims.width as f64 / initial_scale).ceil() as i32,
+            (parent_window.attrs.dims.height as f64 / initial_scale).ceil() as i32,
         );
         positioner
             .set_constraint_adjustment(ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY);

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2580,7 +2580,7 @@ fn fractional_scale_small_popup() {
     assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 1, y: 1 });
     assert_eq!(
         pos.anchor_rect.as_ref().unwrap().size,
-        testwl::Vec2 { x: 1, y: 1 }
+        testwl::Vec2 { x: 0, y: 0 }
     );
 
     f.reconfigure_window(

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2583,16 +2583,13 @@ fn fractional_scale_small_popup() {
         testwl::Vec2 { x: 1, y: 1 }
     );
 
-    f.reconfigure_window(
-        popup,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 2,
-            height: 1,
-        },
-        true,
-    );
+    let dims = WindowDims {
+        x: 0,
+        y: 0,
+        width: 2,
+        height: 1,
+    };
+    f.reconfigure_window(popup, dims, true);
     f.run();
 
     let dims = f.connection().window(popup).dims;

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2595,6 +2595,10 @@ fn fractional_scale_small_popup() {
     );
     f.run();
 
+    let dims = f.connection().window(popup).dims;
+    assert!(dims.width > 0);
+    assert!(dims.height > 0);
+
     let data = f
         .testwl
         .get_surface_data(popup_id)

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2554,8 +2554,8 @@ fn fractional_scale_small_popup() {
         WindowDims {
             x: 0,
             y: 0,
-            width: 0,
-            height: 0,
+            width: 1,
+            height: 1,
         },
         false,
     );
@@ -2564,7 +2564,7 @@ fn fractional_scale_small_popup() {
     let popup = Window::new(2);
     let builder = PopupBuilder::new(popup, toplevel, toplevel_id)
         .width(0)
-        .height(0)
+        .height(1)
         .check_size_and_pos(false);
 
     let (_, popup_id) = f.create_popup(&comp, builder);
@@ -2580,7 +2580,7 @@ fn fractional_scale_small_popup() {
     assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 1, y: 1 });
     assert_eq!(
         pos.anchor_rect.as_ref().unwrap().size,
-        testwl::Vec2 { x: 0, y: 0 }
+        testwl::Vec2 { x: 1, y: 1 }
     );
 
     f.reconfigure_window(
@@ -2589,19 +2589,7 @@ fn fractional_scale_small_popup() {
             x: 0,
             y: 0,
             width: 2,
-            height: 2,
-        },
-        true,
-    );
-    f.run();
-
-    f.reconfigure_window(
-        popup,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 0,
-            height: 0,
+            height: 1,
         },
         true,
     );
@@ -2612,7 +2600,7 @@ fn fractional_scale_small_popup() {
         .get_surface_data(popup_id)
         .expect("Missing popup data");
     let pos = &data.popup().positioner_state;
-    assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 1, y: 1 });
+    assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 2, y: 1 });
 }
 
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2549,10 +2549,22 @@ fn fractional_scale_small_popup() {
         assert_eq!(viewport.height, 67);
     }
 
+    f.reconfigure_window(
+        toplevel,
+        WindowDims {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        },
+        false,
+    );
+    f.run();
+
     let popup = Window::new(2);
     let builder = PopupBuilder::new(popup, toplevel, toplevel_id)
-        .width(1)
-        .height(1)
+        .width(0)
+        .height(0)
         .check_size_and_pos(false);
 
     let (_, popup_id) = f.create_popup(&comp, builder);
@@ -2566,20 +2578,34 @@ fn fractional_scale_small_popup() {
         .expect("Missing popup data");
     let pos = &data.popup().positioner_state;
     assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 1, y: 1 });
+    assert_eq!(
+        pos.anchor_rect.as_ref().unwrap().size,
+        testwl::Vec2 { x: 1, y: 1 }
+    );
 
-    let dims = WindowDims {
-        x: 0,
-        y: 0,
-        width: 2,
-        height: 1,
-    };
-    f.reconfigure_window(popup, dims, true);
-    f.run();
+    f.reconfigure_window(
+        popup,
+        WindowDims {
+            x: 0,
+            y: 0,
+            width: 2,
+            height: 2,
+        },
+        true,
+    );
     f.run();
 
-    let dims = f.connection().window(popup).dims;
-    assert!(dims.width > 0);
-    assert!(dims.height > 0);
+    f.reconfigure_window(
+        popup,
+        WindowDims {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        },
+        true,
+    );
+    f.run();
 
     let data = f
         .testwl

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2563,7 +2563,7 @@ fn fractional_scale_small_popup() {
 
     let popup = Window::new(2);
     let builder = PopupBuilder::new(popup, toplevel, toplevel_id)
-        .width(0)
+        .width(1)
         .height(1)
         .check_size_and_pos(false);
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -815,8 +815,8 @@ impl TestFixture<FakeXConnection> {
                 assert_eq!(
                     pos.size.as_ref().unwrap(),
                     &testwl::Vec2 {
-                        x: (dims.width as f64 / scale) as i32,
-                        y: (dims.height as f64 / scale) as i32
+                        x: (dims.width as f64 / scale).ceil() as i32,
+                        y: (dims.height as f64 / scale).ceil() as i32
                     }
                 );
 
@@ -825,8 +825,8 @@ impl TestFixture<FakeXConnection> {
                     pos.anchor_rect.as_ref().unwrap(),
                     &testwl::Rect {
                         size: testwl::Vec2 {
-                            x: (parent_win.dims.width as f64 / scale) as i32,
-                            y: (parent_win.dims.height as f64 / scale) as i32
+                            x: (parent_win.dims.width as f64 / scale).ceil() as i32,
+                            y: (parent_win.dims.height as f64 / scale).ceil() as i32
                         },
                         offset: testwl::Vec2::default()
                     }
@@ -2476,8 +2476,8 @@ fn fractional_scale_popup() {
     let builder = PopupBuilder::new(popup, toplevel, toplevel_id)
         .x(60)
         .y(60)
-        .width(60)
-        .height(60)
+        .width(61)
+        .height(61)
         .scale(1.5);
     let initial_dims = builder.dims;
     f.create_popup(&comp, builder);


### PR DESCRIPTION
Round popup and anchor-rectangle dimensions up when converting X11 physical geometry to Wayland logical coordinates.

Truncating the fractional result made a 61px popup at scale 1.5 become 40 logical pixels. Rounding up produces 41, so popup and anchor geometry are never smaller than the corresponding scaled X11 geometry.

The existing minimum `1x1` clamp remains for `xdg_positioner.set_size`, where zero is invalid. `set_anchor_rect` retains zero-sized rectangles, which the protocol permits for anchoring a popup to a coordinate.

Adds coverage for fractional-scale conversion and zero-sized input.

**This pull request is assisted by AI/LLMs. The working model is GPT-5.6 Terra xhigh, agent tool is OpenCode.**