### PR TITLE
feat(scaling): add compositor-side supersampling, EWMH maximization, and input region scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /result
+*.patch

--- a/README.md
+++ b/README.md
@@ -45,11 +45,17 @@ which is likely after your compositor is started if it supports systemd.
 Note that you *do not* need the systemd service if the compositor already integrates xwayland-satellite (see below).
 
 ## Scaling/HiDPI
-For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
-the smallest monitor's DPI, meaning apps may have small text on other monitors.
+For most GTK and Qt apps, xwayland-satellite should automatically pick up the right scale.
 
-Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
-so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.
+By default, satellite renders X11 apps at the highest active output scale so text stays sharp on HiDPI screens (compositor handles downscaling for lower-DPI outputs).
+
+### `XWAYLAND_SATELLITE_BASE_SCALE`
+
+Pins the render scale to a fixed multiplier (1.0–8.0) instead of picking `max(output_scale)`. Compositor-side scaling stays on, so popup positioning and coordinate mapping still line up.
+
+Set it to `1` to render at native resolution but keep correct window geometry on HiDPI displays — handy when supersampling costs too much on weak hardware.
+
+Other apps, such as Wine apps, may still need their own HiDPI settings. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good starting point.
 
 Satellite acts as an Xsettings manager for setting scaling related settings, but will get out of the way of other Xsettings managers.
 To manually set these settings, try [xsettingsd](https://codeberg.org/derat/xsettingsd) or another Xsettings manager.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ Some Java applications may present themselves as a blank screen by default with 
 
 ### Scaling/HiDPI
 For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
-the smallest monitor's DPI, meaning apps may have small text on other monitors.
+the smallest monitor's DPI by default, meaning apps may have small text on other monitors.
+
+Alternatively, you can enable compositor-side scaling by setting the `XWAYLAND_SATELLITE_COMPOSITOR_SCALING` environment variable.
+In this mode, satellite will render X11 applications at the maximum monitor's DPI (HiDPI) and let the Wayland compositor downscale them on lower-DPI monitors.
+This ensures that apps do not look tiny or blurry on HiDPI displays in multi-monitor setups.
+You can optionally set `XWAYLAND_SATELLITE_BASE_SCALE` (1.0–8.0) to override the base scale. Setting it to 1.0 keeps native res and saves VRAM without breaking multi-monitor fixes.
 
 Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
 so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub trait RunData {
     fn flags(&self) -> &[String] {
         &[]
     }
+    fn compositor_scaling(&self) -> bool {
+        false
+    }
     fn server(&self) -> Option<UnixStream> {
         None
     }
@@ -155,7 +158,8 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         }
     };
 
-    let mut server_state = EarlyServerState::new(dh, data.server(), connection);
+    let mut server_state =
+        EarlyServerState::new(dh, data.server(), connection, data.compositor_scaling());
     server_state.run();
 
     // Remove the lifetimes on our fds to avoid borrowing issues, since we know they will exist for
@@ -243,17 +247,45 @@ pub fn main(mut data: impl RunData) -> Option<()> {
             xstate.update_global_scale(scale);
         }
 
-        match poll(&mut fds, None) {
-            Ok(_) => {
-                if !fds[3].revents().is_empty() {
-                    let status = xwayland_exit_code(&mut quit_rx);
-                    if status != ExitStatus::default() {
-                        error!("Xwayland exited early with {status}");
-                    }
-                    return None;
-                }
+        let timeout = xstate.poll_timeout();
+        let is_quit = if !xstate.has_pending_transfers() {
+            let mut poll_fds = [
+                PollFd::from_borrowed_fd(server_fd, PollFlags::IN),
+                PollFd::new(&xsock_wl, PollFlags::IN),
+                PollFd::from_borrowed_fd(display_fd, PollFlags::IN),
+                PollFd::new(&quit_rx, PollFlags::IN),
+                PollFd::new(&ready_rx, PollFlags::IN),
+            ];
+            match poll(&mut poll_fds, timeout.as_ref()) {
+                Ok(_) => !poll_fds[3].revents().is_empty(),
+                Err(other) => panic!("Poll failed: {other:?}"),
             }
-            Err(other) => panic!("Poll failed: {other:?}"),
+        } else {
+            let mut poll_fds = vec![
+                PollFd::from_borrowed_fd(server_fd, PollFlags::IN),
+                PollFd::new(&xsock_wl, PollFlags::IN),
+                PollFd::from_borrowed_fd(display_fd, PollFlags::IN),
+                PollFd::new(&quit_rx, PollFlags::IN),
+                PollFd::new(&ready_rx, PollFlags::IN),
+            ];
+            xstate.collect_poll_fds(&mut poll_fds);
+            match poll(&mut poll_fds, timeout.as_ref()) {
+                Ok(_) => {
+                    let is_quit = !poll_fds[3].revents().is_empty();
+                    let events: Vec<_> = poll_fds.iter().map(|f| f.revents()).collect();
+                    xstate.process_pending_clipboard_transfers(&events);
+                    is_quit
+                }
+                Err(other) => panic!("Poll failed: {other:?}"),
+            }
+        };
+
+        if is_quit {
+            let status = xwayland_exit_code(&mut quit_rx);
+            if status != ExitStatus::default() {
+                error!("Xwayland exited early with {status}");
+            }
+            return None;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,17 @@ pub trait RunData {
     fn flags(&self) -> &[String] {
         &[]
     }
+    /// Render at the highest active output scale and let the compositor downscale.
+    /// On by default in the binary; library users may want it off.
+    fn compositor_scaling(&self) -> bool {
+        false
+    }
+    /// Pins the X11 render scale instead of picking max(output_scale).
+    /// Saves VRAM on low-end hardware without breaking HiDPI window placement.
+    /// compositor_scaling() keeps working when this is set.
+    fn base_scale(&self) -> Option<f64> {
+        None
+    }
     fn server(&self) -> Option<UnixStream> {
         None
     }
@@ -153,7 +164,9 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         }
     };
 
-    let mut server_state = EarlyServerState::new(dh, data.server(), connection);
+    let mut server_state =
+        EarlyServerState::new(dh, data.server(), connection, data.compositor_scaling());
+    server_state.set_base_scale(data.base_scale());
     server_state.run();
 
     // Remove the lifetimes on our fds to avoid borrowing issues, since we know they will exist for

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@ pub trait XConnection: Sized + 'static {
 
     fn set_window_dims(&mut self, window: x::Window, dims: PendingSurfaceState) -> bool;
     fn set_fullscreen(&mut self, window: x::Window, fullscreen: bool);
+    fn set_maximized(&mut self, window: x::Window, maximized: bool);
     fn focus_window(&mut self, window: x::Window, output_name: Option<String>);
+    fn focus_popup(&mut self, window: x::Window);
     fn close_window(&mut self, window: x::Window);
     fn unmap_window(&mut self, window: x::Window);
     fn raise_to_top(&mut self, window: x::Window);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ struct RealData {
     display: Option<String>,
     listenfds: Vec<OwnedFd>,
     flags: Vec<String>,
+    base_scale: Option<f64>,
 }
 impl xwayland_satellite::RunData for RealData {
     fn display(&self) -> Option<&str> {
@@ -25,6 +26,14 @@ impl xwayland_satellite::RunData for RealData {
 
     fn flags(&self) -> &[String] {
         &self.flags
+    }
+
+    fn compositor_scaling(&self) -> bool {
+        true
+    }
+
+    fn base_scale(&self) -> Option<f64> {
+        self.base_scale
     }
 }
 
@@ -242,6 +251,20 @@ fn parse_args() -> RealData {
             }
         }
     }
+    if let Ok(v) = std::env::var("XWAYLAND_SATELLITE_BASE_SCALE") {
+        match v.trim().parse::<f64>() {
+            Ok(s) if (1.0..=8.0).contains(&s) && s.is_finite() => {
+                data.base_scale = Some(s);
+            }
+            _ => {
+                log::warn!(
+                    "invalid value {v:?} for XWAYLAND_SATELLITE_BASE_SCALE, \
+                     ignoring (must be between 1.0 and 8.0)"
+                );
+            }
+        }
+    }
+
     data.flags = flags.to_vec();
 
     data

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ struct RealData {
     display: Option<String>,
     listenfds: Vec<OwnedFd>,
     flags: Vec<String>,
+    compositor_scaling: bool,
 }
 impl xwayland_satellite::RunData for RealData {
     fn display(&self) -> Option<&str> {
@@ -23,6 +24,10 @@ impl xwayland_satellite::RunData for RealData {
 
     fn flags(&self) -> &[String] {
         &self.flags
+    }
+
+    fn compositor_scaling(&self) -> bool {
+        self.compositor_scaling
     }
 }
 
@@ -240,6 +245,9 @@ fn parse_args() -> RealData {
             }
         }
     }
+    data.compositor_scaling = std::env::var("XWAYLAND_SATELLITE_COMPOSITOR_SCALING")
+        .map(|v| v != "0" && !v.is_empty())
+        .unwrap_or(false);
     data.flags = flags.to_vec();
 
     data

--- a/src/server/decoration.rs
+++ b/src/server/decoration.rs
@@ -55,7 +55,20 @@ impl Drop for DecorationsDataSatellite {
 }
 
 impl DecorationsDataSatellite {
-    pub const TITLEBAR_HEIGHT: i32 = 25;
+    pub fn calculate_titlebar_height() -> i32 {
+        static HEIGHT: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+        *HEIGHT.get_or_init(|| {
+            let px_scale = FONT.pt_to_px_scale(10.0).unwrap();
+            let font = FONT.as_scaled(px_scale);
+            let line_height = font.ascent() - font.descent() + font.line_gap();
+            let padding = 12.0;
+            (line_height + padding).round() as i32
+        })
+    }
+
+    pub fn titlebar_height(&self) -> i32 {
+        Self::calculate_titlebar_height()
+    }
 
     pub fn try_new(
         state: &InnerServerState<impl X11Selection>,
@@ -88,7 +101,8 @@ impl DecorationsDataSatellite {
                 .subcompositor
                 .get_subsurface(&surface, parent, &state.qh, ())
         };
-        subsurface.set_position(0, -Self::TITLEBAR_HEIGHT);
+        let start_height = Self::calculate_titlebar_height();
+        subsurface.set_position(0, -start_height);
         let viewport = state.viewporter.get_viewport(&surface, &state.qh, ());
 
         Some((
@@ -155,7 +169,7 @@ impl DecorationsDataSatellite {
 
         self.scale = parent_scale_factor;
         let mut drawn_width = (width as f32 * self.scale).ceil() as i32;
-        let drawn_height = (Self::TITLEBAR_HEIGHT as f32 * self.scale).ceil() as i32;
+        let drawn_height = (self.titlebar_height() as f32 * self.scale).ceil() as i32;
 
         let x = x_pixmap(drawn_height as u32, self.scale, self.x_data.hovered);
         if x.width() > drawn_width as u32 {
@@ -198,17 +212,18 @@ impl DecorationsDataSatellite {
         );
         self.x_data = DecorationsBox {
             rect: Rect::from_ltrb(
-                width as f32 - Self::TITLEBAR_HEIGHT as f32,
+                width as f32 - self.titlebar_height() as f32,
                 0.0,
                 width as f32,
-                Self::TITLEBAR_HEIGHT as f32,
+                self.titlebar_height() as f32,
             )
             .unwrap(),
             hovered: false,
         };
 
         self.pixmap = bar;
-        self.viewport.set_destination(width, Self::TITLEBAR_HEIGHT);
+        let bar_h = self.titlebar_height();
+        self.viewport.set_destination(width, bar_h);
         self.update_buffer(world);
     }
 

--- a/src/server/decoration.rs
+++ b/src/server/decoration.rs
@@ -55,7 +55,23 @@ impl Drop for DecorationsDataSatellite {
 }
 
 impl DecorationsDataSatellite {
-    pub const TITLEBAR_HEIGHT: i32 = 25;
+    pub fn calculate_titlebar_height() -> i32 {
+        let px_scale = match FONT.pt_to_px_scale(10.0) {
+            Some(scale) => scale,
+            None => {
+                warn!("Failed to calculate titlebar font scale; using 25px fallback");
+                return 25;
+            }
+        };
+        let font = FONT.as_scaled(px_scale);
+        let line_height = font.ascent() - font.descent() + font.line_gap();
+        let padding = 12.0;
+        (line_height + padding).round() as i32
+    }
+
+    pub fn titlebar_height(&self) -> i32 {
+        Self::calculate_titlebar_height()
+    }
 
     pub fn try_new(
         state: &InnerServerState<impl X11Selection>,
@@ -88,7 +104,8 @@ impl DecorationsDataSatellite {
                 .subcompositor
                 .get_subsurface(&surface, parent, &state.qh, ())
         };
-        subsurface.set_position(0, -Self::TITLEBAR_HEIGHT);
+        let start_height = Self::calculate_titlebar_height();
+        subsurface.set_position(0, -start_height);
         let viewport = state.viewporter.get_viewport(&surface, &state.qh, ());
 
         Some((
@@ -154,8 +171,9 @@ impl DecorationsDataSatellite {
         }
 
         self.scale = parent_scale_factor;
+        let bar_h = self.titlebar_height();
         let mut drawn_width = (width as f32 * self.scale).ceil() as i32;
-        let drawn_height = (Self::TITLEBAR_HEIGHT as f32 * self.scale).ceil() as i32;
+        let drawn_height = (bar_h as f32 * self.scale).ceil() as i32;
 
         let x = x_pixmap(drawn_height as u32, self.scale, self.x_data.hovered);
         if x.width() > drawn_width as u32 {
@@ -197,18 +215,15 @@ impl DecorationsDataSatellite {
             None,
         );
         self.x_data = DecorationsBox {
-            rect: Rect::from_ltrb(
-                width as f32 - Self::TITLEBAR_HEIGHT as f32,
-                0.0,
-                width as f32,
-                Self::TITLEBAR_HEIGHT as f32,
-            )
-            .unwrap(),
+            rect: Rect::from_ltrb(width as f32 - bar_h as f32, 0.0, width as f32, bar_h as f32)
+                .unwrap(),
             hovered: false,
         };
 
         self.pixmap = bar;
-        self.viewport.set_destination(width, Self::TITLEBAR_HEIGHT);
+        self.viewport.set_destination(width, bar_h);
+        // re-sync subsurface position in case height changed since try_new (DPI hotplug)
+        self.subsurface.set_position(0, -bar_h);
         self.update_buffer(world);
     }
 

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -103,13 +103,22 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                 if buffer.is_none() {
                     trace!("xwayland attached null buffer to {client:?}");
                 }
-                let buffer = buffer.as_ref().map(|b| {
-                    let entity: Entity = b.data().copied().unwrap();
-                    state
-                        .world
-                        .get::<&client::wl_buffer::WlBuffer>(entity)
-                        .unwrap()
-                });
+                let buffer = if let Some(b) = buffer.as_ref() {
+                    let Some(entity) = b.data().copied() else {
+                        warn!("surface attach ignored: stale buffer");
+                        return;
+                    };
+
+                    let Some(buffer) = state.world.get::<&client::wl_buffer::WlBuffer>(entity).ok()
+                    else {
+                        warn!("surface attach ignored: stale buffer");
+                        return;
+                    };
+
+                    Some(buffer)
+                } else {
+                    None
+                };
 
                 if configured {
                     client.attach(buffer.as_deref(), x, y);
@@ -234,7 +243,12 @@ impl<S: X11Selection>
                         client,
                         server,
                         viewport,
-                        scale: SurfaceScaleFactor(1.0),
+                        scale: SurfaceScaleFactor(if state.compositor_scaling {
+                            state.global_scale
+                        } else {
+                            1.0
+                        }),
+                        entered_outputs: event::EnteredOutputs(Vec::new()),
                     },
                 );
                 if let Some(f) = fractional {
@@ -264,12 +278,18 @@ impl<S: X11Selection> Dispatch<WlBuffer, Entity> for InnerServerState<S> {
     ) {
         assert!(matches!(request, Request::<WlBuffer>::Destroy));
 
-        state
+        let Some(buffer) = state
             .world
             .get::<&client::wl_buffer::WlBuffer>(*entity)
-            .unwrap()
-            .destroy();
-        state.world.despawn(*entity).unwrap();
+            .ok()
+        else {
+            warn!("buffer destroy ignored: stale buffer");
+            return;
+        };
+
+        buffer.destroy();
+        drop(buffer);
+        let _ = state.world.despawn(*entity);
     }
 }
 
@@ -358,20 +378,31 @@ impl<S: X11Selection> Dispatch<WlPointer, Entity> for InnerServerState<S> {
                 hotspot_y,
                 surface,
             } => {
-                let c_pointer = state
+                let Some(c_pointer) = state
                     .world
                     .get::<&client::wl_pointer::WlPointer>(*entity)
-                    .unwrap();
+                    .ok()
+                else {
+                    warn!("set_cursor ignored: stale pointer");
+                    return;
+                };
 
-                let c_surface = surface.and_then(|s| {
-                    let e = s.data().copied()?;
-                    Some(
-                        state
-                            .world
-                            .get::<&client::wl_surface::WlSurface>(e)
-                            .unwrap(),
-                    )
-                });
+                let c_surface = if let Some(s) = surface {
+                    let Some(e) = s.data().copied() else {
+                        warn!("set_cursor ignored: stale cursor surface");
+                        return;
+                    };
+
+                    let Some(surface) = state.world.get::<&client::wl_surface::WlSurface>(e).ok()
+                    else {
+                        warn!("set_cursor ignored: stale cursor surface");
+                        return;
+                    };
+
+                    Some(surface)
+                } else {
+                    None
+                };
                 c_pointer.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             Request::<WlPointer>::Release => {
@@ -421,13 +452,17 @@ impl<S: X11Selection> Dispatch<WlTouch, Entity> for InnerServerState<S> {
     ) {
         match request {
             Request::<WlTouch>::Release => {
-                state
-                    .world
-                    .get::<&client::wl_touch::WlTouch>(*entity)
-                    .unwrap()
-                    .release();
+                let Some(touch) = state.world.get::<&client::wl_touch::WlTouch>(*entity).ok()
+                else {
+                    warn!("touch release ignored: stale touch");
+                    return;
+                };
+
+                touch.release();
+                drop(touch);
+                let _ = state.world.remove_one::<event::TouchFocus>(*entity);
             }
-            _ => unreachable!(),
+            _ => warn!("unhandled touch request: {request:?}"),
         }
     }
 }
@@ -556,12 +591,22 @@ impl<S: X11Selection> Dispatch<WlOutput, Entity> for InnerServerState<S> {
     ) {
         match request {
             wayland_server::protocol::wl_output::Request::Release => {
-                state
+                let Some(output) = state
                     .world
                     .get::<&client::wl_output::WlOutput>(*entity)
-                    .unwrap()
-                    .release();
-                todo!("handle wloutput destruction");
+                    .ok()
+                else {
+                    warn!("output release ignored: stale output");
+                    return;
+                };
+
+                output.release();
+                drop(output);
+                // remove both sides: server binding is gone, client proxy is dead
+                let _ = state
+                    .world
+                    .remove_one::<client::wl_output::WlOutput>(*entity);
+                let _ = state.world.remove_one::<WlOutput>(*entity);
             }
             _ => warn!("unhandled output request {request:?}"),
         }
@@ -607,7 +652,7 @@ impl<S: X11Selection>
     fn request(
         state: &mut Self,
         _: &wayland_server::Client,
-        _: &s_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
+        s_params: &s_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
         request: <s_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1 as Resource>::Request,
         c_params: &c_dmabuf::zwp_linux_buffer_params_v1::ZwpLinuxBufferParamsV1,
         _: &DisplayHandle,
@@ -616,7 +661,10 @@ impl<S: X11Selection>
         use s_dmabuf::zwp_linux_buffer_params_v1::Request::*;
         match request {
             // TODO: Xwayland doesn't actually seem to use the Create request, and I don't feel like implementing it...
-            Create { .. } => todo!(),
+            Create { .. } => {
+                warn!("zwp_linux_buffer_params_v1.create is not implemented");
+                s_params.failed();
+            }
             CreateImmed {
                 buffer_id,
                 width,
@@ -889,17 +937,23 @@ impl<S: X11Selection> Dispatch<ConfinedPointerServer, Entity> for InnerServerSta
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        let client = state.world.get::<&ConfinedPointerClient>(*entity).unwrap();
+        let Some(client) = state.world.get::<&ConfinedPointerClient>(*entity).ok() else {
+            warn!("confined pointer request ignored: stale ConfinedPointerClient");
+            return;
+        };
         simple_event_shunt! {
             client, request: cp::Request => [
                 SetRegion {
-                    |region| region.as_ref().map(|r| r.data().unwrap())
+                    |region| region.as_ref().and_then(|r| r.data().copied())
                 },
                 Destroy
             ]
         }
     }
 }
+
+#[derive(Clone, Copy)]
+struct LockedPointerSurface(Entity);
 
 impl<S: X11Selection> Dispatch<LockedPointerServer, Entity> for InnerServerState<S> {
     fn request(
@@ -916,24 +970,44 @@ impl<S: X11Selection> Dispatch<LockedPointerServer, Entity> for InnerServerState
                 surface_x,
                 surface_y,
             } => {
-                let (client, scale) = state
-                    .world
-                    .query_one_mut::<(&LockedPointerClient, &SurfaceScaleFactor)>(*entity)
-                    .unwrap();
+                let Some(surf_key) = ({
+                    let mut query = state.world.query_one::<&LockedPointerSurface>(*entity).ok();
+                    query.as_mut().and_then(|q| q.get()).map(|s| s.0)
+                }) else {
+                    warn!("set_cursor_position_hint ignored: missing LockedPointerSurface");
+                    return;
+                };
 
-                // Xwayland believes that the surface is actually <surface scale factor> times bigger
-                // than it currently is, and therefore that the cursor position is also scaled up by the same
-                // amount. So we need to divide the cursor position from Xwayland by the surface scale
-                // to get where the cursor should actually be positioned.
+                let cursor_hint = if state.compositor_scaling {
+                    super::event::xwayland_to_surface_input_coords(
+                        &state.world,
+                        surf_key,
+                        surface_x,
+                        surface_y,
+                    )
+                } else {
+                    state
+                        .world
+                        .get::<&SurfaceScaleFactor>(surf_key)
+                        .ok()
+                        .map(|s| {
+                            let scale = super::event::safe_scale(s.0);
+                            (surface_x / scale, surface_y / scale)
+                        })
+                        .unwrap_or((surface_x, surface_y))
+                };
 
-                client.set_cursor_position_hint(surface_x / scale.0, surface_y / scale.0);
+                if let Ok(client) = state.world.get::<&LockedPointerClient>(*entity) {
+                    client.set_cursor_position_hint(cursor_hint.0, cursor_hint.1);
+                } else {
+                    warn!("set_cursor_position_hint ignored: stale LockedPointerClient");
+                }
             }
             lp::Request::Destroy => {
-                {
-                    let client = state.world.get::<&LockedPointerClient>(*entity).unwrap();
+                if let Ok(client) = state.world.get::<&LockedPointerClient>(*entity) {
                     client.destroy();
                 }
-                state.world.despawn(*entity).unwrap();
+                let _ = state.world.despawn(*entity);
             }
             _ => warn!("unhandled locked pointer request: {request:?}"),
         }
@@ -963,23 +1037,31 @@ impl<S: X11Selection>
                 region,
                 lifetime,
             } => {
-                let surf_key: Entity = surface.data().copied().unwrap();
-                let ptr_key: Entity = pointer.data().copied().unwrap();
+                let Some(surf_key) = surface.data().copied() else {
+                    warn!("confine_pointer ignored: stale surface");
+                    return;
+                };
+                let Some(ptr_key) = pointer.data().copied() else {
+                    warn!("confine_pointer ignored: stale pointer");
+                    return;
+                };
 
                 let entity = state.world.reserve_entity();
                 let client = {
-                    let c_surface = state
-                        .world
-                        .get::<&client::wl_surface::WlSurface>(surf_key)
-                        .unwrap();
-                    let c_ptr = state
-                        .world
-                        .get::<&client::wl_pointer::WlPointer>(ptr_key)
-                        .unwrap();
+                    let Ok(c_surface) = state.world.get::<&client::wl_surface::WlSurface>(surf_key)
+                    else {
+                        warn!("confine_pointer ignored: missing surface");
+                        return;
+                    };
+                    let Ok(c_ptr) = state.world.get::<&client::wl_pointer::WlPointer>(ptr_key)
+                    else {
+                        warn!("confine_pointer ignored: missing pointer");
+                        return;
+                    };
                     client.confine_pointer(
                         &c_surface,
                         &c_ptr,
-                        region.as_ref().map(|r| r.data().unwrap()),
+                        region.as_ref().and_then(|r| r.data().copied()),
                         convert_wenum(lifetime),
                         &state.qh,
                         entity,
@@ -996,39 +1078,41 @@ impl<S: X11Selection>
                 region,
                 lifetime,
             } => {
-                let surf_key: Entity = surface.data().copied().unwrap();
-                let ptr_key: Entity = pointer.data().copied().unwrap();
+                let Some(surf_key) = surface.data().copied() else {
+                    warn!("lock_pointer ignored: stale surface");
+                    return;
+                };
+                let Some(ptr_key) = pointer.data().copied() else {
+                    warn!("lock_pointer ignored: stale pointer");
+                    return;
+                };
                 let entity = state.world.reserve_entity();
 
                 let client = {
-                    let c_surface = state
-                        .world
-                        .get::<&client::wl_surface::WlSurface>(surf_key)
-                        .unwrap();
-                    let c_ptr = state
-                        .world
-                        .get::<&client::wl_pointer::WlPointer>(ptr_key)
-                        .unwrap();
+                    let Ok(c_surface) = state.world.get::<&client::wl_surface::WlSurface>(surf_key)
+                    else {
+                        warn!("lock_pointer ignored: missing surface");
+                        return;
+                    };
+                    let Ok(c_ptr) = state.world.get::<&client::wl_pointer::WlPointer>(ptr_key)
+                    else {
+                        warn!("lock_pointer ignored: missing pointer");
+                        return;
+                    };
                     client.lock_pointer(
                         &c_surface,
                         &c_ptr,
-                        region.as_ref().map(|r| r.data().unwrap()),
+                        region.as_ref().and_then(|r| r.data().copied()),
                         convert_wenum(lifetime),
                         &state.qh,
                         entity,
                     )
                 };
                 let server = data_init.init(id, entity);
-                let surface_scale = state
-                    .world
-                    .get::<&SurfaceScaleFactor>(surf_key)
-                    .as_deref()
-                    .copied()
-                    .unwrap();
 
                 state
                     .world
-                    .spawn_at(entity, (client, server, surface_scale));
+                    .spawn_at(entity, (client, server, LockedPointerSurface(surf_key)));
             }
             Request::Destroy => {
                 client.destroy();
@@ -1136,10 +1220,14 @@ impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, En
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        let client = state
+        let Some(client) = state
             .world
             .get::<&c_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2>(*entity)
-            .unwrap();
+            .ok()
+        else {
+            warn!("tablet tool request ignored: stale tool client");
+            return;
+        };
         match request {
             s_tablet::zwp_tablet_tool_v2::Request::SetCursor {
                 serial,
@@ -1147,19 +1235,28 @@ impl<S: X11Selection> Dispatch<s_tablet::zwp_tablet_tool_v2::ZwpTabletToolV2, En
                 hotspot_x,
                 hotspot_y,
             } => {
-                let surf_key: Option<Entity> = surface.map(|s| s.data().copied().unwrap());
-                let c_surface = surf_key.map(|key| {
-                    state
-                        .world
-                        .get::<&client::wl_surface::WlSurface>(key)
-                        .unwrap()
-                });
+                let c_surface = if let Some(s) = surface {
+                    let Some(e) = s.data().copied() else {
+                        warn!("tablet set_cursor ignored: stale cursor surface");
+                        return;
+                    };
+
+                    let Some(surface) = state.world.get::<&client::wl_surface::WlSurface>(e).ok()
+                    else {
+                        warn!("tablet set_cursor ignored: stale cursor surface");
+                        return;
+                    };
+
+                    Some(surface)
+                } else {
+                    None
+                };
                 client.set_cursor(serial, c_surface.as_deref(), hotspot_x, hotspot_y);
             }
             s_tablet::zwp_tablet_tool_v2::Request::Destroy => {
                 client.destroy();
                 drop(client);
-                state.world.despawn(*entity).unwrap();
+                let _ = state.world.despawn(*entity);
             }
             other => warn!("unhandled tablet tool request: {other:?}"),
         }
@@ -1478,6 +1575,7 @@ impl<S: X11Selection> GlobalDispatch<WlOutput, Global> for InnerServerState<S> {
                 server,
                 client,
                 event::OutputScaleFactor::Output(1),
+                event::TrueOutputScaleFactor(event::OutputScaleFactor::Output(1)),
                 event::OutputDimensions::default(),
                 GlobalName(data.name),
             ),
@@ -1573,6 +1671,11 @@ impl<S: X11Selection> Dispatch<XwaylandSurfaceV1, Entity> for InnerServerState<S
                     let mut builder = hecs::EntityBuilder::new();
                     builder.add_bundle(bundle);
                     state.world.insert(*entity, builder.build()).unwrap();
+                    if let Ok(mut scale) = state.world.get::<&mut SurfaceScaleFactor>(*entity) {
+                        if state.compositor_scaling {
+                            scale.0 = state.global_scale;
+                        }
+                    }
                     state.world.remove_one::<SurfaceSerial>(*entity).unwrap();
                     let data = state.world.entity(*entity).unwrap();
                     let win = data.get::<&x::Window>().as_deref().copied().unwrap();

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -278,17 +278,11 @@ impl<S: X11Selection> Dispatch<WlBuffer, Entity> for InnerServerState<S> {
     ) {
         assert!(matches!(request, Request::<WlBuffer>::Destroy));
 
-        let Some(buffer) = state
-            .world
-            .get::<&client::wl_buffer::WlBuffer>(*entity)
-            .ok()
-        else {
-            warn!("buffer destroy ignored: stale buffer");
-            return;
-        };
-
-        buffer.destroy();
-        drop(buffer);
+        if let Ok(buffer) = state.world.get::<&client::wl_buffer::WlBuffer>(*entity) {
+            buffer.destroy();
+        } else {
+            warn!("buffer destroy: stale buffer proxy");
+        }
         let _ = state.world.despawn(*entity);
     }
 }
@@ -461,6 +455,9 @@ impl<S: X11Selection> Dispatch<WlTouch, Entity> for InnerServerState<S> {
                 touch.release();
                 drop(touch);
                 let _ = state.world.remove_one::<event::TouchFocus>(*entity);
+                let _ = state
+                    .world
+                    .remove::<(client::wl_touch::WlTouch, WlTouch)>(*entity);
             }
             _ => warn!("unhandled touch request: {request:?}"),
         }
@@ -602,11 +599,9 @@ impl<S: X11Selection> Dispatch<WlOutput, Entity> for InnerServerState<S> {
 
                 output.release();
                 drop(output);
-                // remove both sides: server binding is gone, client proxy is dead
                 let _ = state
                     .world
                     .remove_one::<client::wl_output::WlOutput>(*entity);
-                let _ = state.world.remove_one::<WlOutput>(*entity);
             }
             _ => warn!("unhandled output request {request:?}"),
         }

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -165,13 +165,85 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
                     f.destroy();
                     cmd.remove_one::<WpFractionalScaleV1>(*entity);
                 }
+                if let Some(mut active_region) = data.get::<&mut ActiveInputRegion>() {
+                    if let Some(r) = active_region.0.take() {
+                        r.destroy();
+                    }
+                    cmd.remove_one::<ActiveInputRegion>(*entity);
+                }
             }
             Request::<WlSurface>::SetBufferScale { scale } => {
                 client.set_buffer_scale(scale);
             }
             Request::<WlSurface>::SetInputRegion { region } => {
-                let region = region.as_ref().map(|r| r.data().unwrap());
-                client.set_input_region(region);
+                let mut prev_region = data.get::<&mut ActiveInputRegion>();
+                if let Some(r) = region {
+                    let is_popup = data
+                        .get::<&WindowData>()
+                        .map(|d| d.attrs.role.is_popup())
+                        .unwrap_or(false);
+
+                    if is_popup {
+                        client.set_input_region(None);
+                        if let Some(prev) = prev_region.as_mut() {
+                            if let Some(old) = prev.0.take() {
+                                old.destroy();
+                            }
+                        }
+                        drop(prev_region);
+                        return;
+                    }
+
+                    let region_data = r.data::<RegionData>().unwrap();
+                    let ops = region_data.ops.lock().unwrap().clone();
+
+                    let (scale_x, scale_y) = if state.compositor_scaling {
+                        super::event::get_surface_input_scales(&state.world, *entity)
+                    } else {
+                        data.get::<&SurfaceScaleFactor>()
+                            .map(|s| (s.0, s.0))
+                            .unwrap_or((1.0, 1.0))
+                    };
+                    let scale_x = if scale_x > 0.0 { scale_x } else { 1.0 };
+                    let scale_y = if scale_y > 0.0 { scale_y } else { 1.0 };
+
+                    let c_region = state.compositor.create_region(&state.qh, ());
+                    for op in ops {
+                        match op {
+                            RegionOp::Add { x, y, width, height } => {
+                                let sx = (x as f64 / scale_x).round() as i32;
+                                let sy = (y as f64 / scale_y).round() as i32;
+                                let sw = (((x as f64 + width as f64) / scale_x).round() as i32 - sx).max(0);
+                                let sh = (((y as f64 + height as f64) / scale_y).round() as i32 - sy).max(0);
+                                c_region.add(sx, sy, sw, sh);
+                            }
+                            RegionOp::Subtract { x, y, width, height } => {
+                                let sx = (x as f64 / scale_x).round() as i32;
+                                let sy = (y as f64 / scale_y).round() as i32;
+                                let sw = (((x as f64 + width as f64) / scale_x).round() as i32 - sx).max(0);
+                                let sh = (((y as f64 + height as f64) / scale_y).round() as i32 - sy).max(0);
+                                c_region.subtract(sx, sy, sw, sh);
+                            }
+                        }
+                    }
+                    client.set_input_region(Some(&c_region));
+
+                    if let Some(prev) = prev_region.as_mut() {
+                        if let Some(old) = prev.0.replace(c_region) {
+                            old.destroy();
+                        }
+                    } else {
+                        cmd.insert(*entity, (ActiveInputRegion(Some(c_region)),));
+                    }
+                } else {
+                    client.set_input_region(None);
+                    if let Some(prev) = prev_region.as_mut() {
+                        if let Some(old) = prev.0.take() {
+                            old.destroy();
+                        }
+                    }
+                }
+                drop(prev_region);
             }
             other => warn!("unhandled surface request: {other:?}"),
         }
@@ -183,22 +255,54 @@ impl<S: X11Selection> Dispatch<WlSurface, Entity> for InnerServerState<S> {
     }
 }
 
-impl<S: X11Selection> Dispatch<WlRegion, client::wl_region::WlRegion> for InnerServerState<S> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RegionOp {
+    Add { x: i32, y: i32, width: i32, height: i32 },
+    Subtract { x: i32, y: i32, width: i32, height: i32 },
+}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RegionData {
+    pub(super) ops: std::sync::Arc<std::sync::Mutex<Vec<RegionOp>>>,
+}
+
+pub(super) struct ActiveInputRegion(pub(super) Option<client::wl_region::WlRegion>);
+
+impl<S: X11Selection> Dispatch<WlRegion, RegionData> for InnerServerState<S> {
     fn request(
         _: &mut Self,
         _: &wayland_server::Client,
         _: &WlRegion,
         request: <WlRegion as Resource>::Request,
-        client: &client::wl_region::WlRegion,
+        data: &RegionData,
         _: &DisplayHandle,
         _: &mut wayland_server::DataInit<'_, Self>,
     ) {
-        macros::simple_event_shunt! {
-            client, request: wl_region::Request => [
-                Add { x, y, width, height },
-                Subtract { x, y, width, height },
-                Destroy
-            ]
+        match request {
+            wl_region::Request::Add {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                data.ops
+                    .lock()
+                    .unwrap()
+                    .push(RegionOp::Add { x, y, width, height });
+            }
+            wl_region::Request::Subtract {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                data.ops
+                    .lock()
+                    .unwrap()
+                    .push(RegionOp::Subtract { x, y, width, height });
+            }
+            wl_region::Request::Destroy => {}
+            _ => {}
         }
     }
 }
@@ -244,8 +348,8 @@ impl<S: X11Selection>
                 }
             }
             Request::<WlCompositor>::CreateRegion { id } => {
-                let c_region = client.create_region(&state.qh, ());
-                data_init.init(id, c_region);
+                let region_data = RegionData::default();
+                data_init.init(id, region_data);
             }
             other => {
                 warn!("unhandled wlcompositor request: {other:?}");

--- a/src/server/dispatch.rs
+++ b/src/server/dispatch.rs
@@ -234,7 +234,9 @@ impl<S: X11Selection>
                         client,
                         server,
                         viewport,
-                        scale: SurfaceScaleFactor(state.current_scale),
+                        scale: SurfaceScaleFactor(state.global_scale),
+                        true_scale: event::TrueFractionalScale(state.global_scale),
+                        entered_outputs: event::EnteredOutputs(Vec::new()),
                     },
                 );
                 if let Some(f) = fractional {
@@ -901,6 +903,9 @@ impl<S: X11Selection> Dispatch<ConfinedPointerServer, Entity> for InnerServerSta
     }
 }
 
+#[derive(Clone, Copy)]
+struct LockedPointerSurface(Entity);
+
 impl<S: X11Selection> Dispatch<LockedPointerServer, Entity> for InnerServerState<S> {
     fn request(
         state: &mut Self,
@@ -916,17 +921,27 @@ impl<S: X11Selection> Dispatch<LockedPointerServer, Entity> for InnerServerState
                 surface_x,
                 surface_y,
             } => {
-                let (client, scale) = state
-                    .world
-                    .query_one_mut::<(&LockedPointerClient, &SurfaceScaleFactor)>(*entity)
-                    .unwrap();
+                let surf_key = {
+                    let mut query = state
+                        .world
+                        .query_one::<&LockedPointerSurface>(*entity)
+                        .unwrap();
+                    query.get().unwrap().0
+                };
 
-                // Xwayland believes that the surface is actually <surface scale factor> times bigger
-                // than it currently is, and therefore that the cursor position is also scaled up by the same
-                // amount. So we need to divide the cursor position from Xwayland by the surface scale
-                // to get where the cursor should actually be positioned.
+                let scales = if state.compositor_scaling {
+                    super::event::get_surface_input_scales(&state.world, surf_key)
+                } else {
+                    state
+                        .world
+                        .get::<&SurfaceScaleFactor>(surf_key)
+                        .ok()
+                        .map(|s| (s.0, s.0))
+                        .unwrap_or((1.0, 1.0))
+                };
 
-                client.set_cursor_position_hint(surface_x / scale.0, surface_y / scale.0);
+                let client = state.world.get::<&LockedPointerClient>(*entity).unwrap();
+                client.set_cursor_position_hint(surface_x / scales.0, surface_y / scales.1);
             }
             lp::Request::Destroy => {
                 {
@@ -1019,16 +1034,10 @@ impl<S: X11Selection>
                     )
                 };
                 let server = data_init.init(id, entity);
-                let surface_scale = state
-                    .world
-                    .get::<&SurfaceScaleFactor>(surf_key)
-                    .as_deref()
-                    .copied()
-                    .unwrap();
 
                 state
                     .world
-                    .spawn_at(entity, (client, server, surface_scale));
+                    .spawn_at(entity, (client, server, LockedPointerSurface(surf_key)));
             }
             Request::Destroy => {
                 client.destroy();
@@ -1478,6 +1487,7 @@ impl<S: X11Selection> GlobalDispatch<WlOutput, Global> for InnerServerState<S> {
                 server,
                 client,
                 event::OutputScaleFactor::Output(1),
+                event::TrueOutputScaleFactor(event::OutputScaleFactor::Output(1)),
                 event::OutputDimensions::default(),
                 GlobalName(data.name),
             ),

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -51,12 +51,16 @@ use wayland_server::protocol::{
 #[derive(Copy, Clone)]
 pub(super) struct SurfaceScaleFactor(pub f64);
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct EnteredOutputs(pub Vec<Entity>);
+
 #[derive(hecs::Bundle)]
 pub(super) struct SurfaceBundle {
     pub client: client::wl_surface::WlSurface,
     pub server: WlSurface,
     pub viewport: WpViewport,
     pub scale: SurfaceScaleFactor,
+    pub entered_outputs: EnteredOutputs,
 }
 
 #[derive(Debug)]
@@ -95,7 +99,12 @@ impl Event for SurfaceEvents {
                 wp_fractional_scale_v1::Event::PreferredScale { scale } => {
                     let state = state.deref_mut();
                     let entity = state.world.entity(target).unwrap();
-                    let factor = scale as f64 / 120.0;
+                    let true_fractional = scale as f64 / 120.0;
+                    let factor = if state.compositor_scaling {
+                        state.global_scale
+                    } else {
+                        true_fractional
+                    };
                     debug!(
                         "{} scale factor: {}",
                         entity.get::<&WlSurface>().unwrap().id(),
@@ -107,7 +116,9 @@ impl Event for SurfaceEvents {
                     if let Some(OnOutput(output)) = entity.get::<&OnOutput>().as_deref().copied() {
                         if update_output_scale(
                             state.world.query_one(output).unwrap(),
-                            OutputScaleFactor::Fractional(factor),
+                            OutputScaleFactor::Fractional(true_fractional),
+                            state.compositor_scaling,
+                            state.global_scale,
                         ) {
                             state.updated_outputs.push(output);
                         }
@@ -210,17 +221,29 @@ impl SurfaceEvents {
 
                 debug!("{} entered {}", surface.id(), output.id());
 
+                if let Ok(mut entered) = state.world.get::<&mut EnteredOutputs>(target) {
+                    if !entered.0.contains(&output_entity) {
+                        entered.0.push(output_entity);
+                    }
+                }
+
                 let mut query = data.query::<(&x::Window, &mut WindowData)>();
                 if let Some((window, win_data)) = query.get() {
                     let Some(dimensions) = output_data.get::<&OutputDimensions>() else {
                         return;
                     };
+                    let (ox, oy) =
+                        if let Ok(pos) = state.world.get::<&X11OutputPosition>(output_entity) {
+                            (pos.x, pos.y)
+                        } else {
+                            (
+                                dimensions.x - state.global_output_offset.x.value,
+                                dimensions.y - state.global_output_offset.y.value,
+                            )
+                        };
                     win_data.update_output_offset(
                         *window,
-                        WindowOutputOffset {
-                            x: dimensions.x - state.global_output_offset.x.value,
-                            y: dimensions.y - state.global_output_offset.y.value,
-                        },
+                        WindowOutputOffset { x: ox, y: oy },
                         connection,
                     );
                     if state.last_focused_toplevel == Some(*window) {
@@ -230,7 +253,15 @@ impl SurfaceEvents {
                     }
 
                     if state.fractional_scale.is_none() {
-                        let output_scale = output_data.get::<&OutputScaleFactor>().unwrap().get();
+                        let output_scale = if state.compositor_scaling {
+                            if state.global_scale == 1.0 {
+                                // global_scale isn't set this early, so assume 1.0
+                                debug!("compositor scaling: global_scale not ready yet, using 1.0");
+                            }
+                            state.global_scale
+                        } else {
+                            output_data.get::<&OutputScaleFactor>().unwrap().get()
+                        };
                         data.get::<&mut SurfaceScaleFactor>().unwrap().0 = output_scale;
                         drop(query);
                         update_surface_viewport(
@@ -242,6 +273,8 @@ impl SurfaceEvents {
                         if update_output_scale(
                             state.world.query_one(on_output.0).unwrap(),
                             OutputScaleFactor::Fractional(scale.0),
+                            state.compositor_scaling,
+                            state.global_scale,
                         ) {
                             state.updated_outputs.push(on_output.0);
                         }
@@ -255,11 +288,33 @@ impl SurfaceEvents {
                     return;
                 };
                 surface.leave(&output);
+                if let Ok(mut entered) = state.world.get::<&mut EnteredOutputs>(target) {
+                    entered.0.retain(|&e| e != output_entity);
+                }
                 if data
                     .get::<&OnOutput>()
                     .is_some_and(|o| o.0 == output_entity)
                 {
                     cmd.remove_one::<OnOutput>(target);
+                    let mut fallback = None;
+                    if let Ok(entered) = state.world.get::<&EnteredOutputs>(target) {
+                        if let Some(&next_output) = entered.0.iter().find(|&&e| e != output_entity)
+                        {
+                            fallback = Some(next_output);
+                        }
+                    }
+                    if let Some(next_output) = fallback {
+                        cmd.insert_one(target, OnOutput(next_output));
+                        state.updated_outputs.push(next_output);
+                        let scale = data.get::<&SurfaceScaleFactor>().unwrap();
+                        // output is already queued, just keep the true scale from drifting
+                        let _ = update_output_scale(
+                            state.world.query_one(next_output).unwrap(),
+                            OutputScaleFactor::Fractional(scale.0),
+                            state.compositor_scaling,
+                            state.global_scale,
+                        );
+                    }
                 }
             }
             Event::PreferredBufferScale { .. } => {}
@@ -291,25 +346,76 @@ impl SurfaceEvents {
         drop(xdg);
 
         if let Some(pending) = pending {
-            let mut query = data.query::<(
-                &SurfaceScaleFactor,
-                &x::Window,
-                &mut WindowData,
-                &mut SurfaceRole,
-            )>();
-            let (scale_factor, window, window_data, role) = query.get().unwrap();
+            let (scale_factor, window, output_offset, _is_popup, popup_parent) = {
+                let mut query =
+                    data.query::<(&SurfaceScaleFactor, &x::Window, &WindowData, &SurfaceRole)>();
+                let (scale_factor, window, window_data, role) = query.get().unwrap();
+                let is_popup = matches!(role, SurfaceRole::Popup(_));
+                let popup_parent = if let SurfaceRole::Popup(Some(popup_data)) = role {
+                    Some(popup_data.parent)
+                } else {
+                    None
+                };
+                (
+                    scale_factor.0,
+                    *window,
+                    window_data.output_offset,
+                    is_popup,
+                    popup_parent,
+                )
+            };
 
-            let window = *window;
-            let x = (pending.x.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.x;
-            let y = (pending.y.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.y;
-            let width = if pending.width > 0 {
-                (pending.width as f64 * scale_factor.0) as u16
+            let parent_pos_and_decorations_height = if let Some(parent_win) = popup_parent {
+                if let Some(&parent_entity) = state.windows.get(&parent_win) {
+                    let parent_window_data = state.world.get::<&WindowData>(parent_entity).unwrap();
+                    let parent_role = state.world.get::<&SurfaceRole>(parent_entity).unwrap();
+                    let mut decorations_height_scaled = 0;
+                    if let SurfaceRole::Toplevel(Some(toplevel)) = &*parent_role {
+                        if let Some(d) = &toplevel.decoration.satellite {
+                            let parent_surface_width = scale_pos_to_logical(
+                                parent_window_data.attrs.dims.width as f64,
+                                scale_factor,
+                            );
+                            if d.will_draw_decorations(parent_surface_width) {
+                                decorations_height_scaled =
+                                    scale_pos_to_physical(d.titlebar_height() as f64, scale_factor);
+                            }
+                        }
+                    }
+                    Some((
+                        parent_window_data.attrs.dims.x,
+                        parent_window_data.attrs.dims.y,
+                        decorations_height_scaled,
+                    ))
+                } else {
+                    None
+                }
             } else {
+                None
+            };
+
+            let (x, y) = if let Some((px, py, dec_h)) = parent_pos_and_decorations_height {
+                let rx = px as i32 + scale_pos_to_physical(pending.x as f64, scale_factor);
+                let ry = py as i32 + dec_h + scale_pos_to_physical(pending.y as f64, scale_factor);
+                (rx, ry)
+            } else {
+                let rx = scale_pos_to_physical(pending.x as f64, scale_factor) + output_offset.x;
+                let ry = scale_pos_to_physical(pending.y as f64, scale_factor) + output_offset.y;
+                (rx, ry)
+            };
+
+            let width = if pending.width > 0 {
+                scale_size_to_physical(pending.width as f64, scale_factor).clamp(1, u16::MAX as i32)
+                    as u16
+            } else {
+                let window_data = state.world.get::<&WindowData>(target).unwrap();
                 window_data.attrs.dims.width
             };
             let mut height = if pending.height > 0 {
-                (pending.height as f64 * scale_factor.0) as u16
+                scale_size_to_physical(pending.height as f64, scale_factor)
+                    .clamp(1, u16::MAX as i32) as u16
             } else {
+                let window_data = state.world.get::<&WindowData>(target).unwrap();
                 window_data.attrs.dims.height
             };
             debug!(
@@ -317,33 +423,35 @@ impl SurfaceEvents {
                 data.get::<&WlSurface>().unwrap().id(),
             );
 
+            let role = state.world.get::<&SurfaceRole>(target).unwrap();
             if let SurfaceRole::Toplevel(Some(toplevel)) = &*role {
                 if let Some(d) = &toplevel.decoration.satellite {
-                    let surface_width = (width as f64 / scale_factor.0) as i32;
+                    let surface_width = scale_pos_to_logical(width as f64, scale_factor);
                     if d.will_draw_decorations(surface_width) {
-                        height = height
-                            .saturating_sub(
-                                (DecorationsDataSatellite::TITLEBAR_HEIGHT as f64 * scale_factor.0)
-                                    as u16,
-                            )
-                            .max(DecorationsDataSatellite::TITLEBAR_HEIGHT as u16);
+                        let bar_h_scaled =
+                            scale_size_to_physical(d.titlebar_height() as f64, scale_factor)
+                                .clamp(0, u16::MAX as i32) as u16;
+                        height = height.saturating_sub(bar_h_scaled).max(1);
                     }
                 }
             }
+            drop(role);
 
-            window_data.attrs.dims = WindowDims {
-                x: x as i16,
-                y: y as i16,
-                width,
-                height,
-            };
+            {
+                let mut window_data = state.world.get::<&mut WindowData>(target).unwrap();
+                window_data.attrs.dims = WindowDims {
+                    x: x.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+                    y: y.clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+                    width,
+                    height,
+                };
+            }
             let pending = PendingSurfaceState {
                 x,
                 y,
                 width: width as _,
                 height: height as _,
             };
-            drop(query);
             state.world.insert_one(target, pending).unwrap();
             update_surface_viewport(&state.world, state.world.query_one(target).unwrap());
         }
@@ -467,7 +575,7 @@ impl SurfaceEvents {
                     .connection
                     .unmap_window(*data.get::<&x::Window>().unwrap());
             }
-            other => todo!("{other:?}"),
+            other => warn!("unhandled xdg popup event: {other:?}"),
         }
     }
 }
@@ -509,11 +617,12 @@ pub(super) fn update_surface_viewport(
             return;
         };
 
-        let decorations_height = if data.decoration.satellite.is_some() {
-            DecorationsDataSatellite::TITLEBAR_HEIGHT
-        } else {
-            0
-        };
+        let decorations_height = data
+            .decoration
+            .satellite
+            .as_ref()
+            .map(|s| s.titlebar_height())
+            .unwrap_or(0);
 
         if let Some(min) = hints.min_size {
             debug!(
@@ -554,7 +663,41 @@ impl Event for client::wl_seat::Event {
 }
 
 struct PendingEnter(client::wl_pointer::Event);
-enum CurrentSurface {
+#[inline]
+pub(super) fn safe_scale(scale: f64) -> f64 {
+    if scale.is_finite() && scale > 0.0 {
+        scale
+    } else {
+        1.0
+    }
+}
+
+#[inline]
+pub(super) fn scale_pos_to_physical(value: f64, scale: f64) -> i32 {
+    (value * safe_scale(scale)).round() as i32
+}
+
+#[inline]
+pub(super) fn scale_pos_to_logical(value: f64, scale: f64) -> i32 {
+    (value / safe_scale(scale)).round() as i32
+}
+
+#[inline]
+pub(super) fn scale_size_to_physical(value: f64, scale: f64) -> i32 {
+    (value * safe_scale(scale)).ceil().max(1.0) as i32
+}
+
+#[inline]
+pub(super) fn scale_size_to_logical(value: f64, scale: f64) -> i32 {
+    (value / safe_scale(scale)).ceil().max(1.0) as i32
+}
+
+#[inline]
+pub(super) fn scale_input_to_xwayland(value: f64, scale: f64) -> f64 {
+    value * safe_scale(scale)
+}
+#[derive(Clone, Copy)]
+pub(super) enum CurrentSurface {
     Xwayland(Entity),
     Decoration(Entity),
 }
@@ -563,6 +706,11 @@ impl CurrentSurface {
     fn is_decoration(&self) -> bool {
         matches!(self, Self::Decoration(..))
     }
+}
+
+#[derive(Default)]
+pub(super) struct TouchFocus {
+    pub points: std::collections::HashMap<i32, CurrentSurface>,
 }
 pub struct LastClickSerial(pub client::wl_seat::WlSeat, pub u32);
 
@@ -654,9 +802,19 @@ impl Event for client::wl_pointer::Event {
                 cmd.insert(target, (*scale,));
 
                 let surface_is_popup = matches!(role, SurfaceRole::Popup(_));
+                let pointer_coords = if state.compositor_scaling {
+                    surface_to_xwayland_input_coords(
+                        &state.world,
+                        surface_entity.unwrap(),
+                        surface_x,
+                        surface_y,
+                    )
+                } else {
+                    (surface_x * scale.0, surface_y * scale.0)
+                };
                 let mut do_enter = || {
                     debug!("pointer entering {} ({serial} {})", surface.id(), scale.0);
-                    server.enter(serial, surface, surface_x * scale.0, surface_y * scale.0);
+                    server.enter(serial, surface, pointer_coords.0, pointer_coords.1);
                     connection.raise_to_top(*window);
                     if !surface_is_popup {
                         state.last_hovered = Some(*window);
@@ -736,17 +894,38 @@ impl Event for client::wl_pointer::Event {
                         return;
                     }
                 }
-                let (server, scale) = state
+                let pointer_coords = state
                     .world
-                    .query_one_mut::<(&WlPointer, &SurfaceScaleFactor)>(target)
-                    .unwrap();
+                    .get::<&CurrentSurface>(target)
+                    .ok()
+                    .and_then(|surf| match &*surf {
+                        CurrentSurface::Xwayland(e) => {
+                            if state.compositor_scaling {
+                                Some(surface_to_xwayland_input_coords(
+                                    &state.world,
+                                    *e,
+                                    surface_x,
+                                    surface_y,
+                                ))
+                            } else {
+                                state
+                                    .world
+                                    .get::<&SurfaceScaleFactor>(*e)
+                                    .ok()
+                                    .map(|s| (surface_x * s.0, surface_y * s.0))
+                            }
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or((surface_x, surface_y));
+                let server = state.world.get::<&WlPointer>(target).unwrap();
                 trace!(
                     target: "pointer_position",
                     "pointer motion {} {}",
-                    surface_x * scale.0,
-                    surface_y * scale.0
+                    pointer_coords.0,
+                    pointer_coords.1
                 );
-                server.motion(time, surface_x * scale.0, surface_y * scale.0);
+                server.motion(time, pointer_coords.0, pointer_coords.1);
             }
             Self::Button {
                 serial,
@@ -935,8 +1114,9 @@ impl Event for client::wl_keyboard::Event {
 
 impl Event for client::wl_touch::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
+        use client::wl_touch::Event::*;
         match self {
-            Self::Down {
+            Down {
                 serial,
                 time,
                 surface,
@@ -949,52 +1129,172 @@ impl Event for client::wl_touch::Event {
                     let connection = &mut state.connection;
                     let world = &mut state.inner.world;
                     let s_entity = surface.data().copied();
+
                     let mut s_query = s_entity.and_then(|key| {
                         world
                             .query_one::<(&WlSurface, &SurfaceScaleFactor, &x::Window)>(key)
                             .ok()
                     });
-                    if let Some((s_surface, s_factor, window)) =
-                        s_query.as_mut().and_then(|q| q.get())
-                    {
-                        cmd.insert_one(target, *s_factor);
-                        connection.raise_to_top(*window);
-                        let touch = world.get::<&WlTouch>(target).unwrap();
-                        touch.down(serial, time, s_surface, id, x * s_factor.0, y * s_factor.0);
+
+                    let target_info = s_query
+                        .as_mut()
+                        .and_then(|q| q.get())
+                        .map(|(s_surf, scale_factor, win)| (s_surf.clone(), scale_factor.0, *win));
+                    drop(s_query);
+
+                    if let Some((s_surface, scale_factor, window)) = target_info {
+                        let Some(s_entity) = s_entity else {
+                            warn!("touch down failed: stale surface");
+                            return;
+                        };
+
+                        let scales = if state.inner.compositor_scaling {
+                            get_surface_input_scales(world, s_entity)
+                        } else {
+                            (scale_factor, scale_factor)
+                        };
+
+                        let mut focus = world.remove_one::<TouchFocus>(target).unwrap_or_default();
+                        focus.points.insert(id, CurrentSurface::Xwayland(s_entity));
+                        cmd.insert_one(target, focus);
+
+                        connection.raise_to_top(window);
+
+                        if let Ok(touch) = world.get::<&WlTouch>(target) {
+                            touch.down(
+                                serial,
+                                time,
+                                &s_surface,
+                                id,
+                                scale_input_to_xwayland(x, scales.0),
+                                scale_input_to_xwayland(y, scales.1),
+                            );
+                        } else {
+                            warn!("touch down failed: stale touch object");
+                        }
                     } else if let Some(&DecorationMarker { parent }) = surface.data() {
-                        drop(s_query);
+                        let mut focus = world.remove_one::<TouchFocus>(target).unwrap_or_default();
+                        focus.points.insert(id, CurrentSurface::Decoration(parent));
+                        cmd.insert_one(target, focus);
+
                         let seat = {
-                            let seat =
-                                &*state.world.get::<&client::wl_seat::WlSeat>(target).unwrap();
-                            seat.clone()
+                            let Ok(seat_ref) = state.world.get::<&client::wl_seat::WlSeat>(target)
+                            else {
+                                warn!("touch decoration click failed: stale seat");
+                                return;
+                            };
+                            (*seat_ref).clone()
                         };
                         decoration::handle_pointer_motion(state, parent, x, y);
                         decoration::handle_pointer_click(state, parent, &seat, serial);
+                    } else {
+                        warn!("touch down failed: stale surface");
                     }
                 }
                 cmd.run_on(&mut state.world);
             }
-            Self::Motion { time, id, x, y } => {
-                let Ok((touch, scale)) = state
+            Motion { time, id, x, y } => {
+                let Some(current_surface) = state
                     .world
-                    .query_one_mut::<(&WlTouch, &SurfaceScaleFactor)>(target)
+                    .get::<&TouchFocus>(target)
+                    .ok()
+                    .and_then(|focus| focus.points.get(&id).copied())
                 else {
+                    warn!("touch motion failed: missing touch focus for id {id}");
                     return;
                 };
-                touch.motion(time, id, x * scale.0, y * scale.0);
-            }
-            _ => {
-                let touch = state.world.get::<&WlTouch>(target).unwrap();
-                simple_event_shunt! {
-                    touch, self => [
-                        Up { serial, time, id },
-                        Frame,
-                        Cancel,
-                        Shape { id, major, minor },
-                        Orientation { id, orientation }
-                    ]
+
+                let scales = if state.inner.compositor_scaling {
+                    match current_surface {
+                        CurrentSurface::Xwayland(e) => get_surface_input_scales(&state.world, e),
+                        CurrentSurface::Decoration(_) => (1.0, 1.0),
+                    }
+                } else {
+                    match current_surface {
+                        CurrentSurface::Xwayland(e) => {
+                            let scale = state
+                                .world
+                                .get::<&SurfaceScaleFactor>(e)
+                                .ok()
+                                .map(|s| s.0)
+                                .unwrap_or(1.0);
+                            (scale, scale)
+                        }
+                        CurrentSurface::Decoration(_) => (1.0, 1.0),
+                    }
+                };
+
+                match current_surface {
+                    CurrentSurface::Xwayland(_) => {
+                        if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                            touch.motion(
+                                time,
+                                id,
+                                scale_input_to_xwayland(x, scales.0),
+                                scale_input_to_xwayland(y, scales.1),
+                            );
+                        } else {
+                            warn!("touch motion failed: stale touch object");
+                        }
+                    }
+                    CurrentSurface::Decoration(parent) => {
+                        decoration::handle_pointer_motion(state, parent, x, y);
+                    }
                 }
             }
+            Up { serial, time, id } => {
+                let mut cmd = CommandBuffer::new();
+                let remove_focus = if let Ok(mut focus) = state.world.get::<&mut TouchFocus>(target)
+                {
+                    focus.points.remove(&id);
+                    focus.points.is_empty()
+                } else {
+                    false
+                };
+
+                if remove_focus {
+                    cmd.remove_one::<TouchFocus>(target);
+                }
+
+                if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                    touch.up(serial, time, id);
+                } else {
+                    warn!("touch up failed: stale touch object");
+                }
+                cmd.run_on(&mut state.world);
+            }
+            Cancel => {
+                let mut cmd = CommandBuffer::new();
+                cmd.remove_one::<TouchFocus>(target);
+                if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                    touch.cancel();
+                } else {
+                    warn!("touch cancel failed: stale touch object");
+                }
+                cmd.run_on(&mut state.world);
+            }
+            Frame => {
+                if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                    touch.frame();
+                } else {
+                    warn!("touch frame failed: stale touch object");
+                }
+            }
+            Shape { id, major, minor } => {
+                if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                    touch.shape(id, major, minor);
+                } else {
+                    warn!("touch shape failed: stale touch object");
+                }
+            }
+            Orientation { id, orientation } => {
+                if let Ok(touch) = state.world.get::<&WlTouch>(target) {
+                    touch.orientation(id, orientation);
+                } else {
+                    warn!("touch orientation failed: stale touch object");
+                }
+            }
+            _ => warn!("unhandled touch event: {:?}", self),
         }
     }
 }
@@ -1012,6 +1312,306 @@ pub(super) enum OutputScaleFactor {
     Fractional(f64),
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct TrueOutputScaleFactor(pub OutputScaleFactor);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct X11OutputPosition {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub(super) fn recalculate_x11_output_positions(
+    world: &mut World,
+    compositor_scaling: bool,
+    global_scale: f64,
+) {
+    if !compositor_scaling {
+        return;
+    }
+
+    struct OutputNode {
+        entity: Entity,
+        lx: f64,
+        ly: f64,
+        rx: Option<i32>,
+        ry: Option<i32>,
+    }
+
+    // treat outputs as nodes in the compositor layout
+    let mut nodes: Vec<_> = world
+        .query::<(&OutputDimensions, &TrueOutputScaleFactor)>()
+        .iter()
+        .map(|(e, (d, _s))| OutputNode {
+            entity: e,
+            lx: d.x as f64,
+            ly: d.y as f64,
+            rx: None,
+            ry: None,
+        })
+        .collect();
+
+    if nodes.is_empty() {
+        return;
+    }
+
+    // anchor near zero, then walk neighbors so mixed-dpi layouts stay flush
+    let root_idx = nodes
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            let dist_a = a.lx * a.lx + a.ly * a.ly;
+            let dist_b = b.lx * b.lx + b.ly * b.ly;
+            dist_a.total_cmp(&dist_b)
+        })
+        .map(|(i, _)| i)
+        .unwrap();
+
+    nodes[root_idx].rx = Some(0);
+    nodes[root_idx].ry = Some(0);
+
+    // nearest placed output gives the least surprising seam
+    loop {
+        let mut progress = false;
+        let mut best_transition = None;
+
+        for (u_idx, u_node) in nodes.iter().enumerate() {
+            if u_node.rx.is_some() {
+                continue;
+            }
+            for (r_idx, r_node) in nodes.iter().enumerate() {
+                if r_node.rx.is_none() {
+                    continue;
+                }
+                let dx = u_node.lx - r_node.lx;
+                let dy = u_node.ly - r_node.ly;
+                let dist = dx * dx + dy * dy;
+
+                match best_transition {
+                    None => {
+                        best_transition = Some((u_idx, r_idx, dist));
+                    }
+                    Some((_, _, min_dist)) if dist < min_dist => {
+                        best_transition = Some((u_idx, r_idx, dist));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if let Some((u_idx, r_idx, _)) = best_transition {
+            let u_node = &nodes[u_idx];
+            let r_node = &nodes[r_idx];
+
+            let dx = u_node.lx - r_node.lx;
+            let dy = u_node.ly - r_node.ly;
+
+            // compositor scaling wants one x11-sized grid
+            let rx = r_node.rx.unwrap() + scale_pos_to_physical(dx, global_scale);
+            let ry = r_node.ry.unwrap() + scale_pos_to_physical(dy, global_scale);
+
+            nodes[u_idx].rx = Some(rx);
+            nodes[u_idx].ry = Some(ry);
+            progress = true;
+        }
+
+        if !progress {
+            break;
+        }
+    }
+
+    for node in nodes {
+        if node.rx.is_none() {
+            warn!(
+                "Failed to calculate relative X11 position for output {:?}, falling back to (0, 0)",
+                node.entity
+            );
+        }
+        let rx = node.rx.unwrap_or(0);
+        let ry = node.ry.unwrap_or(0);
+        world
+            .insert_one(node.entity, X11OutputPosition { x: rx, y: ry })
+            .unwrap();
+    }
+}
+
+pub(super) fn surface_to_xwayland_input_coords(
+    world: &World,
+    e: Entity,
+    x: f64,
+    y: f64,
+) -> (f64, f64) {
+    let scales = get_surface_input_scales(world, e);
+    (
+        scale_input_to_xwayland(x, scales.0),
+        scale_input_to_xwayland(y, scales.1),
+    )
+}
+
+pub(super) fn xwayland_to_surface_input_coords(
+    world: &World,
+    e: Entity,
+    x: f64,
+    y: f64,
+) -> (f64, f64) {
+    let scales = get_surface_input_scales(world, e);
+    let scale_x = safe_scale(scales.0);
+    let scale_y = safe_scale(scales.1);
+    (x / scale_x, y / scale_y)
+}
+
+pub(super) fn get_surface_input_scales(world: &World, e: Entity) -> (f64, f64) {
+    let target_e = if world.contains(e) && world.get::<&OnOutput>(e).is_err() {
+        if let Ok(marker) = world.get::<&DecorationMarker>(e) {
+            marker.parent
+        } else {
+            let surf = world.get::<&WlSurface>(e).ok();
+            let mut query = world.query::<(&x::Window, &WlSurface)>();
+            query
+                .into_iter()
+                .find(|(win_entity, (_, wl_surf))| {
+                    *win_entity == e
+                        || surf
+                            .as_ref()
+                            .map(|s| wl_surf.id() == s.id())
+                            .unwrap_or(false)
+                })
+                .map(|(win_entity, _)| win_entity)
+                .or_else(|| {
+                    let mut on_output_query = world.query::<(&x::Window, &OnOutput)>();
+                    on_output_query
+                        .into_iter()
+                        .next()
+                        .map(|(win_entity, _)| win_entity)
+                })
+                .unwrap_or(e)
+        }
+    } else {
+        e
+    };
+
+    let scale = world
+        .get::<&SurfaceScaleFactor>(target_e)
+        .ok()
+        .map(|s| s.0)
+        .filter(|s| s.is_finite() && *s > 0.0)
+        .or_else(|| {
+            world.get::<&OnOutput>(target_e).ok().and_then(|on_output| {
+                world
+                    .get::<&TrueOutputScaleFactor>(on_output.0)
+                    .ok()
+                    .map(|s| s.0.get())
+                    .or_else(|| {
+                        world
+                            .get::<&OutputScaleFactor>(on_output.0)
+                            .ok()
+                            .map(|s| s.get())
+                    })
+            })
+        })
+        .unwrap_or(1.0);
+    let win_data = world.get::<&WindowData>(target_e).ok();
+
+    let is_fullscreen = world
+        .get::<&SurfaceRole>(target_e)
+        .ok()
+        .map(|r| match &*r {
+            SurfaceRole::Toplevel(Some(toplevel)) => toplevel.fullscreen,
+            _ => false,
+        })
+        .unwrap_or(false);
+
+    if let Ok(on_output) = world.get::<&OnOutput>(target_e) {
+        if let Ok(dims) = world.get::<&OutputDimensions>(on_output.0) {
+            let (lw, lh) = match (dims.logical_width, dims.logical_height) {
+                (Some(lw), Some(lh)) => (lw, lh),
+                _ => {
+                    if dims.rotated_90 {
+                        (dims.height, dims.width)
+                    } else {
+                        (dims.width, dims.height)
+                    }
+                }
+            };
+            let (physical_w, physical_h) = if dims.rotated_90 {
+                (dims.height as f64, dims.width as f64)
+            } else {
+                (dims.width as f64, dims.height as f64)
+            };
+            let logical_w = lw as f64;
+            let logical_h = lh as f64;
+            if logical_w.is_finite()
+                && logical_w > 0.0
+                && logical_h.is_finite()
+                && logical_h > 0.0
+                && physical_w > 0.0
+                && physical_h > 0.0
+            {
+                if is_fullscreen {
+                    if let Some(win) = &win_data {
+                        let win_w = win.attrs.dims.width as f64;
+                        let win_h = win.attrs.dims.height as f64;
+                        if win_w > 0.0 && win_h > 0.0 {
+                            let scale_x = win_w / logical_w;
+                            let scale_y = win_h / logical_h;
+                            if scale_x.is_finite()
+                                && scale_y.is_finite()
+                                && scale_x > 0.0
+                                && scale_y > 0.0
+                            {
+                                let (physical_w, physical_h) = if dims.rotated_90 {
+                                    (dims.height as f64, dims.width as f64)
+                                } else {
+                                    (dims.width as f64, dims.height as f64)
+                                };
+                                let eff_scale = world
+                                    .get::<&TrueOutputScaleFactor>(on_output.0)
+                                    .ok()
+                                    .map(|s| s.0.get())
+                                    .or_else(|| {
+                                        world
+                                            .get::<&OutputScaleFactor>(on_output.0)
+                                            .ok()
+                                            .map(|s| s.get())
+                                    })
+                                    .unwrap_or(scale);
+
+                                let expected_w = if (win_w - physical_w * eff_scale).abs()
+                                    < (win_w - physical_w).abs()
+                                {
+                                    physical_w * eff_scale
+                                } else {
+                                    physical_w
+                                };
+                                let expected_h = if (win_h - physical_h * eff_scale).abs()
+                                    < (win_h - physical_h).abs()
+                                {
+                                    physical_h * eff_scale
+                                } else {
+                                    physical_h
+                                };
+
+                                let width_error = (win_w - expected_w).abs() / expected_w;
+                                let height_error = (win_h - expected_h).abs() / expected_h;
+
+                                let is_stale_fullscreen_size =
+                                    width_error > 0.08 || height_error > 0.08;
+
+                                if !is_stale_fullscreen_size {
+                                    return (scale_x, scale_y);
+                                }
+                            }
+                        }
+                    }
+                }
+                return (scale, scale);
+            }
+        }
+    }
+
+    (scale, scale)
+}
+
 impl OutputScaleFactor {
     pub(super) fn get(&self) -> f64 {
         match *self {
@@ -1022,29 +1622,43 @@ impl OutputScaleFactor {
 }
 
 #[must_use]
-fn update_output_scale(
-    mut output_scale: hecs::QueryOne<&mut OutputScaleFactor>,
+pub(super) fn update_output_scale(
+    mut output: hecs::QueryOne<(&mut OutputScaleFactor, &mut TrueOutputScaleFactor)>,
     factor: OutputScaleFactor,
+    compositor_scaling: bool,
+    global_scale: f64,
 ) -> bool {
-    let Some(output_scale) = output_scale.get() else {
+    let Some((output_scale, true_output_scale)) = output.get() else {
         return false;
     };
 
-    if matches!(output_scale, OutputScaleFactor::Fractional(..))
+    if matches!(true_output_scale.0, OutputScaleFactor::Fractional(..))
         && matches!(factor, OutputScaleFactor::Output(..))
     {
         return false;
     }
 
-    if *output_scale != factor {
-        *output_scale = factor;
-        return true;
+    let mut changed = false;
+    if true_output_scale.0 != factor {
+        true_output_scale.0 = factor;
+        changed = true;
     }
 
-    false
+    let effective = if compositor_scaling {
+        OutputScaleFactor::Fractional(global_scale)
+    } else {
+        factor
+    };
+
+    if *output_scale != effective {
+        *output_scale = effective;
+        changed = true;
+    }
+
+    changed
 }
 
-enum OutputDimensionsSource {
+pub(super) enum OutputDimensionsSource {
     // The data in this variant is the values needed for the wl_output.geometry event.
     Wl {
         physical_width: i32,
@@ -1058,12 +1672,16 @@ enum OutputDimensionsSource {
 }
 
 pub(super) struct OutputDimensions {
-    source: OutputDimensionsSource,
+    pub source: OutputDimensionsSource,
     pub x: i32,
     pub y: i32,
     pub width: i32,
     pub height: i32,
-    rotated_90: bool,
+    pub refresh: i32,
+    pub mode_flags: WEnum<client::wl_output::Mode>,
+    pub rotated_90: bool,
+    pub logical_width: Option<i32>,
+    pub logical_height: Option<i32>,
 }
 
 impl Default for OutputDimensions {
@@ -1081,7 +1699,11 @@ impl Default for OutputDimensions {
             y: 0,
             width: 0,
             height: 0,
+            refresh: 60000,
+            mode_flags: WEnum::Value(client::wl_output::Mode::Current),
             rotated_90: false,
+            logical_width: None,
+            logical_height: None,
         }
     }
 }
@@ -1132,15 +1754,23 @@ fn update_output_offset(
         );
     }
 
-    update_window_output_offsets(
-        output,
-        &state.global_output_offset,
-        &state.world,
-        connection,
+    recalculate_x11_output_positions(
+        &mut state.world,
+        state.compositor_scaling,
+        state.global_scale,
     );
+    let outputs: Vec<hecs::Entity> = state
+        .world
+        .query::<&OutputDimensions>()
+        .iter()
+        .map(|(e, _)| e)
+        .collect();
+    for out in outputs {
+        update_window_output_offsets(out, &state.global_output_offset, &state.world, connection);
+    }
 }
 
-fn update_window_output_offsets(
+pub(super) fn update_window_output_offsets(
     output: Entity,
     global_output_offset: &GlobalOutputOffset,
     world: &World,
@@ -1149,21 +1779,128 @@ fn update_window_output_offsets(
     let Ok(dimensions) = world.get::<&OutputDimensions>(output) else {
         return;
     };
-    let mut query = world.query::<(&x::Window, &mut WindowData, &OnOutput)>();
+    let (ox, oy) = if let Ok(pos) = world.get::<&X11OutputPosition>(output) {
+        (pos.x, pos.y)
+    } else {
+        (
+            dimensions.x - global_output_offset.x.value,
+            dimensions.y - global_output_offset.y.value,
+        )
+    };
+    let new_offset = WindowOutputOffset { x: ox, y: oy };
 
+    let mut updated_windows: Vec<x::Window> = vec![];
+    let mut query = world.query::<(&x::Window, &mut WindowData, &OnOutput)>();
     for (_, (window, data, _)) in query
         .into_iter()
         .filter(|(_, (_, _, on_output))| on_output.0 == output)
     {
-        data.update_output_offset(
-            *window,
-            WindowOutputOffset {
-                x: dimensions.x - global_output_offset.x.value,
-                y: dimensions.y - global_output_offset.y.value,
-            },
-            connection,
-        );
+        data.update_output_offset(*window, new_offset, connection);
+        updated_windows.push(*window);
     }
+    drop(query);
+
+    // Transient and popup windows don't carry OnOutput, so copy the parent offset
+    // before the next configure uses it for positioner math.
+    if !updated_windows.is_empty() {
+        let mut popup_query =
+            world.query::<(&x::Window, &mut WindowData, &mut SurfaceScaleFactor)>();
+        for (_, (window, data, scale)) in popup_query.into_iter().filter(|(_, (_, data, _))| {
+            data.attrs.is_popup
+                && data
+                    .attrs
+                    .transient_for
+                    .map(|p| updated_windows.contains(&p))
+                    .unwrap_or(false)
+        }) {
+            data.update_output_offset(*window, new_offset, connection);
+            if let Ok(out_scale) = world.get::<&OutputScaleFactor>(output) {
+                scale.0 = out_scale.get();
+            }
+        }
+    }
+}
+
+impl OutputDimensions {
+    pub fn get_true_scale(&self) -> f64 {
+        if let (Some(lw), Some(lh)) = (self.logical_width, self.logical_height) {
+            if lw > 0 && lh > 0 {
+                let physical_width = if self.rotated_90 {
+                    self.height
+                } else {
+                    self.width
+                };
+                return physical_width as f64 / lw as f64;
+            }
+        }
+        1.0
+    }
+}
+
+pub(super) fn guess_initial_scale(
+    world: &World,
+    dims: WindowDims,
+    default_scale: f64,
+    compositor_scaling: bool,
+) -> f64 {
+    if dims.width == 0 || dims.height == 0 {
+        return default_scale;
+    }
+
+    let cx = dims.x as f64 + dims.width as f64 / 2.0;
+    let cy = dims.y as f64 + dims.height as f64 / 2.0;
+
+    let mut best_scale = None;
+    let mut max_scale = 1.0;
+
+    for (entity, (dimensions, scale_factor, true_scale)) in world
+        .query::<(
+            &OutputDimensions,
+            &OutputScaleFactor,
+            Option<&TrueOutputScaleFactor>,
+        )>()
+        .iter()
+    {
+        let s = if compositor_scaling {
+            let ts = true_scale
+                .map(|ts| ts.0.get())
+                .unwrap_or_else(|| dimensions.get_true_scale());
+            if ts > 0.0 { ts } else { scale_factor.get() }
+        } else {
+            scale_factor.get()
+        };
+
+        if s > max_scale {
+            max_scale = s;
+        }
+
+        let (ox, oy) = if compositor_scaling {
+            if let Ok(pos) = world.get::<&X11OutputPosition>(entity) {
+                (pos.x as f64, pos.y as f64)
+            } else {
+                (dimensions.x as f64, dimensions.y as f64)
+            }
+        } else {
+            (dimensions.x as f64, dimensions.y as f64)
+        };
+
+        let (ow, oh) = if dimensions.rotated_90 {
+            (dimensions.height as f64, dimensions.width as f64)
+        } else {
+            (dimensions.width as f64, dimensions.height as f64)
+        };
+
+        if cx >= ox && cx < ox + ow && cy >= oy && cy < oy + oh {
+            best_scale = Some(s);
+            break;
+        }
+    }
+
+    best_scale.unwrap_or(if max_scale > 1.0 {
+        max_scale
+    } else {
+        default_scale
+    })
 }
 
 pub(super) fn update_global_output_offset(
@@ -1171,6 +1908,8 @@ pub(super) fn update_global_output_offset(
     global_output_offset: &GlobalOutputOffset,
     world: &World,
     connection: &mut impl XConnection,
+    global_scale: f64,
+    compositor_scaling: bool,
 ) {
     let entity = world.entity(output).unwrap();
     let mut query = entity.query::<(&OutputDimensions, &WlOutput)>();
@@ -1180,6 +1919,17 @@ pub(super) fn update_global_output_offset(
 
     let x = dimensions.x - global_output_offset.x.value;
     let y = dimensions.y - global_output_offset.y.value;
+    let (scaled_x, scaled_y) = if compositor_scaling {
+        let pos = world.get::<&X11OutputPosition>(output).ok();
+        pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+            (
+                scale_pos_to_physical(x as f64, global_scale),
+                scale_pos_to_physical(y as f64, global_scale),
+            )
+        })
+    } else {
+        (x, y)
+    };
 
     match &dimensions.source {
         OutputDimensionsSource::Wl {
@@ -1190,11 +1940,12 @@ pub(super) fn update_global_output_offset(
             model,
             transform,
         } => {
+            let (pw, ph) = (*physical_width, *physical_height);
             server.geometry(
-                x,
-                y,
-                *physical_width,
-                *physical_height,
+                scaled_x,
+                scaled_y,
+                pw,
+                ph,
                 convert_wenum(*subpixel),
                 make.clone(),
                 model.clone(),
@@ -1205,7 +1956,7 @@ pub(super) fn update_global_output_offset(
             entity
                 .get::<&XdgOutputServer>()
                 .unwrap()
-                .logical_position(x, y);
+                .logical_position(scaled_x, scaled_y);
         }
     }
 
@@ -1275,6 +2026,18 @@ impl OutputEvent {
                     state,
                 );
                 let global_output_offset = state.global_output_offset;
+                let compositor_scaling = state.compositor_scaling;
+                let global_scale = state.global_scale;
+
+                let pos = if compositor_scaling {
+                    state
+                        .world
+                        .get::<&X11OutputPosition>(target)
+                        .ok()
+                        .map(|p| *p)
+                } else {
+                    None
+                };
 
                 let Ok((output, dimensions, xdg)) = state.world.query_one_mut::<(
                     &WlOutput,
@@ -1284,11 +2047,27 @@ impl OutputEvent {
                     return;
                 };
 
+                let (scaled_x, scaled_y) = if compositor_scaling {
+                    pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+                        (
+                            ((x - global_output_offset.x.value) as f64 * global_scale).round()
+                                as i32,
+                            ((y - global_output_offset.y.value) as f64 * global_scale).round()
+                                as i32,
+                        )
+                    })
+                } else {
+                    (
+                        x - global_output_offset.x.value,
+                        y - global_output_offset.y.value,
+                    )
+                };
+                let (pw, ph) = (physical_width, physical_height);
                 output.geometry(
-                    x - global_output_offset.x.value,
-                    y - global_output_offset.y.value,
-                    physical_width,
-                    physical_height,
+                    scaled_x,
+                    scaled_y,
+                    pw,
+                    ph,
                     convert_wenum(subpixel),
                     make,
                     model,
@@ -1304,11 +2083,20 @@ impl OutputEvent {
                     )
                 });
                 if let Some(xdg) = xdg {
-                    if dimensions.rotated_90 {
-                        xdg.logical_size(dimensions.height, dimensions.width);
+                    let (w, h) = if dimensions.rotated_90 {
+                        (dimensions.height, dimensions.width)
                     } else {
-                        xdg.logical_size(dimensions.width, dimensions.height);
-                    }
+                        (dimensions.width, dimensions.height)
+                    };
+                    let (sw, sh) = if compositor_scaling {
+                        (
+                            scale_size_to_physical(w as f64, global_scale),
+                            scale_size_to_physical(h as f64, global_scale),
+                        )
+                    } else {
+                        (w, h)
+                    };
+                    xdg.logical_size(sw, sh);
                 }
             }
             Event::Mode {
@@ -1317,6 +2105,8 @@ impl OutputEvent {
                 height,
                 refresh,
             } => {
+                let compositor_scaling = state.compositor_scaling;
+                let global_scale = state.global_scale;
                 let Ok((output, dimensions)) = state
                     .world
                     .query_one_mut::<(&WlOutput, &mut OutputDimensions)>(target)
@@ -1330,9 +2120,19 @@ impl OutputEvent {
                 {
                     dimensions.width = width;
                     dimensions.height = height;
+                    dimensions.refresh = refresh;
+                    dimensions.mode_flags = convert_wenum(flags);
                     debug!("{} dimensions: {width}x{height}", output.id());
                 }
-                output.mode(convert_wenum(flags), width, height, refresh);
+                let (w, h) = if compositor_scaling {
+                    (
+                        scale_size_to_physical(width as f64, global_scale),
+                        scale_size_to_physical(height as f64, global_scale),
+                    )
+                } else {
+                    (width, height)
+                };
+                output.mode(convert_wenum(flags), w, h, refresh);
             }
             Event::Scale { factor } => {
                 debug!(
@@ -1342,11 +2142,18 @@ impl OutputEvent {
                 if update_output_scale(
                     state.world.query_one(target).unwrap(),
                     OutputScaleFactor::Output(factor),
+                    state.compositor_scaling,
+                    state.global_scale,
                 ) {
                     state.updated_outputs.push(target);
                 }
                 if state.fractional_scale.is_none() {
-                    state.world.get::<&WlOutput>(target).unwrap().scale(factor);
+                    let send_factor = if state.compositor_scaling { 1 } else { factor };
+                    state
+                        .world
+                        .get::<&WlOutput>(target)
+                        .unwrap()
+                        .scale(send_factor);
                 }
             }
             Event::Name { name } => {
@@ -1378,28 +2185,58 @@ impl OutputEvent {
             Event::LogicalPosition { x, y } => {
                 update_output_offset(target, OutputDimensionsSource::Xdg, x, y, state);
                 if !state.global_offset_updated {
+                    let compositor_scaling = state.inner.compositor_scaling;
+                    let global_scale = state.inner.global_scale;
+                    let global_output_offset = state.inner.global_output_offset;
+
+                    let (scaled_x, scaled_y) = if compositor_scaling {
+                        let pos = state.world.get::<&X11OutputPosition>(target).ok();
+                        pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+                            (
+                                scale_pos_to_physical(
+                                    (x - global_output_offset.x.value) as f64,
+                                    global_scale,
+                                ),
+                                scale_pos_to_physical(
+                                    (y - global_output_offset.y.value) as f64,
+                                    global_scale,
+                                ),
+                            )
+                        })
+                    } else {
+                        (
+                            x - state.inner.global_output_offset.x.value,
+                            y - state.inner.global_output_offset.y.value,
+                        )
+                    };
                     state
                         .world
                         .get::<&XdgOutputServer>(target)
                         .unwrap()
-                        .logical_position(
-                            x - state.global_output_offset.x.value,
-                            y - state.global_output_offset.y.value,
-                        );
+                        .logical_position(scaled_x, scaled_y);
                 }
             }
-            Event::LogicalSize { .. } => {
+            Event::LogicalSize { width, height } => {
+                let compositor_scaling = state.inner.compositor_scaling;
+                let global_scale = state.inner.global_scale;
                 let Ok((xdg, dimensions)) = state
                     .world
-                    .query_one_mut::<(&XdgOutputServer, &OutputDimensions)>(target)
+                    .query_one_mut::<(&XdgOutputServer, &mut OutputDimensions)>(target)
                 else {
                     return;
                 };
-                if dimensions.rotated_90 {
-                    xdg.logical_size(dimensions.height, dimensions.width);
+                dimensions.logical_width = Some(width);
+                dimensions.logical_height = Some(height);
+
+                let (sw, sh) = if compositor_scaling {
+                    (
+                        scale_size_to_physical(width as f64, global_scale),
+                        scale_size_to_physical(height as f64, global_scale),
+                    )
                 } else {
-                    xdg.logical_size(dimensions.width, dimensions.height);
-                }
+                    (width, height)
+                };
+                xdg.logical_size(sw, sh);
             }
             _ => simple_event_shunt! {
                 state.world.get::<&XdgOutputServer>(target).unwrap(),
@@ -1450,6 +2287,8 @@ impl Event for c_dmabuf::zwp_linux_dmabuf_feedback_v1::Event {
 impl Event for zwp_relative_pointer_v1::Event {
     fn handle<C: XConnection>(self, target: Entity, state: &mut ServerState<C>) {
         let server = state.world.get::<&RelativePointerServer>(target).unwrap();
+        // Relative motion is already a pointer delta. Scaling it again breaks
+        // locked-pointer clients and games that consume the deltas directly.
         simple_event_shunt! {
             server, self => [
                 RelativeMotion {
@@ -1610,8 +2449,9 @@ impl Event for zwp_tablet_tool_v2::Event {
                         warn!("tablet tool proximity_in failed: stale surface");
                         return;
                     };
-                    let (surface, scale, window) = query.get().unwrap();
-                    cmd.insert(target, (*scale,));
+                    let s_entity = surface.data().copied().unwrap();
+                    let (surface, _, window) = query.get().unwrap();
+                    cmd.insert(target, (CurrentSurface::Xwayland(s_entity),));
 
                     let Some(s_tablet) =
                         tablet
@@ -1634,24 +2474,39 @@ impl Event for zwp_tablet_tool_v2::Event {
                 cmd.run_on(&mut state.world);
             }
             Self::Motion { x, y } => {
-                let (tool, scale) = state
+                let scales = state
                     .world
-                    .query_one_mut::<(&TabletToolServer, Option<&SurfaceScaleFactor>)>(target)
-                    .unwrap();
-                let scale = scale.map(|s| s.0).unwrap_or(1.0);
-                tool.motion(x * scale, y * scale);
+                    .get::<&CurrentSurface>(target)
+                    .ok()
+                    .and_then(|surf| match &*surf {
+                        CurrentSurface::Xwayland(e) => {
+                            Some(get_surface_input_scales(&state.world, *e))
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or((1.0, 1.0));
+                let tool = state.world.get::<&TabletToolServer>(target).unwrap();
+                tool.motion(x * scales.0, y * scales.1);
             }
-            _ => {
+            Self::ProximityOut => {
+                let mut cmd = CommandBuffer::new();
+                cmd.remove_one::<CurrentSurface>(target);
+                {
+                    let tool = state.world.get::<&TabletToolServer>(target).unwrap();
+                    tool.proximity_out();
+                }
+                cmd.run_on(&mut state.world);
+            }
+            other => {
                 let tool = state.world.get::<&TabletToolServer>(target).unwrap();
                 simple_event_shunt! {
-                    tool, self => [
+                    tool, other: zwp_tablet_tool_v2::Event => [
                         Type { |tool_type| convert_wenum(tool_type) },
                         HardwareSerial { hardware_serial_hi, hardware_serial_lo },
                         HardwareIdWacom { hardware_id_hi, hardware_id_lo },
                         Capability { |capability| convert_wenum(capability) },
                         Done,
                         Removed,
-                        ProximityOut,
                         Down { serial },
                         Up,
                         Distance { distance },

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -51,12 +51,20 @@ use wayland_server::protocol::{
 #[derive(Copy, Clone)]
 pub(super) struct SurfaceScaleFactor(pub f64);
 
+#[derive(Copy, Clone)]
+pub(super) struct TrueFractionalScale(pub f64);
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct EnteredOutputs(pub Vec<Entity>);
+
 #[derive(hecs::Bundle)]
 pub(super) struct SurfaceBundle {
     pub client: client::wl_surface::WlSurface,
     pub server: WlSurface,
     pub viewport: WpViewport,
     pub scale: SurfaceScaleFactor,
+    pub true_scale: TrueFractionalScale,
+    pub entered_outputs: EnteredOutputs,
 }
 
 #[derive(Debug)]
@@ -95,7 +103,12 @@ impl Event for SurfaceEvents {
                 wp_fractional_scale_v1::Event::PreferredScale { scale } => {
                     let state = state.deref_mut();
                     let entity = state.world.entity(target).unwrap();
-                    let factor = scale as f64 / 120.0;
+                    let true_fractional = scale as f64 / 120.0;
+                    let factor = if state.compositor_scaling {
+                        state.global_scale
+                    } else {
+                        true_fractional
+                    };
                     debug!(
                         "{} scale factor: {}",
                         entity.get::<&WlSurface>().unwrap().id(),
@@ -103,11 +116,16 @@ impl Event for SurfaceEvents {
                     );
 
                     entity.get::<&mut SurfaceScaleFactor>().unwrap().0 = factor;
+                    if let Some(mut ts) = entity.get::<&mut TrueFractionalScale>() {
+                        ts.0 = true_fractional;
+                    }
 
                     if let Some(OnOutput(output)) = entity.get::<&OnOutput>().as_deref().copied() {
                         if update_output_scale(
                             state.world.query_one(output).unwrap(),
-                            OutputScaleFactor::Fractional(factor),
+                            OutputScaleFactor::Fractional(true_fractional),
+                            state.compositor_scaling,
+                            state.global_scale,
                         ) {
                             state.updated_outputs.push(output);
                         }
@@ -210,17 +228,29 @@ impl SurfaceEvents {
 
                 debug!("{} entered {}", surface.id(), output.id());
 
+                if let Ok(mut entered) = state.world.get::<&mut EnteredOutputs>(target) {
+                    if !entered.0.contains(&output_entity) {
+                        entered.0.push(output_entity);
+                    }
+                }
+
                 let mut query = data.query::<(&x::Window, &mut WindowData)>();
                 if let Some((window, win_data)) = query.get() {
                     let Some(dimensions) = output_data.get::<&OutputDimensions>() else {
                         return;
                     };
+                    let (ox, oy) =
+                        if let Ok(pos) = state.world.get::<&X11OutputPosition>(output_entity) {
+                            (pos.x, pos.y)
+                        } else {
+                            (
+                                dimensions.x - state.global_output_offset.x.value,
+                                dimensions.y - state.global_output_offset.y.value,
+                            )
+                        };
                     win_data.update_output_offset(
                         *window,
-                        WindowOutputOffset {
-                            x: dimensions.x - state.global_output_offset.x.value,
-                            y: dimensions.y - state.global_output_offset.y.value,
-                        },
+                        WindowOutputOffset { x: ox, y: oy },
                         connection,
                     );
                     if state.last_focused_toplevel == Some(*window) {
@@ -230,7 +260,16 @@ impl SurfaceEvents {
                     }
 
                     if state.fractional_scale.is_none() {
-                        let output_scale = output_data.get::<&OutputScaleFactor>().unwrap().get();
+                        let output_scale = if state.compositor_scaling {
+                            if state.global_scale == 1.0 {
+                                warn!(
+                                    "compositor scaling: global_scale not set yet, defaulting to 1.0"
+                                );
+                            }
+                            state.global_scale
+                        } else {
+                            output_data.get::<&OutputScaleFactor>().unwrap().get()
+                        };
                         data.get::<&mut SurfaceScaleFactor>().unwrap().0 = output_scale;
                         drop(query);
                         update_surface_viewport(
@@ -238,10 +277,15 @@ impl SurfaceEvents {
                             state.world.query_one(target).unwrap(),
                         );
                     } else {
-                        let scale = data.get::<&SurfaceScaleFactor>().unwrap();
+                        let scale = data
+                            .get::<&TrueFractionalScale>()
+                            .map(|s| s.0)
+                            .unwrap_or_else(|| data.get::<&SurfaceScaleFactor>().unwrap().0);
                         if update_output_scale(
                             state.world.query_one(on_output.0).unwrap(),
-                            OutputScaleFactor::Fractional(scale.0),
+                            OutputScaleFactor::Fractional(scale),
+                            state.compositor_scaling,
+                            state.global_scale,
                         ) {
                             state.updated_outputs.push(on_output.0);
                         }
@@ -255,11 +299,32 @@ impl SurfaceEvents {
                     return;
                 };
                 surface.leave(&output);
+                if let Ok(mut entered) = state.world.get::<&mut EnteredOutputs>(target) {
+                    entered.0.retain(|&e| e != output_entity);
+                }
                 if data
                     .get::<&OnOutput>()
                     .is_some_and(|o| o.0 == output_entity)
                 {
                     cmd.remove_one::<OnOutput>(target);
+                    let mut fallback = None;
+                    if let Ok(entered) = state.world.get::<&EnteredOutputs>(target) {
+                        if let Some(&next_output) = entered.0.iter().find(|&&e| e != output_entity)
+                        {
+                            fallback = Some(next_output);
+                        }
+                    }
+                    if let Some(next_output) = fallback {
+                        cmd.insert_one(target, OnOutput(next_output));
+                        state.updated_outputs.push(next_output);
+                        let scale = data.get::<&SurfaceScaleFactor>().unwrap();
+                        let _ = update_output_scale(
+                            state.world.query_one(next_output).unwrap(),
+                            OutputScaleFactor::Fractional(scale.0),
+                            state.compositor_scaling,
+                            state.global_scale,
+                        );
+                    }
                 }
             }
             Event::PreferredBufferScale { .. } => {}
@@ -311,6 +376,7 @@ impl SurfaceEvents {
                 "configuring {} ({window:?}): {x}x{y}, {width}x{height}",
                 data.get::<&WlSurface>().unwrap().id(),
             );
+
 
             window_data.attrs.dims = WindowDims {
                 x: x as i16,
@@ -473,11 +539,10 @@ pub(super) fn update_surface_viewport(
         if let Some(d) = &toplevel.decoration.satellite {
             let surface_width = (dims.width as f64 / scale_factor.0) as i32;
             if d.will_draw_decorations(surface_width) {
+                let bar_h = d.titlebar_height();
                 height = height
-                    .saturating_sub(
-                        (DecorationsDataSatellite::TITLEBAR_HEIGHT as f64 * scale_factor.0) as u16,
-                    )
-                    .max(DecorationsDataSatellite::TITLEBAR_HEIGHT as u16);
+                    .saturating_sub((bar_h as f64 * scale_factor.0) as u16)
+                    .max(bar_h as u16);
             }
         }
     }
@@ -506,11 +571,12 @@ pub(super) fn update_surface_viewport(
 }
 
 pub(super) fn update_size_hints(data: &ToplevelData, hints: &WmNormalHints, scale: f64) {
-    let decorations_height = if data.decoration.satellite.is_some() {
-        DecorationsDataSatellite::TITLEBAR_HEIGHT
-    } else {
-        0
-    };
+    let decorations_height = data
+        .decoration
+        .satellite
+        .as_ref()
+        .map(|s| s.titlebar_height())
+        .unwrap_or(0);
     if let Some(min_size) = &hints.min_size {
         data.toplevel.set_min_size(
             (min_size.width as f64 / scale) as i32,
@@ -549,6 +615,7 @@ impl Event for client::wl_seat::Event {
 }
 
 struct PendingEnter(client::wl_pointer::Event);
+#[derive(Clone, Copy)]
 enum CurrentSurface {
     Xwayland(Entity),
     Decoration(Entity),
@@ -649,9 +716,14 @@ impl Event for client::wl_pointer::Event {
                 cmd.insert(target, (*scale,));
 
                 let surface_is_popup = matches!(role, SurfaceRole::Popup(_));
+                let scales = if state.compositor_scaling {
+                    get_surface_input_scales(&state.world, surface_entity.unwrap())
+                } else {
+                    (scale.0, scale.0)
+                };
                 let mut do_enter = || {
                     debug!("pointer entering {} ({serial} {})", surface.id(), scale.0);
-                    server.enter(serial, surface, surface_x * scale.0, surface_y * scale.0);
+                    server.enter(serial, surface, surface_x * scales.0, surface_y * scales.1);
                     connection.raise_to_top(*window);
                     if !surface_is_popup {
                         state.last_hovered = Some(*window);
@@ -731,17 +803,33 @@ impl Event for client::wl_pointer::Event {
                         return;
                     }
                 }
-                let (server, scale) = state
+                let scale_factor = state
                     .world
-                    .query_one_mut::<(&WlPointer, &SurfaceScaleFactor)>(target)
-                    .unwrap();
+                    .get::<&CurrentSurface>(target)
+                    .ok()
+                    .and_then(|surf| match &*surf {
+                        CurrentSurface::Xwayland(e) => {
+                            if state.compositor_scaling {
+                                Some(get_surface_input_scales(&state.world, *e))
+                            } else {
+                                state
+                                    .world
+                                    .get::<&SurfaceScaleFactor>(*e)
+                                    .ok()
+                                    .map(|s| (s.0, s.0))
+                            }
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or((1.0, 1.0));
+                let server = state.world.get::<&WlPointer>(target).unwrap();
                 trace!(
                     target: "pointer_position",
                     "pointer motion {} {}",
-                    surface_x * scale.0,
-                    surface_y * scale.0
+                    surface_x * scale_factor.0,
+                    surface_y * scale_factor.1
                 );
-                server.motion(time, surface_x * scale.0, surface_y * scale.0);
+                server.motion(time, surface_x * scale_factor.0, surface_y * scale_factor.1);
             }
             Self::Button {
                 serial,
@@ -944,18 +1032,32 @@ impl Event for client::wl_touch::Event {
                     let connection = &mut state.connection;
                     let world = &mut state.inner.world;
                     let s_entity = surface.data().copied();
+                    let scales = if let Some(key) = s_entity {
+                        if state.inner.compositor_scaling {
+                            get_surface_input_scales(world, key)
+                        } else {
+                            let scale = world
+                                .get::<&SurfaceScaleFactor>(key)
+                                .ok()
+                                .map(|s| s.0)
+                                .unwrap_or(1.0);
+                            (scale, scale)
+                        }
+                    } else {
+                        (1.0, 1.0)
+                    };
                     let mut s_query = s_entity.and_then(|key| {
                         world
                             .query_one::<(&WlSurface, &SurfaceScaleFactor, &x::Window)>(key)
                             .ok()
                     });
-                    if let Some((s_surface, s_factor, window)) =
+                    if let Some((s_surface, _s_factor, window)) =
                         s_query.as_mut().and_then(|q| q.get())
                     {
-                        cmd.insert_one(target, *s_factor);
+                        cmd.insert_one(target, CurrentSurface::Xwayland(s_entity.unwrap()));
                         connection.raise_to_top(*window);
                         let touch = world.get::<&WlTouch>(target).unwrap();
-                        touch.down(serial, time, s_surface, id, x * s_factor.0, y * s_factor.0);
+                        touch.down(serial, time, s_surface, id, x * scales.0, y * scales.1);
                     } else if let Some(&DecorationMarker { parent }) = surface.data() {
                         drop(s_query);
                         let seat = {
@@ -970,21 +1072,47 @@ impl Event for client::wl_touch::Event {
                 cmd.run_on(&mut state.world);
             }
             Self::Motion { time, id, x, y } => {
-                let Ok((touch, scale)) = state
-                    .world
-                    .query_one_mut::<(&WlTouch, &SurfaceScaleFactor)>(target)
+                let Some(CurrentSurface::Xwayland(e)) =
+                    state.world.get::<&CurrentSurface>(target).ok().map(|s| *s)
                 else {
                     return;
                 };
-                touch.motion(time, id, x * scale.0, y * scale.0);
+                let scales = if state.inner.compositor_scaling {
+                    get_surface_input_scales(&state.world, e)
+                } else {
+                    state
+                        .world
+                        .get::<&SurfaceScaleFactor>(e)
+                        .ok()
+                        .map(|s| (s.0, s.0))
+                        .unwrap_or((1.0, 1.0))
+                };
+                let touch = state.world.get::<&WlTouch>(target).unwrap();
+                touch.motion(time, id, x * scales.0, y * scales.1);
+            }
+            Self::Up { serial, time, id } => {
+                let mut cmd = CommandBuffer::new();
+                cmd.remove_one::<CurrentSurface>(target);
+                {
+                    let touch = state.world.get::<&WlTouch>(target).unwrap();
+                    touch.up(serial, time, id);
+                }
+                cmd.run_on(&mut state.world);
+            }
+            Self::Cancel => {
+                let mut cmd = CommandBuffer::new();
+                cmd.remove_one::<CurrentSurface>(target);
+                {
+                    let touch = state.world.get::<&WlTouch>(target).unwrap();
+                    touch.cancel();
+                }
+                cmd.run_on(&mut state.world);
             }
             _ => {
                 let touch = state.world.get::<&WlTouch>(target).unwrap();
                 simple_event_shunt! {
                     touch, self => [
-                        Up { serial, time, id },
                         Frame,
-                        Cancel,
                         Shape { id, major, minor },
                         Orientation { id, orientation }
                     ]
@@ -1007,6 +1135,183 @@ pub(super) enum OutputScaleFactor {
     Fractional(f64),
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct TrueOutputScaleFactor(pub OutputScaleFactor);
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct X11OutputPosition {
+    pub x: i32,
+    pub y: i32,
+}
+
+pub(super) fn recalculate_x11_output_positions(
+    world: &mut World,
+    compositor_scaling: bool,
+    global_scale: f64,
+) {
+    if !compositor_scaling {
+        return;
+    }
+
+    struct OutputNode {
+        entity: Entity,
+        lx: f64,
+        ly: f64,
+        fx: Option<f64>,
+        fy: Option<f64>,
+        rx: Option<i32>,
+        ry: Option<i32>,
+    }
+
+    let mut nodes: Vec<_> = world
+        .query::<&OutputDimensions>()
+        .iter()
+        .map(|(e, d)| {
+            OutputNode {
+                entity: e,
+                lx: d.x as f64,
+                ly: d.y as f64,
+                fx: None,
+                fy: None,
+                rx: None,
+                ry: None,
+            }
+        })
+        .collect();
+
+    if nodes.is_empty() {
+        return;
+    }
+
+    // Spanning tree handles global coords across mixed-scale monitors
+    let root_idx = nodes
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| {
+            let dist_a = a.lx * a.lx + a.ly * a.ly;
+            let dist_b = b.lx * b.lx + b.ly * b.ly;
+            dist_a.total_cmp(&dist_b)
+        })
+        .map(|(i, _)| i)
+        .unwrap();
+
+    nodes[root_idx].fx = Some(0.0);
+    nodes[root_idx].fy = Some(0.0);
+    nodes[root_idx].rx = Some(0);
+    nodes[root_idx].ry = Some(0);
+
+    loop {
+        let mut progress = false;
+        let mut best_transition = None;
+
+        for (u_idx, u_node) in nodes.iter().enumerate() {
+            if u_node.rx.is_some() {
+                continue;
+            }
+            for (r_idx, r_node) in nodes.iter().enumerate() {
+                if r_node.rx.is_none() {
+                    continue;
+                }
+                let dx = u_node.lx - r_node.lx;
+                let dy = u_node.ly - r_node.ly;
+                let dist = dx * dx + dy * dy;
+
+                match best_transition {
+                    None => {
+                        best_transition = Some((u_idx, r_idx, dist));
+                    }
+                    Some((_, _, min_dist)) if dist < min_dist => {
+                        best_transition = Some((u_idx, r_idx, dist));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if let Some((u_idx, r_idx, _)) = best_transition {
+            let u_node = &nodes[u_idx];
+            let r_node = &nodes[r_idx];
+
+            let dx = u_node.lx - r_node.lx;
+            let dy = u_node.ly - r_node.ly;
+
+            // Accumulate exact floating point offsets from root to prevent quantization drift
+            let fx = r_node.fx.unwrap_or(0.0) + (dx * global_scale);
+            let fy = r_node.fy.unwrap_or(0.0) + (dy * global_scale);
+
+            nodes[u_idx].fx = Some(fx);
+            nodes[u_idx].fy = Some(fy);
+            nodes[u_idx].rx = Some(fx.round() as i32);
+            nodes[u_idx].ry = Some(fy.round() as i32);
+            progress = true;
+        }
+
+        if !progress {
+            break;
+        }
+    }
+
+    for node in nodes {
+        if node.rx.is_none() {
+            warn!(
+                "Failed to calculate relative X11 position for output {:?}, falling back to (0, 0)",
+                node.entity
+            );
+        }
+        let rx = node.rx.unwrap_or(0);
+        let ry = node.ry.unwrap_or(0);
+        world
+            .insert_one(node.entity, X11OutputPosition { x: rx, y: ry })
+            .unwrap();
+    }
+}
+
+pub(super) fn get_surface_input_scales(world: &World, e: Entity) -> (f64, f64) {
+    let scale = world
+        .get::<&SurfaceScaleFactor>(e)
+        .ok()
+        .map(|s| s.0)
+        .unwrap_or(1.0);
+    let win_data = world.get::<&WindowData>(e).ok();
+
+    let is_fullscreen = world
+        .get::<&SurfaceRole>(e)
+        .ok()
+        .map(|r| match &*r {
+            SurfaceRole::Toplevel(Some(toplevel)) => toplevel.fullscreen,
+            _ => false,
+        })
+        .unwrap_or(false);
+
+    if is_fullscreen {
+        if let Ok(on_output) = world.get::<&OnOutput>(e) {
+            if let Ok(dims) = world.get::<&OutputDimensions>(on_output.0) {
+                let (w, h) = if dims.rotated_90 {
+                    (dims.height, dims.width)
+                } else {
+                    (dims.width, dims.height)
+                };
+                // Host ignores output scaling so logical equals physical
+                let logical_w = w as f64;
+                let logical_h = h as f64;
+                if logical_w > 0.0 && logical_h > 0.0 {
+                    let scale_x = win_data
+                        .as_ref()
+                        .map(|d| d.attrs.dims.width as f64 / logical_w)
+                        .unwrap_or(scale);
+                    let scale_y = win_data
+                        .as_ref()
+                        .map(|d| d.attrs.dims.height as f64 / logical_h)
+                        .unwrap_or(scale);
+                    return (scale_x, scale_y);
+                }
+            }
+        }
+    }
+
+    (scale, scale)
+}
+
 impl OutputScaleFactor {
     pub(super) fn get(&self) -> f64 {
         match *self {
@@ -1017,29 +1322,44 @@ impl OutputScaleFactor {
 }
 
 #[must_use]
-fn update_output_scale(
-    mut output_scale: hecs::QueryOne<&mut OutputScaleFactor>,
+pub(super) fn update_output_scale(
+    mut output: hecs::QueryOne<(&mut OutputScaleFactor, &mut TrueOutputScaleFactor)>,
     factor: OutputScaleFactor,
+    compositor_scaling: bool,
+    global_scale: f64,
 ) -> bool {
-    let Some(output_scale) = output_scale.get() else {
+    let Some((output_scale, true_output_scale)) = output.get() else {
         return false;
     };
 
-    if matches!(output_scale, OutputScaleFactor::Fractional(..))
+    if matches!(true_output_scale.0, OutputScaleFactor::Fractional(..))
         && matches!(factor, OutputScaleFactor::Output(..))
     {
         return false;
     }
 
-    if *output_scale != factor {
-        *output_scale = factor;
-        return true;
+    let mut changed = false;
+    if true_output_scale.0 != factor {
+        true_output_scale.0 = factor;
+        changed = true;
     }
 
-    false
+    let effective = if compositor_scaling {
+        OutputScaleFactor::Fractional(global_scale)
+    } else {
+        factor
+    };
+
+    if *output_scale != effective {
+        *output_scale = effective;
+        changed = true;
+    }
+
+    changed
 }
 
-enum OutputDimensionsSource {
+#[derive(PartialEq)]
+pub(super) enum OutputDimensionsSource {
     // The data in this variant is the values needed for the wl_output.geometry event.
     Wl {
         physical_width: i32,
@@ -1053,12 +1373,16 @@ enum OutputDimensionsSource {
 }
 
 pub(super) struct OutputDimensions {
-    source: OutputDimensionsSource,
+    pub source: OutputDimensionsSource,
     pub x: i32,
     pub y: i32,
     pub width: i32,
     pub height: i32,
-    rotated_90: bool,
+    pub physical_mode_width: i32,
+    pub physical_mode_height: i32,
+    pub refresh: i32,
+    pub mode_flags: WEnum<client::wl_output::Mode>,
+    pub rotated_90: bool,
 }
 
 impl Default for OutputDimensions {
@@ -1076,6 +1400,10 @@ impl Default for OutputDimensions {
             y: 0,
             width: 0,
             height: 0,
+            physical_mode_width: 0,
+            physical_mode_height: 0,
+            refresh: 60000,
+            mode_flags: WEnum::Value(client::wl_output::Mode::Current),
             rotated_90: false,
         }
     }
@@ -1127,6 +1455,11 @@ fn update_output_offset(
         );
     }
 
+    recalculate_x11_output_positions(
+        &mut state.world,
+        state.compositor_scaling,
+        state.global_scale,
+    );
     update_window_output_offsets(
         output,
         &state.global_output_offset,
@@ -1135,7 +1468,7 @@ fn update_output_offset(
     );
 }
 
-fn update_window_output_offsets(
+pub(super) fn update_window_output_offsets(
     output: Entity,
     global_output_offset: &GlobalOutputOffset,
     world: &World,
@@ -1144,20 +1477,44 @@ fn update_window_output_offsets(
     let Ok(dimensions) = world.get::<&OutputDimensions>(output) else {
         return;
     };
-    let mut query = world.query::<(&x::Window, &mut WindowData, &OnOutput)>();
+    let (ox, oy) = if let Ok(pos) = world.get::<&X11OutputPosition>(output) {
+        (pos.x, pos.y)
+    } else {
+        (
+            dimensions.x - global_output_offset.x.value,
+            dimensions.y - global_output_offset.y.value,
+        )
+    };
+    let new_offset = WindowOutputOffset { x: ox, y: oy };
 
+    let mut updated_windows: Vec<x::Window> = vec![];
+    let mut query = world.query::<(&x::Window, &mut WindowData, &OnOutput)>();
     for (_, (window, data, _)) in query
         .into_iter()
         .filter(|(_, (_, _, on_output))| on_output.0 == output)
     {
-        data.update_output_offset(
-            *window,
-            WindowOutputOffset {
-                x: dimensions.x - global_output_offset.x.value,
-                y: dimensions.y - global_output_offset.y.value,
-            },
-            connection,
-        );
+        data.update_output_offset(*window, new_offset, connection);
+        updated_windows.push(*window);
+    }
+    drop(query);
+
+    // Sync offset to popups without OnOutput to fix stale positioners
+    if !updated_windows.is_empty() {
+        let mut popup_query =
+            world.query::<(&x::Window, &mut WindowData, &mut SurfaceScaleFactor)>();
+        for (_, (window, data, scale)) in popup_query.into_iter().filter(|(_, (_, data, _))| {
+            data.attrs.role.is_popup()
+                && data
+                    .attrs
+                    .transient_for
+                    .map(|p| updated_windows.contains(&p))
+                    .unwrap_or(false)
+        }) {
+            data.update_output_offset(*window, new_offset, connection);
+            if let Ok(out_scale) = world.get::<&OutputScaleFactor>(output) {
+                scale.0 = out_scale.get();
+            }
+        }
     }
 }
 
@@ -1166,6 +1523,8 @@ pub(super) fn update_global_output_offset(
     global_output_offset: &GlobalOutputOffset,
     world: &World,
     connection: &mut impl XConnection,
+    global_scale: f64,
+    compositor_scaling: bool,
 ) {
     let entity = world.entity(output).unwrap();
     let mut query = entity.query::<(&OutputDimensions, &WlOutput)>();
@@ -1175,6 +1534,17 @@ pub(super) fn update_global_output_offset(
 
     let x = dimensions.x - global_output_offset.x.value;
     let y = dimensions.y - global_output_offset.y.value;
+    let (scaled_x, scaled_y) = if compositor_scaling {
+        let pos = world.get::<&X11OutputPosition>(output).ok();
+        pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+            (
+                (x as f64 * global_scale).round() as i32,
+                (y as f64 * global_scale).round() as i32,
+            )
+        })
+    } else {
+        (x, y)
+    };
 
     match &dimensions.source {
         OutputDimensionsSource::Wl {
@@ -1185,11 +1555,19 @@ pub(super) fn update_global_output_offset(
             model,
             transform,
         } => {
+            let (pw, ph) = if compositor_scaling {
+                (
+                    (*physical_width as f64 * global_scale).round() as i32,
+                    (*physical_height as f64 * global_scale).round() as i32,
+                )
+            } else {
+                (*physical_width, *physical_height)
+            };
             server.geometry(
-                x,
-                y,
-                *physical_width,
-                *physical_height,
+                scaled_x,
+                scaled_y,
+                pw,
+                ph,
                 convert_wenum(*subpixel),
                 make.clone(),
                 model.clone(),
@@ -1200,7 +1578,7 @@ pub(super) fn update_global_output_offset(
             entity
                 .get::<&XdgOutputServer>()
                 .unwrap()
-                .logical_position(x, y);
+                .logical_position(scaled_x, scaled_y);
         }
     }
 
@@ -1270,6 +1648,18 @@ impl OutputEvent {
                     state,
                 );
                 let global_output_offset = state.global_output_offset;
+                let compositor_scaling = state.compositor_scaling;
+                let global_scale = state.global_scale;
+
+                let pos = if compositor_scaling {
+                    state
+                        .world
+                        .get::<&X11OutputPosition>(target)
+                        .ok()
+                        .map(|p| *p)
+                } else {
+                    None
+                };
 
                 let Ok((output, dimensions, xdg)) = state.world.query_one_mut::<(
                     &WlOutput,
@@ -1279,11 +1669,27 @@ impl OutputEvent {
                     return;
                 };
 
+                let (scaled_x, scaled_y) = if compositor_scaling {
+                    pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+                        (
+                            ((x - global_output_offset.x.value) as f64 * global_scale).round()
+                                as i32,
+                            ((y - global_output_offset.y.value) as f64 * global_scale).round()
+                                as i32,
+                        )
+                    })
+                } else {
+                    (
+                        x - global_output_offset.x.value,
+                        y - global_output_offset.y.value,
+                    )
+                };
+                let (pw, ph) = (physical_width, physical_height);
                 output.geometry(
-                    x - global_output_offset.x.value,
-                    y - global_output_offset.y.value,
-                    physical_width,
-                    physical_height,
+                    scaled_x,
+                    scaled_y,
+                    pw,
+                    ph,
                     convert_wenum(subpixel),
                     make,
                     model,
@@ -1299,11 +1705,20 @@ impl OutputEvent {
                     )
                 });
                 if let Some(xdg) = xdg {
-                    if dimensions.rotated_90 {
-                        xdg.logical_size(dimensions.height, dimensions.width);
+                    let (w, h) = if dimensions.rotated_90 {
+                        (dimensions.height, dimensions.width)
                     } else {
-                        xdg.logical_size(dimensions.width, dimensions.height);
-                    }
+                        (dimensions.width, dimensions.height)
+                    };
+                    let (sw, sh) = if compositor_scaling {
+                        (
+                            (w as f64 * global_scale).round() as i32,
+                            (h as f64 * global_scale).round() as i32,
+                        )
+                    } else {
+                        (w, h)
+                    };
+                    xdg.logical_size(sw, sh);
                 }
             }
             Event::Mode {
@@ -1311,23 +1726,54 @@ impl OutputEvent {
                 width,
                 height,
                 refresh,
-            } => {
-                let Ok((output, dimensions)) = state
-                    .world
-                    .query_one_mut::<(&WlOutput, &mut OutputDimensions)>(target)
-                else {
-                    return;
-                };
-
-                if flags
-                    .into_result()
-                    .is_ok_and(|f| f.contains(client::wl_output::Mode::Current))
+                let comp_scaling = state.compositor_scaling;
+                let mut should_update_scale = false;
+                let mut scale_to_update = 0.0;
                 {
-                    dimensions.width = width;
-                    dimensions.height = height;
-                    debug!("{} dimensions: {width}x{height}", output.id());
+                    let Ok((output, dimensions)) = state
+                        .world
+                        .query_one_mut::<(&WlOutput, &mut OutputDimensions)>(target)
+                    else {
+                        return;
+                    };
+
+                    let is_current = flags
+                        .into_result()
+                        .is_ok_and(|f| f.contains(client::wl_output::Mode::Current));
+
+                    if is_current {
+                        dimensions.physical_mode_width = width;
+                        dimensions.physical_mode_height = height;
+                        if dimensions.source != OutputDimensionsSource::Xdg {
+                            dimensions.width = width;
+                            dimensions.height = height;
+                        }
+                        dimensions.refresh = refresh;
+                        dimensions.mode_flags = convert_wenum(flags);
+                        debug!("{} dimensions: {width}x{height}", output.id());
+
+                        if comp_scaling
+                            && dimensions.source == OutputDimensionsSource::Xdg
+                            && dimensions.width > 0
+                        {
+                            let raw_scale = width as f64 / dimensions.width as f64;
+                            scale_to_update = (raw_scale * 120.0).round() / 120.0;
+                            should_update_scale = true;
+                        }
+                    }
+                    output.mode(convert_wenum(flags), width, height, refresh);
                 }
-                output.mode(convert_wenum(flags), width, height, refresh);
+
+                if should_update_scale
+                    && update_output_scale(
+                        state.world.query_one(target).unwrap(),
+                        OutputScaleFactor::Fractional(scale_to_update),
+                        state.compositor_scaling,
+                        state.global_scale,
+                    )
+                {
+                    state.updated_outputs.push(target);
+                }
             }
             Event::Scale { factor } => {
                 debug!(
@@ -1337,11 +1783,18 @@ impl OutputEvent {
                 if update_output_scale(
                     state.world.query_one(target).unwrap(),
                     OutputScaleFactor::Output(factor),
+                    state.compositor_scaling,
+                    state.global_scale,
                 ) {
                     state.updated_outputs.push(target);
                 }
                 if state.fractional_scale.is_none() {
-                    state.world.get::<&WlOutput>(target).unwrap().scale(factor);
+                    let send_factor = if state.compositor_scaling { 1 } else { factor };
+                    state
+                        .world
+                        .get::<&WlOutput>(target)
+                        .unwrap()
+                        .scale(send_factor);
                 }
             }
             Event::Name { name } => {
@@ -1373,28 +1826,82 @@ impl OutputEvent {
             Event::LogicalPosition { x, y } => {
                 update_output_offset(target, OutputDimensionsSource::Xdg, x, y, state);
                 if !state.global_offset_updated {
+                    let (scaled_x, scaled_y) = if state.inner.compositor_scaling {
+                        let pos = state.world.get::<&X11OutputPosition>(target).ok();
+                        pos.map(|p| (p.x, p.y)).unwrap_or_else(|| {
+                            (
+                                ((x - state.inner.global_output_offset.x.value) as f64
+                                    * state.inner.global_scale)
+                                    .round() as i32,
+                                ((y - state.inner.global_output_offset.y.value) as f64
+                                    * state.inner.global_scale)
+                                    .round() as i32,
+                            )
+                        })
+                    } else {
+                        (
+                            x - state.inner.global_output_offset.x.value,
+                            y - state.inner.global_output_offset.y.value,
+                        )
+                    };
                     state
                         .world
                         .get::<&XdgOutputServer>(target)
                         .unwrap()
-                        .logical_position(
-                            x - state.global_output_offset.x.value,
-                            y - state.global_output_offset.y.value,
-                        );
+                        .logical_position(scaled_x, scaled_y);
                 }
             }
-            Event::LogicalSize { .. } => {
-                let Ok((xdg, dimensions)) = state
-                    .world
-                    .query_one_mut::<(&XdgOutputServer, &OutputDimensions)>(target)
-                else {
-                    return;
+            Event::LogicalSize { width, height } => {
+                let compositor_scaling = state.inner.compositor_scaling;
+                let global_scale = state.inner.global_scale;
+
+                let mut should_update_scale = false;
+                let mut scale_to_update = 0.0;
+                let (sw, sh, xdg) = {
+                    let Ok((xdg, dimensions)) = state
+                        .world
+                        .query_one_mut::<(&XdgOutputServer, &mut OutputDimensions)>(target)
+                    else {
+                        return;
+                    };
+                    dimensions.source = OutputDimensionsSource::Xdg;
+                    dimensions.width = width;
+                    dimensions.height = height;
+
+                    if compositor_scaling && dimensions.physical_mode_width > 0 && width > 0 {
+                        let raw_scale = dimensions.physical_mode_width as f64 / width as f64;
+                        scale_to_update = (raw_scale * 120.0).round() / 120.0;
+                        should_update_scale = true;
+                    }
+
+                    let (w, h) = if dimensions.rotated_90 {
+                        (height, width)
+                    } else {
+                        (width, height)
+                    };
+                    let (sw, sh) = if compositor_scaling {
+                        (
+                            (w as f64 * global_scale).round() as i32,
+                            (h as f64 * global_scale).round() as i32,
+                        )
+                    } else {
+                        (w, h)
+                    };
+                    (sw, sh, xdg.clone())
                 };
-                if dimensions.rotated_90 {
-                    xdg.logical_size(dimensions.height, dimensions.width);
-                } else {
-                    xdg.logical_size(dimensions.width, dimensions.height);
+
+                if should_update_scale
+                    && update_output_scale(
+                        state.world.query_one(target).unwrap(),
+                        OutputScaleFactor::Fractional(scale_to_update),
+                        compositor_scaling,
+                        global_scale,
+                    )
+                {
+                    state.updated_outputs.push(target);
                 }
+
+                xdg.logical_size(sw, sh);
             }
             _ => simple_event_shunt! {
                 state.world.get::<&XdgOutputServer>(target).unwrap(),
@@ -1605,8 +2112,9 @@ impl Event for zwp_tablet_tool_v2::Event {
                         warn!("tablet tool proximity_in failed: stale surface");
                         return;
                     };
-                    let (surface, scale, window) = query.get().unwrap();
-                    cmd.insert(target, (*scale,));
+                    let s_entity = surface.data().copied().unwrap();
+                    let (surface, _, window) = query.get().unwrap();
+                    cmd.insert(target, (CurrentSurface::Xwayland(s_entity),));
 
                     let Some(s_tablet) =
                         tablet
@@ -1629,24 +2137,39 @@ impl Event for zwp_tablet_tool_v2::Event {
                 cmd.run_on(&mut state.world);
             }
             Self::Motion { x, y } => {
-                let (tool, scale) = state
+                let scales = state
                     .world
-                    .query_one_mut::<(&TabletToolServer, Option<&SurfaceScaleFactor>)>(target)
-                    .unwrap();
-                let scale = scale.map(|s| s.0).unwrap_or(1.0);
-                tool.motion(x * scale, y * scale);
+                    .get::<&CurrentSurface>(target)
+                    .ok()
+                    .and_then(|surf| match &*surf {
+                        CurrentSurface::Xwayland(e) => {
+                            Some(get_surface_input_scales(&state.world, *e))
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or((1.0, 1.0));
+                let tool = state.world.get::<&TabletToolServer>(target).unwrap();
+                tool.motion(x * scales.0, y * scales.1);
             }
-            _ => {
+            Self::ProximityOut => {
+                let mut cmd = CommandBuffer::new();
+                cmd.remove_one::<CurrentSurface>(target);
+                {
+                    let tool = state.world.get::<&TabletToolServer>(target).unwrap();
+                    tool.proximity_out();
+                }
+                cmd.run_on(&mut state.world);
+            }
+            other => {
                 let tool = state.world.get::<&TabletToolServer>(target).unwrap();
                 simple_event_shunt! {
-                    tool, self => [
+                    tool, other: zwp_tablet_tool_v2::Event => [
                         Type { |tool_type| convert_wenum(tool_type) },
                         HardwareSerial { hardware_serial_hi, hardware_serial_lo },
                         HardwareIdWacom { hardware_id_hi, hardware_id_lo },
                         Capability { |capability| convert_wenum(capability) },
                         Done,
                         Removed,
-                        ProximityOut,
                         Down { serial },
                         Up,
                         Distance { distance },

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -356,27 +356,42 @@ impl SurfaceEvents {
         drop(xdg);
 
         if let Some(pending) = pending {
+            let is_popup = matches!(
+                data.get::<&SurfaceRole>().as_deref(),
+                Some(SurfaceRole::Popup(_))
+            );
             let mut query = data.query::<(&SurfaceScaleFactor, &x::Window, &mut WindowData)>();
             let (scale_factor, window, window_data) = query.get().unwrap();
 
             let window = *window;
-            let x = (pending.x.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.x;
-            let y = (pending.y.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.y;
-            let width = if pending.width > 0 {
-                (pending.width as f64 * scale_factor.0) as u16
+            let (x, y, width, height) = if is_popup {
+                (
+                    window_data.attrs.dims.x as i32,
+                    window_data.attrs.dims.y as i32,
+                    window_data.attrs.dims.width,
+                    window_data.attrs.dims.height,
+                )
             } else {
-                window_data.attrs.dims.width
-            };
-            let height = if pending.height > 0 {
-                (pending.height as f64 * scale_factor.0) as u16
-            } else {
-                window_data.attrs.dims.height
+                let x = (pending.x.max(0) as f64 * scale_factor.0).round() as i32
+                    + window_data.output_offset.x;
+                let y = (pending.y.max(0) as f64 * scale_factor.0).round() as i32
+                    + window_data.output_offset.y;
+                let width = if pending.width > 0 {
+                    (pending.width as f64 * scale_factor.0).round() as u16
+                } else {
+                    window_data.attrs.dims.width
+                };
+                let height = if pending.height > 0 {
+                    (pending.height as f64 * scale_factor.0).round() as u16
+                } else {
+                    window_data.attrs.dims.height
+                };
+                (x, y, width, height)
             };
             debug!(
                 "configuring {} ({window:?}): {x}x{y}, {width}x{height}",
                 data.get::<&WlSurface>().unwrap().id(),
             );
-
 
             window_data.attrs.dims = WindowDims {
                 x: x as i16,
@@ -449,6 +464,16 @@ impl SurfaceEvents {
                             decorations.handle_fullscreen(toplevel.fullscreen);
                         }
                     }
+
+                    let prev_max = toplevel.maximized;
+                    toplevel.maximized =
+                        states.contains(&(u32::from(xdg_toplevel::State::Maximized) as u8));
+                    if toplevel.maximized != prev_max {
+                        state.connection.set_maximized(
+                            *data.get::<&x::Window>().unwrap(),
+                            toplevel.maximized,
+                        );
+                    }
                 };
 
                 role.xdg_mut().unwrap().pending = Some(PendingSurfaceState {
@@ -498,7 +523,11 @@ impl SurfaceEvents {
 
                 if first_configure {
                     let window_data = data.get::<&WindowData>().unwrap();
-                    if window_data.attrs.require_wm_focus() {
+                    // Do not auto-focus popups that are menus.
+                    // Popup menus rely on X11 pointer grabs and expect toplevel focus to be
+                    // maintained; sending SetInputFocus steals focus from the parent, causing
+                    // Chromium/Steam CEF to receive FocusOut and immediately cancel the menu.
+                    if window_data.attrs.require_wm_focus() && !window_data.attrs.is_menu {
                         let window = *data.get::<&x::Window>().unwrap();
                         state.inner.to_focus = Some(FocusData {
                             window,
@@ -510,9 +539,9 @@ impl SurfaceEvents {
             }
             xdg_popup::Event::Repositioned { .. } => {}
             xdg_popup::Event::PopupDone => {
-                state
-                    .connection
-                    .unmap_window(*data.get::<&x::Window>().unwrap());
+                let window = *data.get::<&x::Window>().unwrap();
+                debug!("xdg_popup::PopupDone received for {window:?}");
+                state.connection.unmap_window(window);
             }
             other => todo!("{other:?}"),
         }
@@ -533,7 +562,7 @@ pub(super) fn update_surface_viewport(
     let dims = &window_data.attrs.dims;
     let size_hints = &window_data.attrs.size_hints;
 
-    let width = (dims.width as f64 / scale_factor.0).ceil() as i32;
+    let width = (dims.width as f64 / scale_factor.0).round() as i32;
     let mut height = dims.height;
     if let Some(SurfaceRole::Toplevel(Some(toplevel))) = role {
         if let Some(d) = &toplevel.decoration.satellite {
@@ -546,7 +575,7 @@ pub(super) fn update_surface_viewport(
             }
         }
     }
-    let height = (height as f64 / scale_factor.0).ceil() as i32;
+    let height = (height as f64 / scale_factor.0).round() as i32;
     if width > 0 && height > 0 {
         viewport.set_destination(width, height);
     }
@@ -1726,6 +1755,7 @@ impl OutputEvent {
                 width,
                 height,
                 refresh,
+            } => {
                 let comp_scaling = state.compositor_scaling;
                 let mut should_update_scale = false;
                 let mut scale_to_update = 0.0;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,8 +158,10 @@ impl WindowData {
         }
 
         let dims = &mut self.attrs.dims;
-        dims.x += (offset.x - self.output_offset.x) as i16;
-        dims.y += (offset.y - self.output_offset.y) as i16;
+        let new_x = (dims.x as i64) + (offset.x - self.output_offset.x) as i64;
+        let new_y = (dims.y as i64) + (offset.y - self.output_offset.y) as i64;
+        dims.x = new_x.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
+        dims.y = new_y.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
         self.output_offset = offset;
 
         if connection.set_window_dims(
@@ -486,6 +488,8 @@ pub struct InnerServerState<S: X11Selection> {
     new_scale: Option<f64>,
     pub global_scale: f64,
     pub compositor_scaling: bool,
+    /// If set, pins the global X11 render scale instead of auto max(output_scale).
+    pub base_scale: Option<f64>,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -597,6 +601,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             new_scale: None,
             global_scale: 1.0,
             compositor_scaling,
+            base_scale: None,
             decoration_manager,
             world,
         };
@@ -620,6 +625,18 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
 }
 
 impl<C: XConnection> ServerState<C> {
+    pub fn set_base_scale(&mut self, base_scale: Option<f64>) {
+        if let Some(s) = base_scale {
+            if (1.0..=8.0).contains(&s) && s.is_finite() {
+                self.inner.base_scale = Some(s);
+            } else {
+                log::warn!("invalid base_scale {s}, ignoring");
+            }
+        } else {
+            self.inner.base_scale = None;
+        }
+    }
+
     pub fn run(&mut self) {
         if let Some(r) = self.queue.prepare_read() {
             let fd = r.connection_fd();
@@ -818,6 +835,8 @@ impl<C: XConnection> ServerState<C> {
                 }
 
                 let old_scale = self.global_scale;
+                // base_scale wins if the user pinned it
+                let scale = self.base_scale.unwrap_or(scale);
                 debug!("Using new scale {scale}");
                 self.new_scale = Some(scale);
                 self.global_scale = scale;
@@ -918,8 +937,8 @@ impl<C: XConnection> ServerState<C> {
                             server_output.geometry(
                                 scaled_x,
                                 scaled_y,
-                                (*physical_width as f64 * scale).round() as i32,
-                                (*physical_height as f64 * scale).round() as i32,
+                                *physical_width,
+                                *physical_height,
                                 convert_wenum(*subpixel),
                                 make.clone(),
                                 model.clone(),
@@ -954,11 +973,12 @@ impl<C: XConnection> ServerState<C> {
                     }
                 }
             } else if use_compositor_scaling {
-                // drop back to 1.0 once the last output disappears
-                if self.global_scale != 1.0 {
-                    debug!("No outputs available, resetting global_scale to 1.0");
-                    self.global_scale = 1.0;
-                    self.new_scale = Some(1.0);
+                // no outputs left, so fall back to base_scale (or 1.0)
+                let reset_scale = self.base_scale.unwrap_or(1.0);
+                if self.global_scale != reset_scale {
+                    debug!("No outputs available, resetting global_scale to {reset_scale}");
+                    self.global_scale = reset_scale;
+                    self.new_scale = Some(reset_scale);
 
                     let mut surface_query = self.world.query::<&mut SurfaceScaleFactor>().with::<(
                         &WlSurface,
@@ -968,7 +988,7 @@ impl<C: XConnection> ServerState<C> {
                     );
                     let mut surfaces = vec![];
                     for (surface, surface_scale) in surface_query.iter() {
-                        surface_scale.0 = 1.0;
+                        surface_scale.0 = reset_scale;
                         surfaces.push(surface);
                     }
                     drop(surface_query);
@@ -1016,13 +1036,11 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         for (entity, name) in query.iter() {
             if *name == global {
                 self.updated_outputs.push(*entity);
-                self.world
-                    .remove::<(
-                        OutputScaleFactor,
-                        event::TrueOutputScaleFactor,
-                        OutputDimensions,
-                    )>(*entity)
-                    .unwrap();
+                let _ = self.world.remove::<(
+                    OutputScaleFactor,
+                    event::TrueOutputScaleFactor,
+                    OutputDimensions,
+                )>(*entity);
                 let _ = self.world.remove_one::<event::X11OutputPosition>(*entity);
 
                 let mut surfaces_to_update = Vec::new();
@@ -1035,7 +1053,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                     }
                     if let Some(on_out) = on_out {
                         if on_out.0 == *entity {
-                            // try another active output before clearing OnOutput
+                            // prefer any live output so the window doesn't lose its placement
                             let mut fallback = None;
                             if let Some(ref entered) = entered {
                                 if let Some(&next_out) = entered.0.first() {
@@ -1046,7 +1064,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                                 *on_out = OnOutput(next_out);
                                 surfaces_to_update.push((e, next_out));
                             } else {
-                                // clear OnOutput below if there is no fallback
+                                // no fallback output left, so drop the association instead of pointing at a dead one
                                 surfaces_to_update.push((e, hecs::Entity::DANGLING));
                             }
                         }
@@ -1073,32 +1091,18 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                                 if let Some(win_data) = win_query.get() {
                                     let ox_diff = ox - win_data.output_offset.x;
                                     let oy_diff = oy - win_data.output_offset.y;
-                                    win_data.attrs.dims.x += ox_diff as i16;
-                                    win_data.attrs.dims.y += oy_diff as i16;
+                                    let new_x = (win_data.attrs.dims.x as i64) + ox_diff as i64;
+                                    let new_y = (win_data.attrs.dims.y as i64) + oy_diff as i64;
+                                    win_data.attrs.dims.x =
+                                        new_x.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
+                                    win_data.attrs.dims.y =
+                                        new_y.clamp(i16::MIN as i64, i16::MAX as i64) as i16;
                                     win_data.output_offset = WindowOutputOffset { x: ox, y: oy };
                                 }
                             }
                         }
 
                         self.updated_outputs.push(next_out);
-                        if let Ok(scale) = self.world.get::<&SurfaceScaleFactor>(e) {
-                            let scale_val = scale.0;
-                            let comp_scaling = self.compositor_scaling;
-                            let glob_scale = self.global_scale;
-                            if let Ok(out_query) = self.world.query_one::<(
-                                &mut OutputScaleFactor,
-                                &mut event::TrueOutputScaleFactor,
-                            )>(
-                                next_out
-                            ) {
-                                let _ = event::update_output_scale(
-                                    out_query,
-                                    OutputScaleFactor::Fractional(scale_val),
-                                    comp_scaling,
-                                    glob_scale,
-                                );
-                            }
-                        }
                     }
                 }
                 if self.global_output_offset.x.owner == Some(*entity) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -48,7 +48,7 @@ use wayland_protocols::{
             zwp_tablet_pad_v2, zwp_tablet_seat_v2, zwp_tablet_tool_v2, zwp_tablet_v2,
         },
         tablet::zv2::server::zwp_tablet_manager_v2::ZwpTabletManagerV2,
-        viewporter::client::wp_viewporter::WpViewporter,
+        viewporter::client::{wp_viewport::WpViewport, wp_viewporter::WpViewporter},
     },
     xdg::{
         shell::client::{
@@ -245,6 +245,7 @@ struct PopupData {
     popup: XdgPopup,
     positioner: XdgPositioner,
     xdg: XdgSurfaceData,
+    parent: x::Window,
 }
 
 trait Event {
@@ -483,6 +484,8 @@ pub struct InnerServerState<S: X11Selection> {
     global_offset_updated: bool,
     updated_outputs: Vec<Entity>,
     new_scale: Option<f64>,
+    pub global_scale: f64,
+    pub compositor_scaling: bool,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -490,6 +493,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
         mut dh: DisplayHandle,
         server_connection: Option<UnixStream>,
         client: UnixStream,
+        compositor_scaling: bool,
     ) -> Self {
         let connection = if let Some(stream) = server_connection {
             Connection::from_socket(stream).unwrap()
@@ -591,6 +595,8 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
+            global_scale: 1.0,
+            compositor_scaling,
             decoration_manager,
             world,
         };
@@ -661,6 +667,9 @@ impl<C: XConnection> ServerState<C> {
             self.global_offset_updated = true;
         }
         if self.global_offset_updated {
+            let comp_scaling = self.compositor_scaling;
+            let glob_scale = self.global_scale;
+            recalculate_x11_output_positions(&mut self.world, comp_scaling, glob_scale);
             debug!(
                 target: "output_offset",
                 "updated global output offset: {}x{}",
@@ -673,64 +682,14 @@ impl<C: XConnection> ServerState<C> {
                     &state.global_output_offset,
                     &state.world,
                     &mut self.connection,
+                    state.global_scale,
+                    state.compositor_scaling,
                 );
             }
             self.global_offset_updated = false;
         }
 
-        if !self.updated_outputs.is_empty() {
-            for output in std::mem::take(&mut self.updated_outputs).iter() {
-                let Ok(output_scale) = self.world.get::<&OutputScaleFactor>(*output) else {
-                    continue;
-                };
-                if matches!(*output_scale, OutputScaleFactor::Output(..)) {
-                    let mut surface_query = self
-                        .world
-                        .query::<(&OnOutput, &mut SurfaceScaleFactor)>()
-                        .with::<(&WindowData, &WlSurface)>();
-
-                    let mut surfaces = vec![];
-                    for (surface, (OnOutput(s_output), surface_scale)) in surface_query.iter() {
-                        if s_output == output {
-                            surface_scale.0 = output_scale.get();
-                            surfaces.push(surface);
-                        }
-                    }
-
-                    drop(surface_query);
-                    for surface in surfaces {
-                        update_surface_viewport(
-                            &self.world,
-                            self.world.query_one(surface).unwrap(),
-                        );
-                    }
-                }
-            }
-
-            let mut mixed_scale = false;
-            let mut scale;
-
-            let mut outputs = self.world.query_mut::<&OutputScaleFactor>().into_iter();
-            if let Some((_, output_scale)) = outputs.next() {
-                scale = output_scale.get();
-
-                for (_, output_scale) in outputs {
-                    if output_scale.get() != scale {
-                        mixed_scale = true;
-                        scale = scale.min(output_scale.get());
-                    }
-                }
-
-                if mixed_scale {
-                    warn!(
-                        "Mixed output scales detected, choosing to give apps the smallest detected scale ({scale}x)"
-                    );
-                }
-
-                debug!("Using new scale {scale}");
-                self.new_scale = Some(scale);
-            }
-        }
+        self.update_compositor_scaling_state();
 
         {
             if let Some(FocusData {
@@ -800,6 +759,232 @@ impl<C: XConnection> ServerState<C> {
             self.last_hovered.take();
         }
     }
+
+    fn update_compositor_scaling_state(&mut self) {
+        let outputs_changed = !self.updated_outputs.is_empty();
+        if !self.updated_outputs.is_empty() {
+            for output in std::mem::take(&mut self.updated_outputs).iter() {
+                let Ok(output_scale) = self.world.get::<&OutputScaleFactor>(*output) else {
+                    continue;
+                };
+                let mut surface_query = self
+                    .world
+                    .query::<(&OnOutput, &mut SurfaceScaleFactor)>()
+                    .with::<(&WindowData, &WlSurface)>();
+
+                let mut surfaces = vec![];
+                for (surface, (OnOutput(s_output), surface_scale)) in surface_query.iter() {
+                    if s_output == output {
+                        let factor = if self.compositor_scaling {
+                            self.global_scale
+                        } else {
+                            output_scale.get()
+                        };
+                        surface_scale.0 = factor;
+                        surfaces.push(surface);
+                    }
+                }
+
+                drop(surface_query);
+                for surface in surfaces {
+                    update_surface_viewport(&self.world, self.world.query_one(surface).unwrap());
+                }
+            }
+
+            let mut mixed_scale = false;
+            let mut scale;
+            let use_compositor_scaling = self.compositor_scaling;
+
+            let mut outputs = self
+                .world
+                .query_mut::<&event::TrueOutputScaleFactor>()
+                .into_iter();
+            if let Some((_, output_scale)) = outputs.next() {
+                scale = output_scale.0.get();
+
+                for (_, output_scale) in outputs {
+                    if output_scale.0.get() != scale {
+                        mixed_scale = true;
+                        if use_compositor_scaling {
+                            scale = scale.max(output_scale.0.get());
+                        } else {
+                            scale = scale.min(output_scale.0.get());
+                        }
+                    }
+                }
+
+                if mixed_scale {
+                    warn!("Mixed output scales detected, choosing scale ({scale}x)");
+                }
+
+                let old_scale = self.global_scale;
+                debug!("Using new scale {scale}");
+                self.new_scale = Some(scale);
+                self.global_scale = scale;
+
+                if use_compositor_scaling && (old_scale != scale || outputs_changed) {
+                    let mut surface_query = self.world.query::<&mut SurfaceScaleFactor>().with::<(
+                        &WlSurface,
+                        &WindowData,
+                        &WpViewport,
+                    )>(
+                    );
+                    let mut surfaces = vec![];
+                    for (surface, surface_scale) in surface_query.iter() {
+                        surface_scale.0 = scale;
+                        surfaces.push(surface);
+                    }
+                    drop(surface_query);
+                    for surface in surfaces {
+                        let surface_query = self.world.query_one(surface).unwrap();
+                        update_surface_viewport(&self.world, surface_query);
+                        if let Ok(wl_surface) =
+                            self.world.get::<&client::wl_surface::WlSurface>(surface)
+                        {
+                            (*wl_surface).commit();
+                        }
+                    }
+
+                    let mut output_query = self
+                        .world
+                        .query::<&mut OutputScaleFactor>()
+                        .with::<&WlOutput>();
+                    let mut outputs = vec![];
+                    for (output, output_scale) in output_query.iter() {
+                        if *output_scale != OutputScaleFactor::Fractional(scale) {
+                            *output_scale = OutputScaleFactor::Fractional(scale);
+                            outputs.push(output);
+                        }
+                    }
+                    drop(output_query);
+                    for output in outputs {
+                        self.updated_outputs.push(output);
+                    }
+
+                    let comp_scaling = self.compositor_scaling;
+                    let glob_scale = self.global_scale;
+                    recalculate_x11_output_positions(
+                        &mut self.inner.world,
+                        comp_scaling,
+                        glob_scale,
+                    );
+
+                    let outputs_list: Vec<_> = self
+                        .inner
+                        .world
+                        .query::<&WlOutput>()
+                        .iter()
+                        .map(|(e, _)| e)
+                        .collect();
+                    for e in outputs_list {
+                        event::update_window_output_offsets(
+                            e,
+                            &self.inner.global_output_offset,
+                            &self.inner.world,
+                            &mut self.connection,
+                        );
+                    }
+
+                    for (output, (dimensions, server_output)) in self
+                        .world
+                        .query::<(&event::OutputDimensions, &WlOutput)>()
+                        .iter()
+                    {
+                        let (scaled_x, scaled_y) = if use_compositor_scaling {
+                            self.world
+                                .get::<&event::X11OutputPosition>(output)
+                                .ok()
+                                .map(|p| (p.x, p.y))
+                        } else {
+                            None
+                        }
+                        .unwrap_or_else(|| {
+                            (
+                                ((dimensions.x - self.global_output_offset.x.value) as f64 * scale)
+                                    .round() as i32,
+                                ((dimensions.y - self.global_output_offset.y.value) as f64 * scale)
+                                    .round() as i32,
+                            )
+                        });
+                        if let event::OutputDimensionsSource::Wl {
+                            physical_width,
+                            physical_height,
+                            subpixel,
+                            make,
+                            model,
+                            transform,
+                        } = &dimensions.source
+                        {
+                            server_output.geometry(
+                                scaled_x,
+                                scaled_y,
+                                (*physical_width as f64 * scale).round() as i32,
+                                (*physical_height as f64 * scale).round() as i32,
+                                convert_wenum(*subpixel),
+                                make.clone(),
+                                model.clone(),
+                                convert_wenum(*transform),
+                            );
+                        }
+                        server_output.mode(
+                            convert_wenum(dimensions.mode_flags),
+                            (dimensions.width as f64 * scale).round() as i32,
+                            (dimensions.height as f64 * scale).round() as i32,
+                            dimensions.refresh,
+                        );
+                        if self.fractional_scale.is_none() {
+                            server_output.scale(1);
+                        }
+                        server_output.done();
+
+                        if let Ok(xdg_server) = self.world.get::<&wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_v1::ZxdgOutputV1>(output) {
+                            xdg_server.logical_position(scaled_x, scaled_y);
+
+                            let (w, h) = if dimensions.rotated_90 {
+                                (dimensions.height, dimensions.width)
+                            } else {
+                                (dimensions.width, dimensions.height)
+                            };
+                            xdg_server.logical_size(
+                                (w as f64 * scale).round() as i32,
+                                (h as f64 * scale).round() as i32
+                            );
+                            xdg_server.done();
+                        }
+                    }
+                }
+            } else if use_compositor_scaling {
+                // drop back to 1.0 once the last output disappears
+                if self.global_scale != 1.0 {
+                    debug!("No outputs available, resetting global_scale to 1.0");
+                    self.global_scale = 1.0;
+                    self.new_scale = Some(1.0);
+
+                    let mut surface_query = self.world.query::<&mut SurfaceScaleFactor>().with::<(
+                        &WlSurface,
+                        &WindowData,
+                        &WpViewport,
+                    )>(
+                    );
+                    let mut surfaces = vec![];
+                    for (surface, surface_scale) in surface_query.iter() {
+                        surface_scale.0 = 1.0;
+                        surfaces.push(surface);
+                    }
+                    drop(surface_query);
+                    for surface in surfaces {
+                        let surface_query = self.world.query_one(surface).unwrap();
+                        update_surface_viewport(&self.world, surface_query);
+                        if let Ok(wl_surface) =
+                            self.world.get::<&client::wl_surface::WlSurface>(surface)
+                        {
+                            (*wl_surface).commit();
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<S: X11Selection + 'static> InnerServerState<S> {
@@ -832,17 +1017,88 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             if *name == global {
                 self.updated_outputs.push(*entity);
                 self.world
-                    .remove::<(OutputScaleFactor, OutputDimensions)>(*entity)
+                    .remove::<(
+                        OutputScaleFactor,
+                        event::TrueOutputScaleFactor,
+                        OutputDimensions,
+                    )>(*entity)
                     .unwrap();
-                let query = self
+                let _ = self.world.remove_one::<event::X11OutputPosition>(*entity);
+
+                let mut surfaces_to_update = Vec::new();
+                for (e, (on_out, mut entered)) in self
                     .world
-                    .query_mut::<&OnOutput>()
-                    .into_iter()
-                    .map(|(e, on_out)| (e, *on_out))
-                    .collect::<Vec<_>>();
-                for (e, on_out) in query.iter() {
-                    if *on_out == OnOutput(*entity) {
-                        self.world.remove_one::<OnOutput>(*e).unwrap();
+                    .query_mut::<(Option<&mut OnOutput>, Option<&mut event::EnteredOutputs>)>()
+                {
+                    if let Some(ref mut entered) = entered {
+                        entered.0.retain(|&out| out != *entity);
+                    }
+                    if let Some(on_out) = on_out {
+                        if on_out.0 == *entity {
+                            // try another active output before clearing OnOutput
+                            let mut fallback = None;
+                            if let Some(ref entered) = entered {
+                                if let Some(&next_out) = entered.0.first() {
+                                    fallback = Some(next_out);
+                                }
+                            }
+                            if let Some(next_out) = fallback {
+                                *on_out = OnOutput(next_out);
+                                surfaces_to_update.push((e, next_out));
+                            } else {
+                                // clear OnOutput below if there is no fallback
+                                surfaces_to_update.push((e, hecs::Entity::DANGLING));
+                            }
+                        }
+                    }
+                }
+                for (e, next_out) in surfaces_to_update {
+                    if next_out == hecs::Entity::DANGLING {
+                        let _ = self.world.remove_one::<OnOutput>(e);
+                    } else {
+                        // update the offset without a ConfigureWindow during output removal;
+                        // some GTK/GDK clients crash if they query the CRTC mid-transition
+                        if let Ok(dimensions) = self.world.get::<&OutputDimensions>(next_out) {
+                            let (ox, oy) = if let Ok(pos) =
+                                self.world.get::<&event::X11OutputPosition>(next_out)
+                            {
+                                (pos.x, pos.y)
+                            } else {
+                                (
+                                    dimensions.x - self.global_output_offset.x.value,
+                                    dimensions.y - self.global_output_offset.y.value,
+                                )
+                            };
+                            if let Ok(mut win_query) = self.world.query_one::<&mut WindowData>(e) {
+                                if let Some(win_data) = win_query.get() {
+                                    let ox_diff = ox - win_data.output_offset.x;
+                                    let oy_diff = oy - win_data.output_offset.y;
+                                    win_data.attrs.dims.x += ox_diff as i16;
+                                    win_data.attrs.dims.y += oy_diff as i16;
+                                    win_data.output_offset = WindowOutputOffset { x: ox, y: oy };
+                                }
+                            }
+                        }
+
+                        self.updated_outputs.push(next_out);
+                        if let Ok(scale) = self.world.get::<&SurfaceScaleFactor>(e) {
+                            let scale_val = scale.0;
+                            let comp_scaling = self.compositor_scaling;
+                            let glob_scale = self.global_scale;
+                            if let Ok(out_query) = self.world.query_one::<(
+                                &mut OutputScaleFactor,
+                                &mut event::TrueOutputScaleFactor,
+                            )>(
+                                next_out
+                            ) {
+                                let _ = event::update_output_scale(
+                                    out_query,
+                                    OutputScaleFactor::Fractional(scale_val),
+                                    comp_scaling,
+                                    glob_scale,
+                                );
+                            }
+                        }
                     }
                 }
                 if self.global_output_offset.x.owner == Some(*entity) {
@@ -998,23 +1254,26 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             debug!("setting {window:?} hints {hints:?}");
             let mut query = data.query::<(&SurfaceRole, &SurfaceScaleFactor)>();
             if let Some((SurfaceRole::Toplevel(Some(data)), scale_factor)) = query.get() {
-                let decorations_height = if data.decoration.satellite.is_some() {
-                    DecorationsDataSatellite::TITLEBAR_HEIGHT
-                } else {
-                    0
-                };
+                let decorations_height = data
+                    .decoration
+                    .satellite
+                    .as_ref()
+                    .map(|s| s.titlebar_height())
+                    .unwrap_or(0);
                 if let Some(min_size) = &hints.min_size {
                     data.toplevel.set_min_size(
-                        (min_size.width as f64 / scale_factor.0) as i32,
-                        (min_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        event::scale_size_to_logical(min_size.width as f64, scale_factor.0),
+                        event::scale_size_to_logical(min_size.height as f64, scale_factor.0)
+                            + decorations_height,
                     );
                 } else {
                     data.toplevel.set_min_size(0, 0);
                 }
                 if let Some(max_size) = &hints.max_size {
                     data.toplevel.set_max_size(
-                        (max_size.width as f64 / scale_factor.0) as i32,
-                        (max_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        event::scale_size_to_logical(max_size.width as f64, scale_factor.0),
+                        event::scale_size_to_logical(max_size.height as f64, scale_factor.0)
+                            + decorations_height,
                     );
                 } else {
                     data.toplevel.set_max_size(0, 0);
@@ -1104,31 +1363,55 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return;
         }
 
+        let transient_for = win.attrs.transient_for;
+        drop(win);
+
         if self.xdg_wm_base.version() < 3 {
             return;
         }
 
-        let mut query = data.query::<(&mut SurfaceRole, &SurfaceScaleFactor)>();
+        let mut query = data.query::<(&SurfaceRole, &SurfaceScaleFactor)>();
         let Some((role, scale_factor)) = query.get() else {
             return;
         };
 
         match role {
             SurfaceRole::Popup(Some(popup)) => {
+                let mut parent_dims = WindowDims::default();
+                let mut decorations_height = 0;
+                if let Some(parent) = transient_for {
+                    if let Some(&parent_entity) = self.windows.get(&parent) {
+                        if let Ok(parent_data) = self.world.get::<&WindowData>(parent_entity) {
+                            parent_dims = parent_data.attrs.dims;
+                            if let Ok(parent_role) = self.world.get::<&SurfaceRole>(parent_entity) {
+                                if let SurfaceRole::Toplevel(Some(toplevel)) = &*parent_role {
+                                    if let Some(ref sat) = toplevel.decoration.satellite {
+                                        decorations_height = sat.titlebar_height();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                let rx = event.x() as i32 - parent_dims.x as i32;
+                let ry = event.y() as i32 - parent_dims.y as i32;
+                let ry_scaled =
+                    event::scale_pos_to_logical(ry as f64, scale_factor.0) - decorations_height;
                 popup.positioner.set_offset(
-                    ((event.x() as i32 - win.output_offset.x) as f64 / scale_factor.0) as i32,
-                    ((event.y() as i32 - win.output_offset.y) as f64 / scale_factor.0) as i32,
+                    event::scale_pos_to_logical(rx as f64, scale_factor.0),
+                    ry_scaled,
                 );
                 popup.positioner.set_size(
-                    1.max((event.width() as f64 / scale_factor.0) as i32),
-                    1.max((event.height() as f64 / scale_factor.0) as i32),
+                    event::scale_size_to_logical(event.width() as f64, scale_factor.0),
+                    event::scale_size_to_logical(event.height() as f64, scale_factor.0),
                 );
                 popup.popup.reposition(&popup.positioner, 0);
             }
             SurfaceRole::Toplevel(Some(_)) => {
+                drop(query);
+                let mut win = data.get::<&mut WindowData>().unwrap();
                 win.attrs.dims.width = dims.width;
                 win.attrs.dims.height = dims.height;
-                drop(query);
                 drop(win);
                 update_surface_viewport(&self.world, self.world.query_one(data.entity()).unwrap());
             }
@@ -1342,7 +1625,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
     pub fn destroy_window(&mut self, window: x::Window) {
         if let Some(id) = self.windows.remove(&window) {
             self.world.remove::<(x::Window, WindowData)>(id).unwrap();
-            if self.world.entity(id).unwrap().is_empty() {
+            let entity_ref = self.world.entity(id).unwrap();
+            if !entity_ref.has::<client::wl_surface::WlSurface>() {
                 self.world.despawn(id).unwrap();
             }
         }
@@ -1374,7 +1658,9 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
     fn calc_global_output_offset(&mut self) {
         self.global_output_offset.x.value = i32::MAX;
         self.global_output_offset.y.value = i32::MAX;
+        let mut has_outputs = false;
         for (entity, dimensions) in self.world.query_mut::<&OutputDimensions>() {
+            has_outputs = true;
             if dimensions.x < self.global_output_offset.x.value {
                 self.global_output_offset.x = GlobalOutputOffsetDimension {
                     owner: Some(entity),
@@ -1388,6 +1674,10 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 }
             }
         }
+        if !has_outputs {
+            self.global_output_offset.x.value = 0;
+            self.global_output_offset.y.value = 0;
+        }
     }
 
     /// Creates the appropriate xdg role (toplevel or popup) for the given window.
@@ -1396,6 +1686,22 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         let xdg_surface;
         let mut popup_for = None;
         let mut fullscreen = false;
+
+        if let Ok(data) = self.world.entity(entity) {
+            if let Some(window_data) = data.get::<&WindowData>() {
+                let guessed = event::guess_initial_scale(
+                    &self.world,
+                    window_data.attrs.dims,
+                    self.global_scale,
+                    self.compositor_scaling,
+                );
+                if let Ok(mut scale) = self.world.get::<&mut SurfaceScaleFactor>(entity) {
+                    if self.compositor_scaling {
+                        scale.0 = guessed;
+                    }
+                }
+            }
+        }
 
         {
             let data = self.world.entity(entity).unwrap();
@@ -1579,53 +1885,75 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
     }
 
     fn create_popup(&mut self, entity: Entity, xdg: XdgSurface, parent: x::Window) -> PopupData {
-        let mut query = self
-            .world
-            .query_one::<(&WindowData, &mut SurfaceScaleFactor)>(entity)
-            .unwrap();
+        let (window_dims, initial_scale, parent_dims, parent_surface, x_window, decorations_height) = {
+            let mut query = self
+                .world
+                .query_one::<(&mut WindowData, &mut SurfaceScaleFactor, &x::Window)>(entity)
+                .unwrap();
+            let (window, scale, x_window) = query.get().unwrap();
 
-        let (window, scale) = query.get().unwrap();
-        let mut parent_query = self
-            .world
-            .query_one::<(&WindowData, &SurfaceScaleFactor, &SurfaceRole)>(self.windows[&parent])
-            .unwrap();
-        let (parent_window, parent_scale, parent_role) = parent_query.get().unwrap();
-        let parent_dims = parent_window.attrs.dims;
-        let initial_scale = parent_scale.0;
-        *scale = *parent_scale;
+            let mut parent_query = self
+                .world
+                .query_one::<(&WindowData, &SurfaceScaleFactor, &SurfaceRole)>(
+                    self.windows[&parent],
+                )
+                .unwrap();
+            let (parent_window, parent_scale, parent_role) = parent_query.get().unwrap();
+
+            let parent_offset = parent_window.output_offset;
+            window.output_offset = parent_offset;
+            *scale = *parent_scale;
+
+            let decorations_height = if let SurfaceRole::Toplevel(Some(toplevel)) = parent_role {
+                toplevel
+                    .decoration
+                    .satellite
+                    .as_ref()
+                    .map(|s| s.titlebar_height())
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+
+            (
+                window.attrs.dims,
+                parent_scale.0,
+                parent_window.attrs.dims,
+                parent_role.xdg().unwrap().surface.clone(),
+                *x_window,
+                decorations_height,
+            )
+        };
 
         debug!(
             "creating popup ({:?}) {:?} {:?} {:?} {entity:?} (scale: {initial_scale})",
-            *self.world.get::<&x::Window>(entity).unwrap(),
+            x_window,
             parent,
-            window.attrs.dims,
+            window_dims,
             xdg.id()
         );
 
         let positioner = self.xdg_wm_base.create_positioner(&self.qh, ());
         positioner.set_size(
-            1.max((window.attrs.dims.width as f64 / initial_scale) as i32),
-            1.max((window.attrs.dims.height as f64 / initial_scale) as i32),
+            1.max((window_dims.width as f64 / initial_scale) as i32),
+            1.max((window_dims.height as f64 / initial_scale) as i32),
         );
-        let x = ((window.attrs.dims.x - parent_dims.x) as f64 / initial_scale) as i32;
-        let y = ((window.attrs.dims.y - parent_dims.y) as f64 / initial_scale) as i32;
+        let x = ((window_dims.x - parent_dims.x) as f64 / initial_scale) as i32;
+        let mut y = ((window_dims.y - parent_dims.y) as f64 / initial_scale) as i32;
+        y -= decorations_height;
         positioner.set_offset(x, y);
         positioner.set_anchor(Anchor::TopLeft);
         positioner.set_gravity(Gravity::BottomRight);
+        let parent_h = (parent_dims.height as f64 / initial_scale) as i32;
         positioner.set_anchor_rect(
             0,
             0,
-            (parent_window.attrs.dims.width as f64 / initial_scale) as i32,
-            (parent_window.attrs.dims.height as f64 / initial_scale) as i32,
+            (parent_dims.width as f64 / initial_scale) as i32,
+            parent_h,
         );
         positioner
             .set_constraint_adjustment(ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY);
-        let popup = xdg.get_popup(
-            Some(&parent_role.xdg().unwrap().surface),
-            &positioner,
-            &self.qh,
-            entity,
-        );
+        let popup = xdg.get_popup(Some(&parent_surface), &positioner, &self.qh, entity);
 
         PopupData {
             popup,
@@ -1635,6 +1963,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 configured: false,
                 pending: None,
             },
+            parent,
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,7 +50,7 @@ use wayland_protocols::{
             zwp_tablet_pad_v2, zwp_tablet_seat_v2, zwp_tablet_tool_v2, zwp_tablet_v2,
         },
         tablet::zv2::server::zwp_tablet_manager_v2::ZwpTabletManagerV2,
-        viewporter::client::wp_viewporter::WpViewporter,
+        viewporter::client::{wp_viewport::WpViewport, wp_viewporter::WpViewporter},
     },
     xdg::{
         shell::client::{
@@ -485,7 +485,8 @@ pub struct InnerServerState<S: X11Selection> {
     global_offset_updated: bool,
     updated_outputs: Vec<Entity>,
     new_scale: Option<f64>,
-    current_scale: f64,
+    pub global_scale: f64,
+    pub compositor_scaling: bool,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -493,6 +494,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
         mut dh: DisplayHandle,
         server_connection: Option<UnixStream>,
         client: UnixStream,
+        compositor_scaling: bool,
     ) -> Self {
         let connection = if let Some(stream) = server_connection {
             Connection::from_socket(stream).unwrap()
@@ -594,7 +596,8 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
-            current_scale: 1.0,
+            global_scale: 1.0,
+            compositor_scaling,
             decoration_manager,
             world,
         };
@@ -665,6 +668,9 @@ impl<C: XConnection> ServerState<C> {
             self.global_offset_updated = true;
         }
         if self.global_offset_updated {
+            let comp_scaling = self.compositor_scaling;
+            let glob_scale = self.global_scale;
+            recalculate_x11_output_positions(&mut self.world, comp_scaling, glob_scale);
             debug!(
                 target: "output_offset",
                 "updated global output offset: {}x{}",
@@ -677,65 +683,14 @@ impl<C: XConnection> ServerState<C> {
                     &state.global_output_offset,
                     &state.world,
                     &mut self.connection,
+                    state.global_scale,
+                    state.compositor_scaling,
                 );
             }
             self.global_offset_updated = false;
         }
 
-        if !self.updated_outputs.is_empty() {
-            for output in std::mem::take(&mut self.updated_outputs).iter() {
-                let Ok(output_scale) = self.world.get::<&OutputScaleFactor>(*output) else {
-                    continue;
-                };
-                if matches!(*output_scale, OutputScaleFactor::Output(..)) {
-                    let mut surface_query = self
-                        .world
-                        .query::<(&OnOutput, &mut SurfaceScaleFactor)>()
-                        .with::<(&WindowData, &WlSurface)>();
-
-                    let mut surfaces = vec![];
-                    for (surface, (OnOutput(s_output), surface_scale)) in surface_query.iter() {
-                        if s_output == output {
-                            surface_scale.0 = output_scale.get();
-                            surfaces.push(surface);
-                        }
-                    }
-
-                    drop(surface_query);
-                    for surface in surfaces {
-                        update_surface_viewport(
-                            &self.world,
-                            self.world.query_one(surface).unwrap(),
-                        );
-                    }
-                }
-            }
-
-            let mut mixed_scale = false;
-            let mut scale;
-
-            let mut outputs = self.world.query_mut::<&OutputScaleFactor>().into_iter();
-            if let Some((_, output_scale)) = outputs.next() {
-                scale = output_scale.get();
-
-                for (_, output_scale) in outputs {
-                    if output_scale.get() != scale {
-                        mixed_scale = true;
-                        scale = scale.min(output_scale.get());
-                    }
-                }
-
-                if mixed_scale {
-                    warn!(
-                        "Mixed output scales detected, choosing to give apps the smallest detected scale ({scale}x)"
-                    );
-                }
-
-                debug!("Using new scale {scale}");
-                self.new_scale = Some(scale);
-                self.current_scale = scale;
-            }
-        }
+        self.update_compositor_scaling_state();
 
         {
             if let Some(FocusData {
@@ -805,6 +760,265 @@ impl<C: XConnection> ServerState<C> {
             self.last_hovered.take();
         }
     }
+
+    fn update_compositor_scaling_state(&mut self) {
+        let outputs_changed = !self.updated_outputs.is_empty();
+        if !self.updated_outputs.is_empty() {
+            for output in std::mem::take(&mut self.updated_outputs).iter() {
+                let Ok(output_scale) = self.world.get::<&OutputScaleFactor>(*output) else {
+                    continue;
+                };
+                let mut surface_query = self
+                    .world
+                    .query::<(&OnOutput, &mut SurfaceScaleFactor)>()
+                    .with::<(&WindowData, &WlSurface)>();
+
+                let mut surfaces = vec![];
+                for (surface, (OnOutput(s_output), surface_scale)) in surface_query.iter() {
+                    if s_output == output {
+                        let factor = if self.compositor_scaling {
+                            self.global_scale
+                        } else {
+                            output_scale.get()
+                        };
+                        surface_scale.0 = factor;
+                        surfaces.push(surface);
+                    }
+                }
+
+                drop(surface_query);
+                for surface in surfaces {
+                    update_surface_viewport(&self.world, self.world.query_one(surface).unwrap());
+                }
+            }
+
+            let mut mixed_scale = false;
+            let mut scale;
+            let use_compositor_scaling = self.compositor_scaling;
+
+            let mut outputs = self
+                .world
+                .query_mut::<&event::TrueOutputScaleFactor>()
+                .into_iter();
+            if let Some((_, output_scale)) = outputs.next() {
+                scale = output_scale.0.get();
+
+                for (_, output_scale) in outputs {
+                    if output_scale.0.get() != scale {
+                        mixed_scale = true;
+                        if use_compositor_scaling {
+                            scale = scale.max(output_scale.0.get());
+                        } else {
+                            scale = scale.min(output_scale.0.get());
+                        }
+                    }
+                }
+
+                if mixed_scale {
+                    warn!("Mixed output scales detected, choosing scale ({scale}x)");
+                }
+
+                if use_compositor_scaling {
+                    if let Some(base_scale) = std::env::var("XWAYLAND_SATELLITE_BASE_SCALE")
+                        .ok()
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .filter(|f| f.is_finite())
+                        .map(|f| f.clamp(1.0, 8.0))
+                    {
+                        scale = base_scale;
+                    }
+                }
+
+                let old_scale = self.global_scale;
+                debug!("Using new scale {scale}");
+                self.new_scale = Some(scale);
+                self.global_scale = scale;
+
+                if use_compositor_scaling && (old_scale != scale || outputs_changed) {
+                    let mut surface_query = self.world.query::<&mut SurfaceScaleFactor>().with::<(
+                        &WlSurface,
+                        &WindowData,
+                        &WpViewport,
+                    )>(
+                    );
+                    let mut surfaces = vec![];
+                    for (surface, surface_scale) in surface_query.iter() {
+                        surface_scale.0 = scale;
+                        surfaces.push(surface);
+                    }
+                    drop(surface_query);
+                    for surface in surfaces {
+                        let surface_query = self.world.query_one(surface).unwrap();
+                        update_surface_viewport(&self.world, surface_query);
+                        if let Ok(wl_surface) =
+                            self.world.get::<&client::wl_surface::WlSurface>(surface)
+                        {
+                            (*wl_surface).commit();
+                        }
+                    }
+
+                    let mut output_query = self
+                        .world
+                        .query::<&mut OutputScaleFactor>()
+                        .with::<&WlOutput>();
+                    let mut outputs = vec![];
+                    for (output, output_scale) in output_query.iter() {
+                        if *output_scale != OutputScaleFactor::Fractional(scale) {
+                            *output_scale = OutputScaleFactor::Fractional(scale);
+                            outputs.push(output);
+                        }
+                    }
+                    drop(output_query);
+                    for output in outputs {
+                        self.updated_outputs.push(output);
+                    }
+
+                    let comp_scaling = self.compositor_scaling;
+                    let glob_scale = self.global_scale;
+                    recalculate_x11_output_positions(
+                        &mut self.inner.world,
+                        comp_scaling,
+                        glob_scale,
+                    );
+
+                    let outputs_list: Vec<_> = self
+                        .inner
+                        .world
+                        .query::<&WlOutput>()
+                        .iter()
+                        .map(|(e, _)| e)
+                        .collect();
+                    for e in outputs_list {
+                        event::update_window_output_offsets(
+                            e,
+                            &self.inner.global_output_offset,
+                            &self.inner.world,
+                            &mut self.connection,
+                        );
+                    }
+
+                    for (output, (dimensions, server_output)) in self
+                        .world
+                        .query::<(&event::OutputDimensions, &WlOutput)>()
+                        .iter()
+                    {
+                        let (scaled_x, scaled_y) = if use_compositor_scaling {
+                            self.world
+                                .get::<&event::X11OutputPosition>(output)
+                                .ok()
+                                .map(|p| (p.x, p.y))
+                        } else {
+                            None
+                        }
+                        .unwrap_or_else(|| {
+                            (
+                                ((dimensions.x - self.global_output_offset.x.value) as f64 * scale)
+                                    .round() as i32,
+                                ((dimensions.y - self.global_output_offset.y.value) as f64 * scale)
+                                    .round() as i32,
+                            )
+                        });
+                        if let event::OutputDimensionsSource::Wl {
+                            physical_width,
+                            physical_height,
+                            subpixel,
+                            make,
+                            model,
+                            transform,
+                        } = &dimensions.source
+                        {
+                            server_output.geometry(
+                                scaled_x,
+                                scaled_y,
+                                *physical_width,
+                                *physical_height,
+                                convert_wenum(*subpixel),
+                                make.clone(),
+                                model.clone(),
+                                convert_wenum(*transform),
+                            );
+                        }
+                        let (mode_w, mode_h) = if dimensions.physical_mode_width > 0
+                            && dimensions.physical_mode_height > 0
+                        {
+                            (
+                                dimensions.physical_mode_width,
+                                dimensions.physical_mode_height,
+                            )
+                        } else {
+                            match dimensions.source {
+                                event::OutputDimensionsSource::Xdg => (
+                                    (dimensions.width as f64 * scale).round() as i32,
+                                    (dimensions.height as f64 * scale).round() as i32,
+                                ),
+                                event::OutputDimensionsSource::Wl { .. } => {
+                                    (dimensions.width, dimensions.height)
+                                }
+                            }
+                        };
+                        server_output.mode(
+                            convert_wenum(dimensions.mode_flags),
+                            mode_w,
+                            mode_h,
+                            dimensions.refresh,
+                        );
+                        if self.fractional_scale.is_none() {
+                            server_output.scale(1);
+                        }
+                        server_output.done();
+
+                        if let Ok(xdg_server) = self.world.get::<&wayland_protocols::xdg::xdg_output::zv1::server::zxdg_output_v1::ZxdgOutputV1>(output) {
+                            xdg_server.logical_position(scaled_x, scaled_y);
+
+                            let (w, h) = if dimensions.rotated_90 {
+                                (dimensions.height, dimensions.width)
+                            } else {
+                                (dimensions.width, dimensions.height)
+                            };
+                            let (sw, sh) = match dimensions.source {
+                                event::OutputDimensionsSource::Xdg => (
+                                    (w as f64 * scale).round() as i32,
+                                    (h as f64 * scale).round() as i32,
+                                ),
+                                event::OutputDimensionsSource::Wl { .. } => (w, h),
+                            };
+                            xdg_server.logical_size(sw, sh);
+                            xdg_server.done();
+                        }
+                    }
+                }
+            } else if use_compositor_scaling {
+                // Reset to 1.0 when empty to prevent stale scale
+                if self.global_scale != 1.0 {
+                    debug!("No outputs available, resetting global_scale to 1.0");
+                    self.global_scale = 1.0;
+                    self.new_scale = Some(1.0);
+
+                    let mut surface_query = self.world.query::<&mut SurfaceScaleFactor>().with::<(
+                        &WlSurface,
+                        &WindowData,
+                        &WpViewport,
+                    )>(
+                    );
+                    let mut surfaces = vec![];
+                    for (surface, surface_scale) in surface_query.iter() {
+                        surface_scale.0 = 1.0;
+                        surfaces.push(surface);
+                    }
+                    drop(surface_query);
+                    for surface in surfaces {
+                        let surface_query = self.world.query_one(surface).unwrap();
+                        update_surface_viewport(&self.world, surface_query);
+                        if let Ok(wl_surface) =
+                            self.world.get::<&client::wl_surface::WlSurface>(surface)
+                        {
+                            (*wl_surface).commit();
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<S: X11Selection + 'static> InnerServerState<S> {
@@ -818,7 +1032,9 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
         let globals = std::mem::take(&mut self.world.removed_globals);
         for global in globals {
-            let (global_struct, global_id) = self.globals_map.remove(&global).unwrap();
+            let Some((global_struct, global_id)) = self.globals_map.remove(&global) else {
+                continue;
+            };
             self.dh.disable_global::<InnerServerState<S>>(global_id);
             if global_struct.interface == <WlOutput>::interface().name {
                 self.remove_output(global);
@@ -837,17 +1053,85 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             if *name == global {
                 self.updated_outputs.push(*entity);
                 self.world
-                    .remove::<(OutputScaleFactor, OutputDimensions)>(*entity)
+                    .remove::<(
+                        OutputScaleFactor,
+                        event::TrueOutputScaleFactor,
+                        OutputDimensions,
+                    )>(*entity)
                     .unwrap();
-                let query = self
+                let _ = self.world.remove_one::<event::X11OutputPosition>(*entity);
+
+                let mut surfaces_to_update = Vec::new();
+                for (e, (on_out, mut entered)) in self
                     .world
-                    .query_mut::<&OnOutput>()
-                    .into_iter()
-                    .map(|(e, on_out)| (e, *on_out))
-                    .collect::<Vec<_>>();
-                for (e, on_out) in query.iter() {
-                    if *on_out == OnOutput(*entity) {
-                        self.world.remove_one::<OnOutput>(*e).unwrap();
+                    .query_mut::<(Option<&mut OnOutput>, Option<&mut event::EnteredOutputs>)>()
+                {
+                    if let Some(ref mut entered) = entered {
+                        entered.0.retain(|&out| out != *entity);
+                    }
+                    if let Some(on_out) = on_out {
+                        if on_out.0 == *entity {
+                            let mut fallback = None;
+                            if let Some(ref entered) = entered {
+                                if let Some(&next_out) = entered.0.first() {
+                                    fallback = Some(next_out);
+                                }
+                            }
+                            if let Some(next_out) = fallback {
+                                *on_out = OnOutput(next_out);
+                                surfaces_to_update.push((e, next_out));
+                            } else {
+                                surfaces_to_update.push((e, hecs::Entity::DANGLING));
+                            }
+                        }
+                    }
+                }
+                for (e, next_out) in surfaces_to_update {
+                    if next_out == hecs::Entity::DANGLING {
+                        let _ = self.world.remove_one::<OnOutput>(e);
+                    } else {
+                        // Update offset silently to avoid triggering ConfigureWindow and crashing GDK
+                        if let Ok(dimensions) = self.world.get::<&OutputDimensions>(next_out) {
+                            let (ox, oy) = if let Ok(pos) =
+                                self.world.get::<&event::X11OutputPosition>(next_out)
+                            {
+                                (pos.x, pos.y)
+                            } else {
+                                (
+                                    dimensions.x - self.global_output_offset.x.value,
+                                    dimensions.y - self.global_output_offset.y.value,
+                                )
+                            };
+                            if let Ok(mut win_query) = self.world.query_one::<&mut WindowData>(e) {
+                                if let Some(win_data) = win_query.get() {
+                                    let ox_diff = ox - win_data.output_offset.x;
+                                    let oy_diff = oy - win_data.output_offset.y;
+                                    win_data.attrs.dims.x += ox_diff as i16;
+                                    win_data.attrs.dims.y += oy_diff as i16;
+                                    win_data.output_offset = WindowOutputOffset { x: ox, y: oy };
+                                }
+                            }
+                        }
+
+                        self.updated_outputs.push(next_out);
+                        if let Ok(scale) = self.world.get::<&SurfaceScaleFactor>(e) {
+                            let scale_val = scale.0;
+                            let comp_scaling = self.compositor_scaling;
+                            let glob_scale = self.global_scale;
+                            if let Ok(out_query) = self.world.query_one::<(
+                                &mut OutputScaleFactor,
+                                &mut event::TrueOutputScaleFactor,
+                            )>(
+                                next_out
+                            ) {
+                                let _ = event::update_output_scale(
+                                    out_query,
+                                    OutputScaleFactor::Fractional(scale_val),
+                                    comp_scaling,
+                                    glob_scale,
+                                );
+                            }
+                        }
                     }
                 }
                 if self.global_output_offset.x.owner == Some(*entity) {
@@ -1085,21 +1369,43 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             return;
         }
 
+        let transient_for = win.attrs.transient_for;
+        drop(win);
+
         if self.xdg_wm_base.version() < 3 {
             return;
         }
 
-        let mut query = data.query::<(&mut SurfaceRole, &SurfaceScaleFactor)>();
+        let mut query = data.query::<(&SurfaceRole, &SurfaceScaleFactor)>();
         let Some((role, scale_factor)) = query.get() else {
             return;
         };
 
         match role {
             SurfaceRole::Popup(Some(popup)) => {
-                popup.positioner.set_offset(
-                    ((event.x() as i32 - win.output_offset.x) as f64 / scale_factor.0) as i32,
-                    ((event.y() as i32 - win.output_offset.y) as f64 / scale_factor.0) as i32,
-                );
+                let mut parent_dims = WindowDims::default();
+                let mut decorations_height = 0;
+                if let Some(parent) = transient_for {
+                    if let Some(&parent_entity) = self.windows.get(&parent) {
+                        if let Ok(parent_data) = self.world.get::<&WindowData>(parent_entity) {
+                            parent_dims = parent_data.attrs.dims;
+                            if let Ok(parent_role) = self.world.get::<&SurfaceRole>(parent_entity) {
+                                if let SurfaceRole::Toplevel(Some(toplevel)) = &*parent_role {
+                                    if let Some(ref sat) = toplevel.decoration.satellite {
+                                        decorations_height = sat.titlebar_height();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                let rx = event.x() as i32 - parent_dims.x as i32;
+                let ry = event.y() as i32 - parent_dims.y as i32;
+                let mut ry_scaled = (ry as f64 / scale_factor.0) as i32;
+                ry_scaled -= decorations_height;
+                popup
+                    .positioner
+                    .set_offset((rx as f64 / scale_factor.0) as i32, ry_scaled);
                 popup.positioner.set_size(
                     1.max((event.width() as f64 / scale_factor.0) as i32),
                     1.max((event.height() as f64 / scale_factor.0) as i32),
@@ -1107,9 +1413,10 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 popup.popup.reposition(&popup.positioner, 0);
             }
             SurfaceRole::Toplevel(Some(_)) => {
+                drop(query);
+                let mut win = data.get::<&mut WindowData>().unwrap();
                 win.attrs.dims.width = dims.width;
                 win.attrs.dims.height = dims.height;
-                drop(query);
                 drop(win);
                 update_surface_viewport(&self.world, self.world.query_one(data.entity()).unwrap());
             }
@@ -1572,53 +1879,75 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
     }
 
     fn create_popup(&mut self, entity: Entity, xdg: XdgSurface, parent: x::Window) -> PopupData {
-        let mut query = self
-            .world
-            .query_one::<(&WindowData, &mut SurfaceScaleFactor)>(entity)
-            .unwrap();
+        let (window_dims, initial_scale, parent_dims, parent_surface, x_window, decorations_height) = {
+            let mut query = self
+                .world
+                .query_one::<(&mut WindowData, &mut SurfaceScaleFactor, &x::Window)>(entity)
+                .unwrap();
+            let (window, scale, x_window) = query.get().unwrap();
 
-        let (window, scale) = query.get().unwrap();
-        let mut parent_query = self
-            .world
-            .query_one::<(&WindowData, &SurfaceScaleFactor, &SurfaceRole)>(self.windows[&parent])
-            .unwrap();
-        let (parent_window, parent_scale, parent_role) = parent_query.get().unwrap();
-        let parent_dims = parent_window.attrs.dims;
-        let initial_scale = parent_scale.0;
-        *scale = *parent_scale;
+            let mut parent_query = self
+                .world
+                .query_one::<(&WindowData, &SurfaceScaleFactor, &SurfaceRole)>(
+                    self.windows[&parent],
+                )
+                .unwrap();
+            let (parent_window, parent_scale, parent_role) = parent_query.get().unwrap();
+
+            let parent_offset = parent_window.output_offset;
+            window.output_offset = parent_offset;
+            *scale = *parent_scale;
+
+            let decorations_height = if let SurfaceRole::Toplevel(Some(toplevel)) = parent_role {
+                toplevel
+                    .decoration
+                    .satellite
+                    .as_ref()
+                    .map(|s| s.titlebar_height())
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+
+            (
+                window.attrs.dims,
+                parent_scale.0,
+                parent_window.attrs.dims,
+                parent_role.xdg().unwrap().surface.clone(),
+                *x_window,
+                decorations_height,
+            )
+        };
 
         debug!(
             "creating popup ({:?}) {:?} {:?} {:?} {entity:?} (scale: {initial_scale})",
-            *self.world.get::<&x::Window>(entity).unwrap(),
+            x_window,
             parent,
-            window.attrs.dims,
+            window_dims,
             xdg.id()
         );
 
         let positioner = self.xdg_wm_base.create_positioner(&self.qh, ());
         positioner.set_size(
-            1.max((window.attrs.dims.width as f64 / initial_scale) as i32),
-            1.max((window.attrs.dims.height as f64 / initial_scale) as i32),
+            1.max((window_dims.width as f64 / initial_scale) as i32),
+            1.max((window_dims.height as f64 / initial_scale) as i32),
         );
-        let x = ((window.attrs.dims.x - parent_dims.x) as f64 / initial_scale) as i32;
-        let y = ((window.attrs.dims.y - parent_dims.y) as f64 / initial_scale) as i32;
+        let x = ((window_dims.x - parent_dims.x) as f64 / initial_scale) as i32;
+        let mut y = ((window_dims.y - parent_dims.y) as f64 / initial_scale) as i32;
+        y -= decorations_height;
         positioner.set_offset(x, y);
         positioner.set_anchor(Anchor::TopLeft);
         positioner.set_gravity(Gravity::BottomRight);
+        let parent_h = (parent_dims.height as f64 / initial_scale) as i32;
         positioner.set_anchor_rect(
             0,
             0,
-            (parent_window.attrs.dims.width as f64 / initial_scale) as i32,
-            (parent_window.attrs.dims.height as f64 / initial_scale) as i32,
+            (parent_dims.width as f64 / initial_scale) as i32,
+            parent_h,
         );
         positioner
             .set_constraint_adjustment(ConstraintAdjustment::SlideX | ConstraintAdjustment::SlideY);
-        let popup = xdg.get_popup(
-            Some(&parent_role.xdg().unwrap().surface),
-            &positioner,
-            &self.qh,
-            entity,
-        );
+        let popup = xdg.get_popup(Some(&parent_surface), &positioner, &self.qh, entity);
 
         PopupData {
             popup,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -103,6 +103,8 @@ where
 struct WindowAttributes {
     acquire_input_via_wm: bool,
     has_take_focus: bool,
+    is_menu: bool,
+    override_redirect: bool,
     role: WindowRole,
     dims: WindowDims,
     size_hints: Option<WmNormalHints>,
@@ -111,6 +113,8 @@ struct WindowAttributes {
     group: Option<x::Window>,
     decorations: Option<Decorations>,
     transient_for: Option<x::Window>,
+    fullscreen: bool,
+    maximized: bool,
 }
 
 impl WindowAttributes {
@@ -139,6 +143,7 @@ impl WindowData {
         Self {
             mapped: false,
             attrs: WindowAttributes {
+                override_redirect,
                 role: WindowRole::new_basic(override_redirect),
                 dims,
                 ..Default::default()
@@ -239,6 +244,7 @@ struct ToplevelData {
     toplevel: XdgToplevel,
     xdg: XdgSurfaceData,
     fullscreen: bool,
+    maximized: bool,
     decoration: decoration::DecorationsData,
 }
 
@@ -247,6 +253,7 @@ struct PopupData {
     popup: XdgPopup,
     positioner: XdgPositioner,
     xdg: XdgSurfaceData,
+    parent: x::Window,
 }
 
 trait Event {
@@ -422,6 +429,9 @@ impl<S: X11Selection> XConnection for NoConnection<S> {
     fn focus_window(&mut self, _: x::Window, _: Option<String>) {
         debug!("could not focus window without XWayland initialized");
     }
+    fn focus_popup(&mut self, _: x::Window) {
+        debug!("could not focus popup without XWayland initialized");
+    }
     fn close_window(&mut self, _: x::Window) {
         debug!("could not close window without XWayland initialized");
     }
@@ -433,6 +443,9 @@ impl<S: X11Selection> XConnection for NoConnection<S> {
     }
     fn set_fullscreen(&mut self, _: x::Window, _: bool) {
         debug!("could not toggle fullscreen without XWayland initialized");
+    }
+    fn set_maximized(&mut self, _: x::Window, _: bool) {
+        debug!("could not toggle maximized without XWayland initialized");
     }
     fn set_window_dims(&mut self, _: x::Window, _: crate::server::PendingSurfaceState) -> bool {
         debug!("could not set window dimensions without XWayland initialized");
@@ -703,8 +716,10 @@ impl<C: XConnection> ServerState<C> {
                     "focusing {} {window:?}",
                     if is_popup { "popup" } else { "window" }
                 );
-                self.connection.focus_window(window, output_name);
-                if !is_popup {
+                if is_popup {
+                    self.connection.focus_popup(window);
+                } else {
+                    self.connection.focus_window(window, output_name);
                     self.last_focused_toplevel = Some(window);
                 }
             } else if self.unfocus {
@@ -1052,13 +1067,12 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         for (entity, name) in query.iter() {
             if *name == global {
                 self.updated_outputs.push(*entity);
-                self.world
+                let _ = self.world
                     .remove::<(
                         OutputScaleFactor,
                         event::TrueOutputScaleFactor,
                         OutputDimensions,
-                    )>(*entity)
-                    .unwrap();
+                    )>(*entity);
                 let _ = self.world.remove_one::<event::X11OutputPosition>(*entity);
 
                 let mut surfaces_to_update = Vec::new();
@@ -1266,6 +1280,25 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         attrs.has_take_focus = has_take_focus;
     }
 
+    pub fn set_win_is_menu(&mut self, window: x::Window, is_menu: bool) {
+        let Some(id) = self.windows.get(&window).copied() else {
+            return;
+        };
+
+        let attrs = &mut self.world.get::<&mut WindowData>(id).unwrap().attrs;
+        attrs.is_menu = is_menu;
+    }
+
+    pub fn is_override_redirect(&self, window: x::Window) -> bool {
+        let Some(id) = self.windows.get(&window).copied() else {
+            return false;
+        };
+        let Ok(data) = self.world.get::<&WindowData>(id) else {
+            return false;
+        };
+        data.attrs.override_redirect
+    }
+
     pub fn set_size_hints(&mut self, window: x::Window, hints: WmNormalHints) {
         let Some(data) = self
             .windows
@@ -1312,6 +1345,22 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 }
             }
             win.attrs.decorations = Some(decorations);
+        }
+    }
+
+    pub fn set_win_maximized(&mut self, window: x::Window, maximized: bool) {
+        if let Some(id) = self.windows.get(&window).copied() {
+            if let Ok(mut win) = self.world.get::<&mut WindowData>(id) {
+                win.attrs.maximized = maximized;
+            }
+        }
+    }
+
+    pub fn set_win_fullscreen(&mut self, window: x::Window, fullscreen: bool) {
+        if let Some(id) = self.windows.get(&window).copied() {
+            if let Ok(mut win) = self.world.get::<&mut WindowData>(id) {
+                win.attrs.fullscreen = fullscreen;
+            }
         }
     }
 
@@ -1385,7 +1434,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             SurfaceRole::Popup(Some(popup)) => {
                 let mut parent_dims = WindowDims::default();
                 let mut decorations_height = 0;
-                if let Some(parent) = transient_for {
+                let parent = transient_for.or(Some(popup.parent));
+                if let Some(parent) = parent {
                     if let Some(&parent_entity) = self.windows.get(&parent) {
                         if let Ok(parent_data) = self.world.get::<&WindowData>(parent_entity) {
                             parent_dims = parent_data.attrs.dims;
@@ -1401,16 +1451,20 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 }
                 let rx = event.x() as i32 - parent_dims.x as i32;
                 let ry = event.y() as i32 - parent_dims.y as i32;
-                let mut ry_scaled = (ry as f64 / scale_factor.0) as i32;
+                let mut ry_scaled = (ry as f64 / scale_factor.0).round() as i32;
                 ry_scaled -= decorations_height;
-                popup
-                    .positioner
-                    .set_offset((rx as f64 / scale_factor.0) as i32, ry_scaled);
-                popup.positioner.set_size(
-                    1.max((event.width() as f64 / scale_factor.0) as i32),
-                    1.max((event.height() as f64 / scale_factor.0) as i32),
-                );
+                let rx_scaled = (rx as f64 / scale_factor.0).round() as i32;
+                let new_w = 1.max((event.width() as f64 / scale_factor.0).round() as i32);
+                let new_h = 1.max((event.height() as f64 / scale_factor.0).round() as i32);
+                popup.positioner.set_offset(rx_scaled, ry_scaled);
+                popup.positioner.set_size(new_w, new_h);
                 popup.popup.reposition(&popup.positioner, 0);
+
+                drop(query);
+                let mut win = data.get::<&mut WindowData>().unwrap();
+                win.attrs.dims = dims;
+                drop(win);
+                update_surface_viewport(&self.world, self.world.query_one(data.entity()).unwrap());
             }
             SurfaceRole::Toplevel(Some(_)) => {
                 drop(query);
@@ -1487,14 +1541,26 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         };
 
         let Some(role) = data.get::<&SurfaceRole>() else {
-            warn!("Tried to set window without role fullscreen: {window:?}");
+            if let Some(mut win) = data.get::<&mut WindowData>() {
+                win.attrs.fullscreen = state.apply(win.attrs.fullscreen);
+            } else {
+                warn!("Tried to set window without role fullscreen: {window:?}");
+            }
             return;
         };
 
         let SurfaceRole::Toplevel(Some(toplevel)) = &*role else {
-            warn!("Tried to set an unmapped toplevel or non toplevel fullscreen: {window:?}");
+            if let Some(mut win) = data.get::<&mut WindowData>() {
+                win.attrs.fullscreen = state.apply(win.attrs.fullscreen);
+            } else {
+                warn!("Tried to set an unmapped toplevel or non toplevel fullscreen: {window:?}");
+            }
             return;
         };
+
+        if let Some(mut win) = data.get::<&mut WindowData>() {
+            win.attrs.fullscreen = state.apply(win.attrs.fullscreen);
+        }
 
         use crate::xstate::SetState;
         match state {
@@ -1505,6 +1571,53 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                     toplevel.toplevel.unset_fullscreen()
                 } else {
                     toplevel.toplevel.set_fullscreen(None)
+                }
+            }
+        }
+    }
+
+    pub fn set_maximized(&mut self, window: x::Window, state: super::xstate::SetState) {
+        let Some(data) = self
+            .windows
+            .get(&window)
+            .copied()
+            .and_then(|id| self.world.entity(id).ok())
+        else {
+            warn!("Tried to set unknown window {window:?} maximized");
+            return;
+        };
+
+        let Some(role) = data.get::<&SurfaceRole>() else {
+            if let Some(mut win) = data.get::<&mut WindowData>() {
+                win.attrs.maximized = state.apply(win.attrs.maximized);
+            } else {
+                warn!("Tried to set window without role maximized: {window:?}");
+            }
+            return;
+        };
+
+        let SurfaceRole::Toplevel(Some(toplevel)) = &*role else {
+            if let Some(mut win) = data.get::<&mut WindowData>() {
+                win.attrs.maximized = state.apply(win.attrs.maximized);
+            } else {
+                warn!("Tried to set an unmapped toplevel or non toplevel maximized: {window:?}");
+            }
+            return;
+        };
+
+        if let Some(mut win) = data.get::<&mut WindowData>() {
+            win.attrs.maximized = state.apply(win.attrs.maximized);
+        }
+
+        use crate::xstate::SetState;
+        match state {
+            SetState::Add => toplevel.toplevel.set_maximized(),
+            SetState::Remove => toplevel.toplevel.unset_maximized(),
+            SetState::Toggle => {
+                if toplevel.maximized {
+                    toplevel.toplevel.unset_maximized()
+                } else {
+                    toplevel.toplevel.set_maximized()
                 }
             }
         }
@@ -1684,6 +1797,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         let xdg_surface;
         let mut popup_for = None;
         let mut fullscreen = false;
+        let maximized;
         let splash;
 
         {
@@ -1708,13 +1822,18 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                     break;
                 }
             }
+            if window_data.attrs.fullscreen {
+                fullscreen = true;
+                popup_for = None;
+            }
+            maximized = window_data.attrs.maximized;
         }
 
         let (role, is_toplevel) = if let Some(parent) = popup_for {
             let data = self.create_popup(entity, xdg_surface, parent);
             (SurfaceRole::Popup(Some(data)), false)
         } else {
-            let data = self.create_toplevel(entity, xdg_surface, fullscreen, splash);
+            let data = self.create_toplevel(entity, xdg_surface, fullscreen, maximized, splash);
             (SurfaceRole::Toplevel(Some(data)), true)
         };
 
@@ -1743,11 +1862,12 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
         entity: Entity,
         xdg: XdgSurface,
         fullscreen: bool,
+        maximized: bool,
         splash: bool,
     ) -> ToplevelData {
         let window = self.world.get::<&WindowData>(entity).unwrap();
         debug!(
-            "creating toplevel for {:?} fullscreen: {fullscreen:?}",
+            "creating toplevel for {:?} fullscreen: {fullscreen:?} maximized: {maximized:?}",
             *self.world.get::<&x::Window>(entity).unwrap()
         );
 
@@ -1793,6 +1913,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
         if fullscreen {
             toplevel.set_fullscreen(None);
+        } else if maximized {
+            toplevel.set_maximized();
         }
 
         let wl_decoration = self.decoration_manager.as_ref().map(|decoration_manager| {
@@ -1871,6 +1993,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             },
             toplevel,
             fullscreen: false,
+            maximized,
             decoration: DecorationsData {
                 wl: wl_decoration,
                 satellite: sat_decoration,
@@ -1929,11 +2052,11 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
 
         let positioner = self.xdg_wm_base.create_positioner(&self.qh, ());
         positioner.set_size(
-            1.max((window_dims.width as f64 / initial_scale) as i32),
-            1.max((window_dims.height as f64 / initial_scale) as i32),
+            1.max((window_dims.width as f64 / initial_scale).round() as i32),
+            1.max((window_dims.height as f64 / initial_scale).round() as i32),
         );
-        let x = ((window_dims.x - parent_dims.x) as f64 / initial_scale) as i32;
-        let mut y = ((window_dims.y - parent_dims.y) as f64 / initial_scale) as i32;
+        let x = ((window_dims.x - parent_dims.x) as f64 / initial_scale).round() as i32;
+        let mut y = ((window_dims.y - parent_dims.y) as f64 / initial_scale).round() as i32;
         y -= decorations_height;
         positioner.set_offset(x, y);
         positioner.set_anchor(Anchor::TopLeft);
@@ -1957,6 +2080,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 configured: false,
                 pending: None,
             },
+            parent,
         }
     }
 }

--- a/src/server/selection.rs
+++ b/src/server/selection.rs
@@ -16,7 +16,10 @@ use smithay_client_toolkit::primary_selection::device::PrimarySelectionDevice;
 use smithay_client_toolkit::primary_selection::offer::PrimarySelectionOffer;
 use smithay_client_toolkit::primary_selection::selection::PrimarySelectionSource;
 use std::io::Read;
+use std::os::fd::AsFd;
 use std::rc::{Rc, Weak};
+
+pub const MAX_CLIPBOARD_SIZE: usize = 16 * 1024 * 1024;
 
 pub(super) struct SelectionStates<S: X11Selection> {
     clipboard: Option<SelectionState<S, Clipboard>>,
@@ -153,15 +156,68 @@ pub struct ForeignSelection<T: SelectionType> {
 
 #[allow(private_bounds)]
 impl<T: SelectionType> ForeignSelection<T> {
+    pub(crate) fn receive_async(&self, mime_type: String) -> std::io::Result<ReadPipe> {
+        let pipe = T::receive_offer(&self.inner, mime_type)?;
+        if let Err(e) = rustix::fs::fcntl_setfl(&pipe, rustix::fs::OFlags::NONBLOCK) {
+            warn!("Failed to set non-blocking mode on clipboard pipe: {:?}", e);
+        }
+        Ok(pipe)
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn receive(
         &self,
         mime_type: String,
         state: &ServerState<impl XConnection>,
     ) -> Vec<u8> {
         let mut pipe = T::receive_offer(&self.inner, mime_type).unwrap();
+        if let Err(e) = rustix::fs::fcntl_setfl(&pipe, rustix::fs::OFlags::NONBLOCK) {
+            warn!("Failed to set non-blocking mode on clipboard pipe: {:?}", e);
+        }
         state.queue.flush().unwrap();
         let mut data = Vec::new();
-        pipe.read_to_end(&mut data).unwrap();
+        // Sync read with timeout for tests
+        let timeout = rustix::event::Timespec {
+            tv_sec: 2,
+            tv_nsec: 0,
+        };
+        loop {
+            let ready = {
+                let borrowed_fd = pipe.as_fd();
+                let poll_fd =
+                    rustix::event::PollFd::new(&borrowed_fd, rustix::event::PollFlags::IN);
+                let mut fds = [poll_fd];
+                rustix::event::poll(&mut fds, Some(&timeout))
+            };
+            match ready {
+                Ok(0) => {
+                    warn!("Clipboard read timeout");
+                    break;
+                }
+                Ok(_) => {
+                    let mut buf = [0u8; 4096];
+                    match pipe.read(&mut buf) {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            data.extend_from_slice(&buf[..n]);
+                            if data.len() > MAX_CLIPBOARD_SIZE {
+                                warn!("Clipboard size exceeds 16MB limit, aborting transfer");
+                                return Vec::new();
+                            }
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                        Err(e) => {
+                            warn!("Clipboard read error: {e:?}");
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Clipboard poll error: {e:?}");
+                    break;
+                }
+            }
+        }
         data
     }
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -374,7 +374,7 @@ impl EarlyTestFixture {
         });
 
         let (fake_client, xwls_server) = UnixStream::pair().unwrap();
-        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server);
+        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server, false);
         let testwl = thread.join().unwrap();
 
         let xwls_connection = Connection::from_socket(fake_client).unwrap();
@@ -2557,7 +2557,7 @@ fn fractional_scale_small_popup() {
         .get_surface_data(popup_id)
         .expect("Missing popup data");
     let pos = &data.popup().positioner_state;
-    assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 1, y: 1 });
+    assert_eq!(pos.size.unwrap(), testwl::Vec2 { x: 2, y: 1 });
 }
 
 #[test]
@@ -2638,8 +2638,21 @@ fn toplevel_size_limits_scaled() {
 
     let data = f.testwl.get_surface_data(id).unwrap();
     let toplevel = data.toplevel();
-    assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
-    assert_eq!(toplevel.max_size, Some(testwl::Vec2 { x: 100, y: 125 }));
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        toplevel.min_size,
+        Some(testwl::Vec2 {
+            x: 20,
+            y: 20 + bar_h
+        })
+    );
+    assert_eq!(
+        toplevel.max_size,
+        Some(testwl::Vec2 {
+            x: 100,
+            y: 100 + bar_h
+        })
+    );
 
     // Try unsetting size hints one after another
     f.satellite.set_size_hints(
@@ -2655,7 +2668,14 @@ fn toplevel_size_limits_scaled() {
     f.run();
     let data = f.testwl.get_surface_data(id).unwrap();
     let toplevel = data.toplevel();
-    assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        toplevel.min_size,
+        Some(testwl::Vec2 {
+            x: 20,
+            y: 20 + bar_h
+        })
+    );
     assert_eq!(toplevel.max_size, None);
 
     f.satellite.set_size_hints(
@@ -2938,6 +2958,108 @@ fn quick_destroy_window_with_serial() {
 }
 
 #[test]
+fn rotated_compositor_scaling_pointer_lock_position_hint() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    f.satellite.compositor_scaling = true;
+
+    let pointer =
+        TestObject::<WlPointer>::from_request(&comp.seat.obj, wl_seat::Request::GetPointer {});
+    f.run();
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (surface, id) = f.create_toplevel(&comp, win);
+    f.testwl
+        .configure_toplevel(id, 2800, 4480, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity))
+        .unwrap();
+
+    {
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.rotated_90 = true;
+        drop(dims);
+
+        f.satellite
+            .inner
+            .world
+            .insert_one(
+                output_entity,
+                super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(
+                    1.75,
+                )),
+            )
+            .unwrap();
+    }
+
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 2800;
+        win_data.attrs.dims.height = 4480;
+    }
+
+    let locked_pointer = TestObject::<ZwpLockedPointerV1>::from_request(
+        &comp.pointer_constraints.obj,
+        zwp_pointer_constraints_v1::Request::LockPointer {
+            surface: surface.obj.clone(),
+            pointer: pointer.obj.clone(),
+            region: None,
+            lifetime: WEnum::Value(zwp_pointer_constraints_v1::Lifetime::Persistent),
+        },
+    );
+
+    locked_pointer.set_cursor_position_hint(52.5, 87.5);
+    f.run();
+    f.run();
+
+    let lock_data = f
+        .testwl
+        .locked_pointer()
+        .expect("Missing locked pointer data");
+    assert_eq!(lock_data.surface, id);
+    assert_eq!(
+        lock_data.cursor_hint,
+        Some(testwl::Vec2f { x: 30.0, y: 50.0 })
+    );
+}
+
+#[test]
 fn scaled_pointer_lock_position_hint() {
     let mut f = TestFixture::new_pre_connect(|testwl| {
         testwl.enable_fractional_scale();
@@ -3012,8 +3134,35 @@ fn disconnected_output_rescaling() {
     fractional.preferred_scale(180); // 1.5 scale
     f.testwl.move_surface_to_output(id, &output_ext);
     f.run();
-    // Multiple monitors with different scaling will select the lowest scale across monitors
+    // mixed-DPI setups used to pick the lowest monitor scale
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+
+    // testwl doesn't synthesize this leave when the surface moves
+    {
+        let surface_entity = f
+            .satellite
+            .world
+            .query::<&super::event::OnOutput>()
+            .iter()
+            .next()
+            .unwrap()
+            .0;
+        let output_main_entity = f
+            .satellite
+            .world
+            .query::<&super::event::OutputDimensions>()
+            .iter()
+            .find(|(_, dims)| dims.x == 0)
+            .unwrap()
+            .0;
+        if let Ok(mut entered) = f
+            .satellite
+            .world
+            .get::<&mut super::event::EnteredOutputs>(surface_entity)
+        {
+            entered.0.retain(|&e| e != output_main_entity);
+        }
+    }
 
     f.remove_output(output_ext);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3051,13 +3200,14 @@ fn client_side_decorations() {
     f.run();
 
     let data = f.connection().window(window);
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(
         data.dims,
         WindowDims {
             x: 0,
             y: 0,
             width: 100,
-            height: 75
+            height: 100 - bar_h as u16,
         }
     );
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
@@ -3067,7 +3217,8 @@ fn client_side_decorations() {
     let Some(SurfaceRole::Subsurface(subsurface)) = &data.role else {
         panic!("surface was not a subsurface: {:?}", data.role);
     };
-    assert_eq!(subsurface.position, testwl::Vec2 { x: 0, y: -25 });
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(subsurface.position, testwl::Vec2 { x: 0, y: -bar_h });
     assert_eq!(subsurface.parent, id);
     let subsurface = subsurface.subsurface.clone();
 
@@ -3152,7 +3303,9 @@ fn client_side_decorations_no_global() {
                 toplevel = Some(*id);
             }
             SurfaceRole::Subsurface(sub) => {
-                assert_eq!(sub.position, testwl::Vec2 { x: 0, y: -25 });
+                let bar_h =
+                    super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+                assert_eq!(sub.position, testwl::Vec2 { x: 0, y: -bar_h });
                 subsurface_parent = Some(sub.parent);
             }
             other => panic!("got surface with unexpected role: {other:?}"),
@@ -3173,13 +3326,14 @@ fn resize_decorations_on_reconfigure() {
     f.run();
 
     let data = f.connection().window(window);
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(
         data.dims,
         WindowDims {
             x: 0,
             y: 0,
             width: 100,
-            height: 75
+            height: 100 - bar_h as u16,
         }
     );
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
@@ -3188,7 +3342,7 @@ fn resize_decorations_on_reconfigure() {
     let buf_dims = f
         .testwl
         .get_buffer_dimensions(data.buffer.as_ref().expect("Missing buffer for subsurface"));
-    assert_eq!(buf_dims, testwl::Vec2 { x: 100, y: 25 });
+    assert_eq!(buf_dims, testwl::Vec2 { x: 100, y: bar_h });
     assert!(
         matches!(data.role, Some(SurfaceRole::Subsurface(_))),
         "surface was not a subsurface: {:?}",
@@ -3209,7 +3363,8 @@ fn resize_decorations_on_reconfigure() {
     let buf_dims = f
         .testwl
         .get_buffer_dimensions(data.buffer.as_ref().expect("Missing buffer for subsurface"));
-    assert_eq!(buf_dims, testwl::Vec2 { x: 200, y: 25 });
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(buf_dims, testwl::Vec2 { x: 200, y: bar_h });
 }
 
 #[test]
@@ -3230,3 +3385,1193 @@ fn decorations_with_title_on_thin_window() {
 /// See Pointer::handle_event for an explanation.
 #[test]
 fn popup_pointer_motion_workaround() {}
+
+#[test]
+fn test_recalculate_x11_output_positions_multi_scale() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 2560x1600 @ 1.75
+    // m2: 1920x1080 @ 1.0 at x=1463 (2560/1.75)
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    // m1 at 0,0
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // m2 sits flush after m1
+    // m1 x11 width: (1463 * 1.75).round() = 2560
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 2560);
+    assert_eq!(pos2.y, 0);
+}
+
+#[test]
+fn test_recalculate_x11_output_positions_rotated() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1 (rotated 90): 2560x1600 @ 1.75. logical width is physical height (1600)
+    // logical width: 1600/1.75 = 914
+    // m2: 1920x1080 @ 1.0 at x=914
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            rotated_90: true,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 914,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            rotated_90: false,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // m2 sits flush after m1
+    // logical width of m1: 1600/1.75 = 914
+    // m1 x11 width: (914 * 1.75).round() = 1600
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 1600);
+    assert_eq!(pos2.y, 0);
+}
+
+#[test]
+fn test_recalculate_x11_output_positions_2d_l_shape() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1 (scale 2.0): starts at (0, 0), logical size 960x540
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(2.0)),
+    ));
+
+    // m2 (scale 1.5): starts at (960, 0) (to the right of m1)
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 960,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.5)),
+    ));
+
+    // m3 (scale 1.0): starts at (0, 540) (below m1)
+    let m3 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 540,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 2.0);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // m2 is adjacent horizontally to m1
+    // relative offset = dx: 960. global_scale = 2.0.
+    // x = 0 + 960 * 2.0 = 1920.
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 1920);
+    assert_eq!(pos2.y, 0);
+
+    // m3 is adjacent vertically to m1
+    // relative offset = dy: 540. global_scale = 2.0.
+    // y = 0 + 540 * 2.0 = 1080.
+    let pos3 = world.get::<&X11OutputPosition>(m3).unwrap();
+    assert_eq!(pos3.x, 0);
+    assert_eq!(pos3.y, 1080);
+}
+
+#[test]
+fn test_window_offset_with_compositor_scaling() {
+    use super::event::{
+        OnOutput, OutputDimensions, OutputDimensionsSource, OutputScaleFactor,
+        TrueOutputScaleFactor, recalculate_x11_output_positions, update_window_output_offsets,
+    };
+    use crate::xstate::WindowDims;
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 2560x1600 @ 1.75
+    // m2: 1920x1080 @ 1.0 at x=1463
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let win_id = Window::new(123);
+    let mut win_data = super::WindowData::new(
+        false,
+        WindowDims {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 200,
+        },
+        None,
+    );
+    win_data.mapped = true;
+
+    let window_entity = world.spawn((win_id, win_data, OnOutput(m2)));
+
+    let mut conn = FakeXConnection::default();
+    conn.windows.insert(
+        win_id,
+        WindowData {
+            mapped: true,
+            fullscreen: false,
+            dims: WindowDims {
+                x: 100,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+        },
+    );
+
+    let global_offset = super::GlobalOutputOffset {
+        x: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+        y: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+    };
+
+    update_window_output_offsets(m2, &global_offset, &world, &mut conn);
+
+    // window offset should match m2 X11 pos (2560), not logical offset (1463)
+    let win_data = world.get::<&super::WindowData>(window_entity).unwrap();
+    assert_eq!(win_data.output_offset.x, 2560);
+    assert_eq!(win_data.output_offset.y, 0);
+}
+
+#[test]
+fn test_monitor_disconnect_scaling_fallback() {
+    use super::WindowOutputOffset;
+    use super::event::{
+        EnteredOutputs, OnOutput, OutputDimensions, OutputDimensionsSource, OutputScaleFactor,
+        SurfaceScaleFactor, TrueOutputScaleFactor, X11OutputPosition, update_output_scale,
+    };
+    use crate::xstate::WindowDims;
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 1.75 scale at (100, 200)
+    // m2: 1.0 scale (will be disconnected)
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 100,
+            y: 200,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(1.75),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(1.0),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    // window overlaps m1 and m2, initially outputs to m2
+    let window_entity = world.spawn((
+        Window::new(123),
+        super::WindowData::new(
+            false,
+            WindowDims {
+                x: 1500,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+            None,
+        ),
+        OnOutput(m2),
+        EnteredOutputs(vec![m1, m2]),
+        SurfaceScaleFactor(1.0),
+    ));
+
+    // simulate remove_output for m2
+    let mut updated_outputs = Vec::new();
+    let mut surfaces_to_update = Vec::new();
+
+    world
+        .remove::<(OutputScaleFactor, TrueOutputScaleFactor, OutputDimensions)>(m2)
+        .unwrap();
+
+    for (e, (on_out, mut entered)) in
+        world.query_mut::<(Option<&mut OnOutput>, Option<&mut EnteredOutputs>)>()
+    {
+        if let Some(ref mut entered) = entered {
+            entered.0.retain(|&out| out != m2);
+        }
+        if let Some(on_out) = on_out {
+            if on_out.0 == m2 {
+                let mut fallback = None;
+                if let Some(ref entered) = entered {
+                    if let Some(&next_out) = entered.0.first() {
+                        fallback = Some(next_out);
+                    }
+                }
+                if let Some(next_out) = fallback {
+                    *on_out = OnOutput(next_out);
+                    surfaces_to_update.push((e, next_out));
+                } else {
+                    surfaces_to_update.push((e, hecs::Entity::DANGLING));
+                }
+            }
+        }
+    }
+    for (e, next_out) in surfaces_to_update {
+        if next_out == hecs::Entity::DANGLING {
+            let _ = world.remove_one::<OnOutput>(e);
+        } else {
+            if let Ok(scale) = world.get::<&SurfaceScaleFactor>(e) {
+                let scale_val = scale.0;
+
+                let mut query = world
+                    .query_one::<(&Window, &mut super::WindowData)>(e)
+                    .unwrap();
+                if let Some((window, win_data)) = query.get() {
+                    if let Ok(dimensions) = world.get::<&OutputDimensions>(next_out) {
+                        let (ox, oy) = if let Ok(pos) = world.get::<&X11OutputPosition>(next_out) {
+                            (pos.x, pos.y)
+                        } else {
+                            (dimensions.x, dimensions.y)
+                        };
+                        let mut conn = FakeXConnection::default();
+                        conn.windows.insert(
+                            *window,
+                            WindowData {
+                                mapped: true,
+                                fullscreen: false,
+                                dims: WindowDims {
+                                    x: 1500,
+                                    y: 100,
+                                    width: 200,
+                                    height: 200,
+                                },
+                            },
+                        );
+                        win_data.update_output_offset(
+                            *window,
+                            WindowOutputOffset { x: ox, y: oy },
+                            &mut conn,
+                        );
+                    }
+                }
+                drop(query);
+
+                if let Ok(out_query) = world
+                    .query_one::<(&mut OutputScaleFactor, &mut TrueOutputScaleFactor)>(next_out)
+                {
+                    if update_output_scale(
+                        out_query,
+                        OutputScaleFactor::Fractional(scale_val),
+                        false,
+                        1.0,
+                    ) {
+                        updated_outputs.push(next_out);
+                    }
+                }
+            }
+        }
+    }
+
+    // 1. window switched to m1
+    let new_on_output = world.get::<&OnOutput>(window_entity).unwrap();
+    assert_eq!(new_on_output.0, m1);
+
+    // 2. EnteredOutputs only contains m1
+    let entered = world.get::<&EnteredOutputs>(window_entity).unwrap();
+    assert_eq!(entered.0, vec![m1]);
+
+    // 3. m1 scale updated to window scale (1.0) and added to updated_outputs
+    assert!(updated_outputs.contains(&m1));
+    let m1_scale = world.get::<&OutputScaleFactor>(m1).unwrap();
+    assert_eq!(m1_scale.get(), 1.0);
+
+    // 4. window offset updated to m1 coordinates (100, 200)
+    let win_data = world.get::<&super::WindowData>(window_entity).unwrap();
+    assert_eq!(win_data.output_offset.x, 100);
+    assert_eq!(win_data.output_offset.y, 200);
+}
+
+#[test]
+fn reconfigure_popup_with_decorations() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let toplevel = Window::new(1);
+    let (_, t_id) = f.create_toplevel(&comp, toplevel);
+
+    // Force client-side decorations
+    f.testwl
+        .force_decoration_mode(t_id, zxdg_toplevel_decoration_v1::Mode::ClientSide);
+    f.testwl
+        .configure_toplevel(t_id, 100, 100, vec![xdg_toplevel::State::Activated]);
+    f.run();
+
+    let popup = Window::new(2);
+    // Popup initially at x=20, y=40 relative to parent
+    let (_, p_id) = f.create_popup(
+        &comp,
+        PopupBuilder::new(popup, toplevel, t_id)
+            .x(20)
+            .y(40)
+            .check_size_and_pos(false),
+    );
+    f.satellite.set_transient_for(popup, toplevel);
+
+    // Offset should subtract titlebar height (40 - 25)
+    let surface_data = f.testwl.get_surface_data(p_id).unwrap();
+    let pos = &surface_data.popup().positioner_state;
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        pos.offset,
+        testwl::Vec2 {
+            x: 20,
+            y: 40 - bar_h
+        }
+    );
+
+    // Reconfigure popup to new absolute coordinates
+    // Offset should update to (30, 25) after titlebar deduction
+    let new_popup_dims = WindowDims {
+        x: 30,
+        y: 50,
+        width: 50,
+        height: 50,
+    };
+    f.reconfigure_window(popup, new_popup_dims, true);
+    f.run();
+
+    let surface_data2 = f.testwl.get_surface_data(p_id).unwrap();
+    let pos2 = &surface_data2.popup().positioner_state;
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        pos2.offset,
+        testwl::Vec2 {
+            x: 30,
+            y: 50 - bar_h
+        }
+    );
+}
+
+#[test]
+fn pointer_enter_coordinates_rotated_compositor_scaling() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    f.satellite.compositor_scaling = true;
+
+    let pointer =
+        TestObject::<WlPointer>::from_request(&comp.seat.obj, wl_seat::Request::GetPointer {});
+    f.run();
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+    f.testwl
+        .configure_toplevel(id, 2800, 4480, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity))
+        .unwrap();
+
+    {
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.rotated_90 = true;
+        drop(dims);
+
+        f.satellite
+            .inner
+            .world
+            .insert_one(
+                output_entity,
+                super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(
+                    1.75,
+                )),
+            )
+            .unwrap();
+    }
+
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 2800;
+        win_data.attrs.dims.height = 4480;
+    }
+
+    f.testwl.move_pointer_to(id, 20.0, 40.0);
+    f.run();
+    f.run();
+
+    let mut events = pointer.data.events.lock().unwrap();
+    let event = events
+        .drain(..)
+        .find(|event| {
+            matches!(
+                event,
+                wayland_client::protocol::wl_pointer::Event::Enter { .. }
+            )
+        })
+        .expect("missing pointer enter event");
+    let wayland_client::protocol::wl_pointer::Event::Enter {
+        surface_x,
+        surface_y,
+        ..
+    } = event
+    else {
+        unreachable!();
+    };
+
+    assert!((surface_x - 35.0).abs() < 1e-5);
+    assert!((surface_y - 70.0).abs() < 1e-5);
+
+    drop(events);
+    f.testwl.move_pointer_on_current_surface(30.0, 50.0);
+    f.run();
+    f.run();
+
+    let events = &mut pointer.data.events.lock().unwrap();
+    let event = events
+        .drain(..)
+        .find(|event| {
+            matches!(
+                event,
+                wayland_client::protocol::wl_pointer::Event::Motion { .. }
+            )
+        })
+        .expect("missing pointer motion event");
+    let wayland_client::protocol::wl_pointer::Event::Motion {
+        surface_x,
+        surface_y,
+        ..
+    } = event
+    else {
+        unreachable!();
+    };
+
+    assert!((surface_x - 52.5).abs() < 1e-5);
+    assert!((surface_y - 87.5).abs() < 1e-5);
+}
+
+#[test]
+fn test_get_surface_input_scales_rotated_compositor_scaling() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+
+    f.satellite.compositor_scaling = true;
+
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+
+    f.testwl
+        .configure_toplevel(id, 2800, 4480, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity))
+        .unwrap();
+
+    // Modify the output's dimensions to be rotated 90 degrees and set scale factor
+    {
+        f.satellite
+            .inner
+            .world
+            .insert_one(
+                output_entity,
+                super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(
+                    1.75,
+                )),
+            )
+            .unwrap();
+
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.rotated_90 = true;
+    }
+
+    // rotated output + fractional scale is where the width/height swap bites
+    // since rotated 90, physical width is height, height is width
+    // logical width = 1600, X11 width = 1600 * 1.75 = 2800
+    // logical height = 2560, X11 height = 2560 * 1.75 = 4480
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 2800;
+        win_data.attrs.dims.height = 4480;
+    }
+
+    let (scale_x, scale_y) =
+        super::event::get_surface_input_scales(&f.satellite.inner.world, window_entity);
+
+    // It should be exactly 1.75 (2800 / 1600 = 1.75, 4480 / 2560 = 1.75)
+    assert!((scale_x - 1.75).abs() < 1e-5);
+    assert!((scale_y - 1.75).abs() < 1e-5);
+}
+
+#[test]
+fn test_get_surface_input_scales_fullscreen_logical_size() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    f.satellite.compositor_scaling = true;
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+    f.testwl
+        .configure_toplevel(id, 2561, 1601, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity))
+        .unwrap();
+
+    {
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.logical_width = Some(1463);
+        dims.logical_height = Some(915);
+    }
+
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 2561;
+        win_data.attrs.dims.height = 1601;
+    }
+
+    let (scale_x, scale_y) =
+        super::event::get_surface_input_scales(&f.satellite.inner.world, window_entity);
+
+    assert!((scale_x - 2561.0 / 1463.0).abs() < 1e-5);
+    assert!((scale_y - 1601.0 / 915.0).abs() < 1e-5);
+}
+
+#[test]
+fn test_recalculate_x11_output_positions_negative_dx_dy() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1 (scale 1.5): starts at logical (0, 0), so it is the root node
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.5)),
+    ));
+
+    // m2 (scale 2.0): starts at logical (-960, 0) (to the left of m1)
+    // dx = -960. Under global_scale = 2.0, x = 0 + -960 * 2.0 = -1920.
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: -960,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(2.0)),
+    ));
+
+    // m3 (scale 1.0): starts at logical (0, -540) (above m1)
+    // dy = -540. Under global_scale = 2.0, y = 0 + -540 * 2.0 = -1080.
+    let m3 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: -540,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 2.0);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, -1920);
+    assert_eq!(pos2.y, 0);
+
+    let pos3 = world.get::<&X11OutputPosition>(m3).unwrap();
+    assert_eq!(pos3.x, 0);
+    assert_eq!(pos3.y, -1080);
+}
+
+#[test]
+fn test_update_all_window_offsets() {
+    use super::event::{
+        OnOutput, OutputDimensions, OutputDimensionsSource, OutputScaleFactor,
+        TrueOutputScaleFactor, recalculate_x11_output_positions, update_window_output_offsets,
+    };
+    use crate::xstate::WindowDims;
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 2560x1600 @ 1.75
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    // m2: 1920x1080 @ 1.0 at x=1463
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let win_id1 = Window::new(123);
+    let mut win_data1 = super::WindowData::new(
+        false,
+        WindowDims {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 200,
+        },
+        None,
+    );
+    win_data1.mapped = true;
+    let window_entity1 = world.spawn((win_id1, win_data1, OnOutput(m1)));
+
+    let win_id2 = Window::new(456);
+    let mut win_data2 = super::WindowData::new(
+        false,
+        WindowDims {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 200,
+        },
+        None,
+    );
+    win_data2.mapped = true;
+    let window_entity2 = world.spawn((win_id2, win_data2, OnOutput(m2)));
+
+    let mut conn = FakeXConnection::default();
+    conn.windows.insert(
+        win_id1,
+        WindowData {
+            mapped: true,
+            fullscreen: false,
+            dims: WindowDims {
+                x: 100,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+        },
+    );
+    conn.windows.insert(
+        win_id2,
+        WindowData {
+            mapped: true,
+            fullscreen: false,
+            dims: WindowDims {
+                x: 100,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+        },
+    );
+
+    let mut global_offset = super::GlobalOutputOffset {
+        x: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+        y: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+    };
+
+    // Initial updates to synchronize window offsets
+    update_window_output_offsets(m1, &global_offset, &world, &mut conn);
+    update_window_output_offsets(m2, &global_offset, &world, &mut conn);
+
+    assert_eq!(
+        world
+            .get::<&super::WindowData>(window_entity1)
+            .unwrap()
+            .output_offset
+            .x,
+        0
+    );
+    assert_eq!(
+        world
+            .get::<&super::WindowData>(window_entity2)
+            .unwrap()
+            .output_offset
+            .x,
+        2560
+    );
+
+    // Now m1 changes position (moves to logical x=1000)
+    {
+        let mut dims = world.get::<&mut OutputDimensions>(m1).unwrap();
+        dims.x = 1000;
+        global_offset.x.value = 1000;
+        global_offset.x.owner = Some(m1);
+    }
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    // Simulate update_output_offset behavior (iterates over all outputs)
+    let outputs: Vec<hecs::Entity> = world
+        .query::<&OutputDimensions>()
+        .iter()
+        .map(|(e, _)| e)
+        .collect();
+    for out in outputs {
+        update_window_output_offsets(out, &global_offset, &world, &mut conn);
+    }
+
+    // Both window offsets must be updated.
+    // m1 is now root since it is leftmost (1000 < 1463), so rx = 0.
+    // m2 is adjacent to m1 with dx = 1463 - 1000 = 463.
+    // rx = 0 + 463 * 1.75 = 810.
+    let win_data1 = world.get::<&super::WindowData>(window_entity1).unwrap();
+    let win_data2 = world.get::<&super::WindowData>(window_entity2).unwrap();
+    assert_eq!(win_data1.output_offset.x, 0);
+    assert_eq!(win_data2.output_offset.x, 810);
+}
+
+#[test]
+fn test_guess_initial_scale_on_output() {
+    use super::event::{self, OutputDimensions, OutputScaleFactor};
+    use hecs::World;
+
+    let mut world = World::new();
+    let _output = world.spawn((
+        OutputDimensions {
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            logical_width: Some(1463),
+            logical_height: Some(915),
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(1.75),
+    ));
+
+    let scale = event::guess_initial_scale(
+        &world,
+        WindowDims {
+            x: 100,
+            y: 100,
+            width: 800,
+            height: 600,
+        },
+        1.0,
+        false,
+    );
+    assert_eq!(scale, 1.75);
+}
+
+#[test]
+fn test_guess_initial_scale_with_compositor_scaling() {
+    use super::X11OutputPosition;
+    use super::event::{self, OutputDimensions, OutputScaleFactor, TrueOutputScaleFactor};
+    use hecs::World;
+
+    let mut world = World::new();
+    world.spawn((
+        OutputDimensions {
+            x: -100,
+            y: 0,
+            width: 200,
+            height: 200,
+            logical_width: Some(100),
+            logical_height: Some(100),
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(2.0),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(2.0)),
+        X11OutputPosition { x: -200, y: 0 },
+    ));
+    world.spawn((
+        OutputDimensions {
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 100,
+            logical_width: Some(100),
+            logical_height: Some(100),
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(2.0),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+        X11OutputPosition { x: 0, y: 0 },
+    ));
+
+    let scale = event::guess_initial_scale(
+        &world,
+        WindowDims {
+            x: 20,
+            y: 20,
+            width: 50,
+            height: 50,
+        },
+        2.0,
+        true,
+    );
+    assert_eq!(scale, 1.0);
+}
+
+#[test]
+fn test_get_surface_input_scales_fullscreen_unconfigured_initial_fallback() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    f.satellite.compositor_scaling = true;
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+    f.testwl
+        .configure_toplevel(id, 1462, 914, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    // Set output logical dims to 1462x914, physical to 2560x1600, and surface scale to 1.75
+    {
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.logical_width = Some(1462);
+        dims.logical_height = Some(914);
+    }
+    let _ = f
+        .satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::SurfaceScaleFactor(1.75));
+    let _ = f
+        .satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity));
+
+    // Simulate initial launch where X11 window dims are unconfigured (e.g. 1920x1080)
+    // while expected physical dims would be 1462 * 1.75 = 2558x1599.
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 1920;
+        win_data.attrs.dims.height = 1080;
+    }
+
+    // Must fallback to surface scale (1.75, 1.75) instead of corrupted (1920/1462 = 1.313)
+    let (scale_x, scale_y) =
+        super::event::get_surface_input_scales(&f.satellite.inner.world, window_entity);
+    assert!((scale_x - 1.75).abs() < 1e-5);
+    assert!((scale_y - 1.75).abs() < 1e-5);
+}
+
+#[test]
+fn test_base_scale_override() {
+    let mut f = TestFixture::new();
+    f.satellite.compositor_scaling = true;
+
+    let output_entity = f.satellite.inner.world.spawn((
+        super::event::OutputDimensions {
+            source: super::event::OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(2.0)),
+    ));
+
+    // Verify global_scale is pinned to 1.0 despite 2.0x output
+    f.satellite.set_base_scale(Some(1.0));
+    assert_eq!(f.satellite.inner.base_scale, Some(1.0));
+
+    // Verify invalid values are rejected and ignored
+    f.satellite.set_base_scale(Some(10.0));
+    assert_eq!(f.satellite.inner.base_scale, Some(1.0));
+
+    // Verify input scaling stays at 1.0 when SurfaceScaleFactor is 1.0 on a 2.0x output
+    let window_entity = f.satellite.inner.world.spawn((
+        super::SurfaceScaleFactor(1.0),
+        super::event::OnOutput(output_entity),
+    ));
+    let (scale_x, scale_y) =
+        super::event::get_surface_input_scales(&f.satellite.inner.world, window_entity);
+    assert_eq!(scale_x, 1.0);
+    assert_eq!(scale_y, 1.0);
+}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -19,6 +19,7 @@ use wayland_client::{
         wl_keyboard::WlKeyboard,
         wl_output::{self, WlOutput},
         wl_pointer::WlPointer,
+        wl_region::WlRegion,
         wl_registry::WlRegistry,
         wl_seat::{self, WlSeat},
         wl_shm::{Format, WlShm},
@@ -149,12 +150,20 @@ impl Compositor {
 
         (buffer, surface)
     }
+
+    fn create_region(&self) -> TestObject<WlRegion> {
+        TestObject::<WlRegion>::from_request(
+            &self.compositor.obj,
+            Req::<WlCompositor>::CreateRegion {},
+        )
+    }
 }
 
 #[derive(Debug, Default)]
 struct WindowData {
     mapped: bool,
     fullscreen: bool,
+    maximized: bool,
     dims: WindowDims,
 }
 #[derive(Default)]
@@ -214,6 +223,11 @@ impl super::XConnection for FakeXConnection {
     }
 
     #[track_caller]
+    fn set_maximized(&mut self, window: xcb::x::Window, maximized: bool) {
+        self.window_mut(window).maximized = maximized;
+    }
+
+    #[track_caller]
     fn set_window_dims(&mut self, window: Window, state: super::PendingSurfaceState) -> bool {
         self.window_mut(window).dims = WindowDims {
             x: state.x as _,
@@ -227,6 +241,15 @@ impl super::XConnection for FakeXConnection {
 
     #[track_caller]
     fn focus_window(&mut self, window: Window, _output_name: Option<String>) {
+        assert!(
+            self.windows.contains_key(&window),
+            "Unknown window: {window:?}"
+        );
+        self.focused_window = window.into();
+    }
+
+    #[track_caller]
+    fn focus_popup(&mut self, window: Window) {
         assert!(
             self.windows.contains_key(&window),
             "Unknown window: {window:?}"
@@ -707,6 +730,7 @@ impl TestFixture<FakeXConnection> {
                 height: 50,
             },
             fullscreen: false,
+            maximized: false,
         };
 
         self.new_window(window, false, data);
@@ -782,6 +806,7 @@ impl TestFixture<FakeXConnection> {
             mapped: true,
             dims,
             fullscreen: false,
+            maximized: false,
         };
         self.new_window(window, true, data);
         self.map_window(comp, window, &surface.obj, &buffer);
@@ -902,6 +927,7 @@ impl TestFixture<FakeXConnection> {
     }
 
     fn reconfigure_window(&mut self, window: Window, dims: WindowDims, override_redirect: bool) {
+        self.satellite.connection.window_mut(window).dims = dims;
         self.satellite
             .reconfigure_window(x::ConfigureNotifyEvent::new(
                 window,
@@ -1332,6 +1358,7 @@ fn window_group_properties() {
             ..Default::default()
         },
         fullscreen: false,
+        maximized: false,
     };
 
     let (_, surface) = comp.create_surface();
@@ -1371,6 +1398,7 @@ fn splash_window_fixed_size() {
         mapped: false,
         dims,
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(splash, false, data);
     f.satellite
@@ -1684,6 +1712,7 @@ fn popup_focus_on_map_with_input_hint() {
         mapped: true,
         dims,
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(win_popup, true, data);
     f.satellite.set_win_hints(
@@ -1725,6 +1754,7 @@ fn popup_no_focus_input_hint_wm_take_focus() {
         mapped: true,
         dims,
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(win_popup, true, data);
     f.satellite.set_win_hints(
@@ -2162,6 +2192,7 @@ fn reconfigure_popup_after_map() {
         mapped: true,
         dims: old_dims,
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(popup, true, popup_data);
     f.satellite.map_window(popup);
@@ -2390,6 +2421,7 @@ fn fullscreen_heuristic() {
                 height: 1000,
             },
             fullscreen: false,
+            maximized: false,
         };
         f.new_window(window, override_redirect, data);
         f.map_window(&comp, window, &surface.obj, &buffer);
@@ -2613,6 +2645,7 @@ fn toplevel_size_limits_scaled() {
             ..Default::default()
         },
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(window, false, data);
     f.satellite.set_size_hints(
@@ -2779,6 +2812,7 @@ fn transient_for_toplevel() {
                 ..Default::default()
             },
             fullscreen: false,
+            maximized: false,
         },
     );
 
@@ -2955,6 +2989,7 @@ fn quick_destroy_window_with_serial() {
             height: 50,
         },
         fullscreen: false,
+        maximized: false,
     };
     f.new_window(window, false, data);
     f.satellite.map_window(window);
@@ -3134,7 +3169,7 @@ fn client_side_decorations() {
     let viewport = data.viewport.as_ref().unwrap();
     let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 100 - bar_h as i32);
+    assert_eq!(viewport.height, 100 - bar_h);
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
@@ -3196,6 +3231,7 @@ fn client_side_decorations_no_global() {
             height: 50,
         },
         fullscreen: false,
+        maximized: false,
     };
 
     f.new_window(window, false, data);
@@ -3243,7 +3279,7 @@ fn resize_decorations_on_reconfigure() {
     let viewport = data.viewport.as_ref().unwrap();
     let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 100 - bar_h as i32);
+    assert_eq!(viewport.height, 100 - bar_h);
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
@@ -3264,7 +3300,7 @@ fn resize_decorations_on_reconfigure() {
     let data = f.testwl.get_surface_data(id).unwrap();
     let viewport = data.viewport.as_ref().unwrap();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 100 - bar_h as i32);
+    assert_eq!(viewport.height, 100 - bar_h);
 
     let dims = WindowDims {
         x: 0,
@@ -3563,6 +3599,7 @@ fn test_window_offset_with_compositor_scaling() {
         WindowData {
             mapped: true,
             fullscreen: false,
+            maximized: false,
             dims: WindowDims {
                 x: 100,
                 y: 100,
@@ -3702,6 +3739,7 @@ fn test_monitor_disconnect_scaling_fallback() {
                             WindowData {
                                 mapped: true,
                                 fullscreen: false,
+                                maximized: false,
                                 dims: WindowDims {
                                     x: 1500,
                                     y: 100,
@@ -3930,4 +3968,308 @@ fn test_base_scale_override() {
     unsafe {
         std::env::remove_var("XWAYLAND_SATELLITE_BASE_SCALE");
     }
+}
+
+#[test]
+fn maximized() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+
+    f.satellite.set_maximized(win, SetState::Add);
+    f.run();
+    f.run();
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        data.toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+
+    f.satellite.set_maximized(win, SetState::Remove);
+    f.run();
+    f.run();
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        !data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+
+    f.satellite.set_maximized(win, SetState::Toggle);
+    f.run();
+    f.run();
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        data.toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+
+    f.satellite.set_maximized(win, SetState::Toggle);
+    f.run();
+    f.run();
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        !data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+
+    f.testwl
+        .configure_toplevel(id, 800, 600, vec![xdg_toplevel::State::Maximized]);
+    f.run();
+    f.run();
+    assert!(f.satellite.connection.windows[&win].maximized);
+
+    f.testwl.configure_toplevel(id, 800, 600, vec![]);
+    f.run();
+    f.run();
+    assert!(!f.satellite.connection.windows[&win].maximized);
+}
+
+#[test]
+fn maximized_pre_mapping() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(2);
+
+    let data = WindowData {
+        mapped: true,
+        dims: WindowDims {
+            x: 0,
+            y: 0,
+            width: 50,
+            height: 50,
+        },
+        fullscreen: false,
+        maximized: false,
+    };
+    f.new_window(win, false, data);
+
+    // Set maximized before mapping
+    f.satellite.set_maximized(win, SetState::Add);
+
+    let (buffer, surface) = comp.create_surface();
+    f.map_window(&comp, win, &surface.obj, &buffer);
+    f.run();
+    f.run();
+
+    let id = f.check_new_surface();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        data.toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+}
+
+#[test]
+fn input_region_scaling() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(1);
+    let (surface, id) = f.create_toplevel(&comp, win);
+
+    let surface_entity = f.satellite.windows[&win];
+    f.satellite
+        .world
+        .get::<&mut super::event::SurfaceScaleFactor>(surface_entity)
+        .unwrap()
+        .0 = 2.0;
+
+    let region = comp.create_region();
+    region
+        .send_request(Req::<WlRegion>::Add {
+            x: 20,
+            y: 40,
+            width: 200,
+            height: 100,
+        })
+        .unwrap();
+
+    surface
+        .send_request(Req::<WlSurface>::SetInputRegion {
+            region: Some(region.obj.clone()),
+        })
+        .unwrap();
+    surface.send_request(Req::<WlSurface>::Commit {}).unwrap();
+
+    f.run();
+    f.run();
+
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    // Scale 2.0 downsamples [20, 40, 200, 100] to [10, 20, 100, 50]
+    assert_eq!(
+        surface_data.input_region,
+        Some(vec![(10, 20, 100, 50)])
+    );
+
+    surface
+        .send_request(Req::<WlSurface>::SetInputRegion { region: None })
+        .unwrap();
+    surface.send_request(Req::<WlSurface>::Commit {}).unwrap();
+
+    f.run();
+    f.run();
+
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    assert_eq!(surface_data.input_region, None);
+}
+
+#[test]
+fn input_region_complex_polygon_and_negative_coords() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(1);
+    let (surface, id) = f.create_toplevel(&comp, win);
+
+    let surface_entity = f.satellite.windows[&win];
+    f.satellite
+        .world
+        .get::<&mut super::event::SurfaceScaleFactor>(surface_entity)
+        .unwrap()
+        .0 = 1.5;
+
+    let region = comp.create_region();
+    region
+        .send_request(Req::<WlRegion>::Add {
+            x: -60,
+            y: -30,
+            width: 60,
+            height: 30,
+        })
+        .unwrap();
+    region
+        .send_request(Req::<WlRegion>::Add {
+            x: 0,
+            y: -30,
+            width: 60,
+            height: 30,
+        })
+        .unwrap();
+    region
+        .send_request(Req::<WlRegion>::Add {
+            x: 60,
+            y: -30,
+            width: 60,
+            height: 30,
+        })
+        .unwrap();
+    region
+        .send_request(Req::<WlRegion>::Subtract {
+            x: 10,
+            y: -20,
+            width: 20,
+            height: 10,
+        })
+        .unwrap();
+
+    surface
+        .send_request(Req::<WlSurface>::SetInputRegion {
+            region: Some(region.obj.clone()),
+        })
+        .unwrap();
+    surface.send_request(Req::<WlSurface>::Commit {}).unwrap();
+
+    f.run();
+    f.run();
+
+    let surface_data = f.testwl.get_surface_data(id).unwrap();
+    let rects = surface_data.input_region.as_ref().unwrap();
+    assert_eq!(rects.len(), 3);
+
+    assert_eq!(rects[0].0 + rects[0].2, rects[1].0);
+    assert_eq!(rects[1].0 + rects[1].2, rects[2].0);
+
+    assert_eq!(rects[0], (-40, -20, 40, 20));
+    assert_eq!(rects[1], (0, -20, 40, 20));
+    assert_eq!(rects[2], (40, -20, 40, 20));
+}
+
+#[test]
+fn maximized_rapid_toggles_and_idempotence() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+
+    for _ in 0..5 {
+        f.satellite.set_maximized(win, SetState::Add);
+    }
+    f.run();
+    f.run();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert_eq!(
+        data.toplevel()
+            .states
+            .iter()
+            .filter(|&&s| s == xdg_toplevel::State::Maximized)
+            .count(),
+        1
+    );
+
+    for i in 0..4 {
+        f.satellite.set_maximized(win, SetState::Toggle);
+        f.run();
+        f.run();
+        let data = f.testwl.get_surface_data(id).unwrap();
+        let is_max = data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized);
+        assert_eq!(is_max, i % 2 == 1);
+    }
+
+    for _ in 0..5 {
+        f.satellite.set_maximized(win, SetState::Remove);
+    }
+    f.run();
+    f.run();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert!(
+        !data
+            .toplevel()
+            .states
+            .contains(&xdg_toplevel::State::Maximized)
+    );
+}
+
+#[test]
+fn surface_destroy_with_active_input_region() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let win = Window::new(1);
+    let (surface, id) = f.create_toplevel(&comp, win);
+
+    for i in 1..=5 {
+        let region = comp.create_region();
+        region
+            .send_request(Req::<WlRegion>::Add {
+                x: i * 10,
+                y: i * 10,
+                width: 100,
+                height: 100,
+            })
+            .unwrap();
+        surface
+            .send_request(Req::<WlSurface>::SetInputRegion {
+                region: Some(region.obj),
+            })
+            .unwrap();
+        surface.send_request(Req::<WlSurface>::Commit {}).unwrap();
+        f.run();
+    }
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    assert_eq!(data.input_region, Some(vec![(50, 50, 100, 100)]));
+
+    f.satellite.unmap_window(win);
+    f.satellite.destroy_window(win);
+    surface.obj.destroy();
+    f.run();
+    f.run();
+
+    assert!(f.testwl.get_surface_data(id).is_none());
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -374,7 +374,7 @@ impl EarlyTestFixture {
         });
 
         let (fake_client, xwls_server) = UnixStream::pair().unwrap();
-        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server);
+        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server, false);
         let testwl = thread.join().unwrap();
 
         let xwls_connection = Connection::from_socket(fake_client).unwrap();
@@ -741,7 +741,7 @@ impl TestFixture<FakeXConnection> {
             assert!(surface_data.buffer.is_some());
         }
 
-        let scale = self.satellite.current_scale;
+        let scale = self.satellite.global_scale;
         let expected_width = (100.0 * scale) as u16;
         let expected_height = (100.0 * scale) as u16;
 
@@ -2671,8 +2671,21 @@ fn toplevel_size_limits_scaled() {
 
     let data = f.testwl.get_surface_data(id).unwrap();
     let toplevel = data.toplevel();
-    assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
-    assert_eq!(toplevel.max_size, Some(testwl::Vec2 { x: 100, y: 125 }));
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        toplevel.min_size,
+        Some(testwl::Vec2 {
+            x: 20,
+            y: 20 + bar_h
+        })
+    );
+    assert_eq!(
+        toplevel.max_size,
+        Some(testwl::Vec2 {
+            x: 100,
+            y: 100 + bar_h
+        })
+    );
 
     // Try unsetting size hints one after another
     f.satellite.set_size_hints(
@@ -2688,7 +2701,14 @@ fn toplevel_size_limits_scaled() {
     f.run();
     let data = f.testwl.get_surface_data(id).unwrap();
     let toplevel = data.toplevel();
-    assert_eq!(toplevel.min_size, Some(testwl::Vec2 { x: 20, y: 45 }));
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        toplevel.min_size,
+        Some(testwl::Vec2 {
+            x: 20,
+            y: 20 + bar_h
+        })
+    );
     assert_eq!(toplevel.max_size, None);
 
     f.satellite.set_size_hints(
@@ -3045,8 +3065,35 @@ fn disconnected_output_rescaling() {
     fractional.preferred_scale(180); // 1.5 scale
     f.testwl.move_surface_to_output(id, &output_ext);
     f.run();
-    // Multiple monitors with different scaling will select the lowest scale across monitors
+    // Mixed-DPI setups pick the lowest scale across monitors
     assert_eq!(f.satellite.inner.new_scale, Some(1.5));
+
+    // testwl does not auto-leave output on surface move
+    {
+        let surface_entity = f
+            .satellite
+            .world
+            .query::<&super::event::OnOutput>()
+            .iter()
+            .next()
+            .unwrap()
+            .0;
+        let output_main_entity = f
+            .satellite
+            .world
+            .query::<&super::event::OutputDimensions>()
+            .iter()
+            .find(|(_, dims)| dims.x == 0)
+            .unwrap()
+            .0;
+        if let Ok(mut entered) = f
+            .satellite
+            .world
+            .get::<&mut super::event::EnteredOutputs>(surface_entity)
+        {
+            entered.0.retain(|&e| e != output_main_entity);
+        }
+    }
 
     f.remove_output(output_ext);
     let surface_data = f.testwl.get_surface_data(id).expect("No surface data");
@@ -3085,9 +3132,9 @@ fn client_side_decorations() {
 
     let data = f.testwl.get_surface_data(id).unwrap();
     let viewport = data.viewport.as_ref().unwrap();
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 75);
-
+    assert_eq!(viewport.height, 100 - bar_h as i32);
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
@@ -3095,7 +3142,8 @@ fn client_side_decorations() {
     let Some(SurfaceRole::Subsurface(subsurface)) = &data.role else {
         panic!("surface was not a subsurface: {:?}", data.role);
     };
-    assert_eq!(subsurface.position, testwl::Vec2 { x: 0, y: -25 });
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(subsurface.position, testwl::Vec2 { x: 0, y: -bar_h });
     assert_eq!(subsurface.parent, id);
     let subsurface = subsurface.subsurface.clone();
 
@@ -3169,7 +3217,9 @@ fn client_side_decorations_no_global() {
                 toplevel = Some(*id);
             }
             SurfaceRole::Subsurface(sub) => {
-                assert_eq!(sub.position, testwl::Vec2 { x: 0, y: -25 });
+                let bar_h =
+                    super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+                assert_eq!(sub.position, testwl::Vec2 { x: 0, y: -bar_h });
                 subsurface_parent = Some(sub.parent);
             }
             other => panic!("got surface with unexpected role: {other:?}"),
@@ -3191,16 +3241,16 @@ fn resize_decorations_on_reconfigure() {
 
     let data = f.testwl.get_surface_data(id).unwrap();
     let viewport = data.viewport.as_ref().unwrap();
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 75);
-
+    assert_eq!(viewport.height, 100 - bar_h as i32);
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
     let buf_dims = f
         .testwl
         .get_buffer_dimensions(data.buffer.as_ref().expect("Missing buffer for subsurface"));
-    assert_eq!(buf_dims, testwl::Vec2 { x: 100, y: 25 });
+    assert_eq!(buf_dims, testwl::Vec2 { x: 100, y: bar_h });
     assert!(
         matches!(data.role, Some(SurfaceRole::Subsurface(_))),
         "surface was not a subsurface: {:?}",
@@ -3214,7 +3264,7 @@ fn resize_decorations_on_reconfigure() {
     let data = f.testwl.get_surface_data(id).unwrap();
     let viewport = data.viewport.as_ref().unwrap();
     assert_eq!(viewport.width, 100);
-    assert_eq!(viewport.height, 75);
+    assert_eq!(viewport.height, 100 - bar_h as i32);
 
     let dims = WindowDims {
         x: 0,
@@ -3230,7 +3280,8 @@ fn resize_decorations_on_reconfigure() {
     let buf_dims = f
         .testwl
         .get_buffer_dimensions(data.buffer.as_ref().expect("Missing buffer for subsurface"));
-    assert_eq!(buf_dims, testwl::Vec2 { x: 200, y: 25 });
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(buf_dims, testwl::Vec2 { x: 200, y: bar_h });
 }
 
 #[test]
@@ -3286,3 +3337,597 @@ fn decorations_max_height_int_max() {
 /// See Pointer::handle_event for an explanation.
 #[test]
 fn popup_pointer_motion_workaround() {}
+
+#[test]
+fn test_recalculate_x11_output_positions_multi_scale() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 2560x1600 @ 1.75
+    // m2: 1920x1080 @ 1.0 at x=1463 (2560/1.75)
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // 1463 * 1.75 = 2560
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 2560);
+    assert_eq!(pos2.y, 0);
+}
+
+#[test]
+fn test_recalculate_x11_output_positions_rotated() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1 (rotated 90): 2560x1600 @ 1.75. logical width is physical height (1600)
+    // logical width: 1600/1.75 = 914
+    // m2: 1920x1080 @ 1.0 at x=914
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            rotated_90: true,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 914,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            rotated_90: false,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // 914 * 1.75 = 1600
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 1600);
+    assert_eq!(pos2.y, 0);
+}
+
+#[test]
+fn test_recalculate_x11_output_positions_2d_l_shape() {
+    use super::event::{
+        OutputDimensions, OutputDimensionsSource, OutputScaleFactor, TrueOutputScaleFactor,
+        X11OutputPosition, recalculate_x11_output_positions,
+    };
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1 (scale 2.0): starts at (0, 0), logical size 960x540
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(2.0)),
+    ));
+
+    // m2 (scale 1.5): starts at (960, 0) (to the right of m1)
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 960,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.5)),
+    ));
+
+    // m3 (scale 1.0): starts at (0, 540) (below m1)
+    let m3 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 540,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 2.0);
+
+    let pos1 = world.get::<&X11OutputPosition>(m1).unwrap();
+    assert_eq!(pos1.x, 0);
+    assert_eq!(pos1.y, 0);
+
+    // 960 * 2.0 = 1920
+    let pos2 = world.get::<&X11OutputPosition>(m2).unwrap();
+    assert_eq!(pos2.x, 1920);
+    assert_eq!(pos2.y, 0);
+
+    // 540 * 2.0 = 1080
+    let pos3 = world.get::<&X11OutputPosition>(m3).unwrap();
+    assert_eq!(pos3.x, 0);
+    assert_eq!(pos3.y, 1080);
+}
+
+#[test]
+fn test_window_offset_with_compositor_scaling() {
+    use super::event::{
+        OnOutput, OutputDimensions, OutputDimensionsSource, OutputScaleFactor,
+        TrueOutputScaleFactor, recalculate_x11_output_positions, update_window_output_offsets,
+    };
+    use crate::xstate::WindowDims;
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 2560x1600 @ 1.75
+    // m2: 1920x1080 @ 1.0 at x=1463
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 0,
+            y: 0,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    recalculate_x11_output_positions(&mut world, true, 1.75);
+
+    let win_id = Window::new(123);
+    let mut win_data = super::WindowData::new(
+        false,
+        WindowDims {
+            x: 100,
+            y: 100,
+            width: 200,
+            height: 200,
+        },
+        None,
+    );
+    win_data.mapped = true;
+
+    let window_entity = world.spawn((win_id, win_data, OnOutput(m2)));
+
+    let mut conn = FakeXConnection::default();
+    conn.windows.insert(
+        win_id,
+        WindowData {
+            mapped: true,
+            fullscreen: false,
+            dims: WindowDims {
+                x: 100,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+        },
+    );
+
+    let global_offset = super::GlobalOutputOffset {
+        x: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+        y: super::GlobalOutputOffsetDimension {
+            owner: Some(m1),
+            value: 0,
+        },
+    };
+
+    update_window_output_offsets(m2, &global_offset, &world, &mut conn);
+
+    // Window offset matches X11 output position (2560), not logical offset (1463)
+    let win_data = world.get::<&super::WindowData>(window_entity).unwrap();
+    assert_eq!(win_data.output_offset.x, 2560);
+    assert_eq!(win_data.output_offset.y, 0);
+}
+
+#[test]
+fn test_monitor_disconnect_scaling_fallback() {
+    use super::WindowOutputOffset;
+    use super::event::{
+        EnteredOutputs, OnOutput, OutputDimensions, OutputDimensionsSource, OutputScaleFactor,
+        SurfaceScaleFactor, TrueOutputScaleFactor, X11OutputPosition, update_output_scale,
+    };
+    use crate::xstate::WindowDims;
+    use hecs::World;
+
+    let mut world = World::new();
+
+    // m1: 1.75 scale at (100, 200)
+    // m2: 1.0 scale (will be disconnected)
+    let m1 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 100,
+            y: 200,
+            width: 2560,
+            height: 1600,
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(1.75),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.75)),
+    ));
+
+    let m2 = world.spawn((
+        OutputDimensions {
+            source: OutputDimensionsSource::Xdg,
+            x: 1463,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            ..Default::default()
+        },
+        OutputScaleFactor::Fractional(1.0),
+        TrueOutputScaleFactor(OutputScaleFactor::Fractional(1.0)),
+    ));
+
+    // Window overlaps m1 and m2, assigned to m2
+    let window_entity = world.spawn((
+        Window::new(123),
+        super::WindowData::new(
+            false,
+            WindowDims {
+                x: 1500,
+                y: 100,
+                width: 200,
+                height: 200,
+            },
+            None,
+        ),
+        OnOutput(m2),
+        EnteredOutputs(vec![m1, m2]),
+        SurfaceScaleFactor(1.0),
+    ));
+
+    let mut updated_outputs = Vec::new();
+    let mut surfaces_to_update = Vec::new();
+
+    world
+        .remove::<(OutputScaleFactor, TrueOutputScaleFactor, OutputDimensions)>(m2)
+        .unwrap();
+
+    for (e, (on_out, mut entered)) in
+        world.query_mut::<(Option<&mut OnOutput>, Option<&mut EnteredOutputs>)>()
+    {
+        if let Some(ref mut entered) = entered {
+            entered.0.retain(|&out| out != m2);
+        }
+        if let Some(on_out) = on_out {
+            if on_out.0 == m2 {
+                let mut fallback = None;
+                if let Some(ref entered) = entered {
+                    if let Some(&next_out) = entered.0.first() {
+                        fallback = Some(next_out);
+                    }
+                }
+                if let Some(next_out) = fallback {
+                    *on_out = OnOutput(next_out);
+                    surfaces_to_update.push((e, next_out));
+                } else {
+                    surfaces_to_update.push((e, hecs::Entity::DANGLING));
+                }
+            }
+        }
+    }
+    for (e, next_out) in surfaces_to_update {
+        if next_out == hecs::Entity::DANGLING {
+            let _ = world.remove_one::<OnOutput>(e);
+        } else {
+            if let Ok(scale) = world.get::<&SurfaceScaleFactor>(e) {
+                let scale_val = scale.0;
+
+                let mut query = world
+                    .query_one::<(&Window, &mut super::WindowData)>(e)
+                    .unwrap();
+                if let Some((window, win_data)) = query.get() {
+                    if let Ok(dimensions) = world.get::<&OutputDimensions>(next_out) {
+                        let (ox, oy) = if let Ok(pos) = world.get::<&X11OutputPosition>(next_out) {
+                            (pos.x, pos.y)
+                        } else {
+                            (dimensions.x, dimensions.y)
+                        };
+                        let mut conn = FakeXConnection::default();
+                        conn.windows.insert(
+                            *window,
+                            WindowData {
+                                mapped: true,
+                                fullscreen: false,
+                                dims: WindowDims {
+                                    x: 1500,
+                                    y: 100,
+                                    width: 200,
+                                    height: 200,
+                                },
+                            },
+                        );
+                        win_data.update_output_offset(
+                            *window,
+                            WindowOutputOffset { x: ox, y: oy },
+                            &mut conn,
+                        );
+                    }
+                }
+                drop(query);
+
+                if let Ok(out_query) = world
+                    .query_one::<(&mut OutputScaleFactor, &mut TrueOutputScaleFactor)>(next_out)
+                {
+                    if update_output_scale(
+                        out_query,
+                        OutputScaleFactor::Fractional(scale_val),
+                        false,
+                        1.0,
+                    ) {
+                        updated_outputs.push(next_out);
+                    }
+                }
+            }
+        }
+    }
+
+    let new_on_output = world.get::<&OnOutput>(window_entity).unwrap();
+    assert_eq!(new_on_output.0, m1);
+
+    let entered = world.get::<&EnteredOutputs>(window_entity).unwrap();
+    assert_eq!(entered.0, vec![m1]);
+
+    assert!(updated_outputs.contains(&m1));
+    let m1_scale = world.get::<&OutputScaleFactor>(m1).unwrap();
+    assert_eq!(m1_scale.get(), 1.0);
+
+    let win_data = world.get::<&super::WindowData>(window_entity).unwrap();
+    assert_eq!(win_data.output_offset.x, 100);
+    assert_eq!(win_data.output_offset.y, 200);
+}
+
+#[test]
+fn reconfigure_popup_with_decorations() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+    let toplevel = Window::new(1);
+    let (_, t_id) = f.create_toplevel(&comp, toplevel);
+
+    f.testwl
+        .force_decoration_mode(t_id, zxdg_toplevel_decoration_v1::Mode::ClientSide);
+    f.testwl
+        .configure_toplevel(t_id, 100, 100, vec![xdg_toplevel::State::Activated]);
+    f.run();
+
+    let popup = Window::new(2);
+    let (_, p_id) = f.create_popup(
+        &comp,
+        PopupBuilder::new(popup, toplevel, t_id)
+            .x(20)
+            .y(40)
+            .check_size_and_pos(false),
+    );
+    f.satellite.set_transient_for(popup, toplevel);
+
+    let surface_data = f.testwl.get_surface_data(p_id).unwrap();
+    let pos = &surface_data.popup().positioner_state;
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        pos.offset,
+        testwl::Vec2 {
+            x: 20,
+            y: 40 - bar_h
+        }
+    );
+
+    let new_popup_dims = WindowDims {
+        x: 30,
+        y: 50,
+        width: 50,
+        height: 50,
+    };
+    f.reconfigure_window(popup, new_popup_dims, true);
+    f.run();
+
+    let surface_data2 = f.testwl.get_surface_data(p_id).unwrap();
+    let pos2 = &surface_data2.popup().positioner_state;
+    let bar_h = super::decoration::DecorationsDataSatellite::calculate_titlebar_height();
+    assert_eq!(
+        pos2.offset,
+        testwl::Vec2 {
+            x: 30,
+            y: 50 - bar_h
+        }
+    );
+}
+
+#[test]
+fn test_get_surface_input_scales_rotated_compositor_scaling() {
+    let (mut f, comp) = TestFixture::new_with_compositor();
+
+    f.satellite.compositor_scaling = true;
+
+    let (_, _) = f.new_output(0, 0);
+
+    let win = Window::new(1);
+    let (_, id) = f.create_toplevel(&comp, win);
+
+    f.testwl
+        .configure_toplevel(id, 2800, 4480, vec![xdg_toplevel::State::Fullscreen]);
+    f.run();
+
+    let window_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&Window>()
+        .iter()
+        .find(|(_, w)| **w == win)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .find(|(_, dims)| dims.x == 0 && dims.y == 0)
+        .map(|(e, _)| e)
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(window_entity, super::event::OnOutput(output_entity))
+        .unwrap();
+
+    {
+        f.satellite
+            .inner
+            .world
+            .insert_one(
+                output_entity,
+                super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(
+                    1.75,
+                )),
+            )
+            .unwrap();
+
+        let mut dims = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::event::OutputDimensions>(output_entity)
+            .unwrap();
+        dims.width = 2560;
+        dims.height = 1600;
+        dims.rotated_90 = true;
+    }
+
+    // When rotated 90, physical width becomes height
+    {
+        let mut win_data = f
+            .satellite
+            .inner
+            .world
+            .get::<&mut super::WindowData>(window_entity)
+            .unwrap();
+        win_data.attrs.dims.width = 2800;
+        win_data.attrs.dims.height = 4480;
+    }
+
+    let (scale_x, scale_y) =
+        super::event::get_surface_input_scales(&f.satellite.inner.world, window_entity);
+
+    assert!((scale_x - 1.75).abs() < 1e-5);
+    assert!((scale_y - 1.75).abs() < 1e-5);
+}
+
+#[test]
+fn test_base_scale_override() {
+    let (mut f, _comp) = TestFixture::new_with_compositor();
+    f.satellite.compositor_scaling = true;
+
+    // set base scale to 1.0
+    unsafe {
+        std::env::set_var("XWAYLAND_SATELLITE_BASE_SCALE", "1.0");
+    }
+
+    let (_, _) = f.new_output(0, 0);
+
+    let output_entity = f
+        .satellite
+        .inner
+        .world
+        .query::<&super::event::OutputDimensions>()
+        .iter()
+        .map(|(e, _)| e)
+        .next()
+        .unwrap();
+
+    f.satellite
+        .inner
+        .world
+        .insert_one(
+            output_entity,
+            super::event::TrueOutputScaleFactor(super::event::OutputScaleFactor::Fractional(
+                1.75,
+            )),
+        )
+        .unwrap();
+
+    f.satellite.inner.updated_outputs.push(output_entity);
+    f.satellite.update_compositor_scaling_state();
+
+    // assert 1.0 overrides 1.75
+    assert_eq!(f.satellite.inner.global_scale, 1.0);
+
+    // reset env
+    unsafe {
+        std::env::remove_var("XWAYLAND_SATELLITE_BASE_SCALE");
+    }
+}

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -234,6 +234,7 @@ impl XState {
         };
         r.create_ewmh_window();
         r.set_xsettings_owner();
+        r.update_global_scale(1.0);
         r
     }
 

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -294,6 +294,8 @@ impl XState {
                 self.atoms.motif_wm_hints,
                 self.atoms.net_wm_state,
                 self.atoms.wm_fullscreen,
+                self.atoms.wm_maximized_vert,
+                self.atoms.wm_maximized_horz,
                 self.atoms.moveresize,
             ],
         );
@@ -416,15 +418,17 @@ impl XState {
                         self.handle_window_properties(server_state, e.window())
                     );
                     server_state.map_window(e.window());
-                    unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
-                        &x::ChangeProperty {
-                            mode: x::PropMode::Replace,
-                            window: e.window(),
-                            property: self.atoms.wm_state,
-                            r#type: self.atoms.wm_state,
-                            data: &[WmState::Normal as u32, x::Window::none().resource_id()],
-                        }
-                    ));
+                    if !e.override_redirect() {
+                        unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
+                            &x::ChangeProperty {
+                                mode: x::PropMode::Replace,
+                                window: e.window(),
+                                property: self.atoms.wm_state,
+                                r#type: self.atoms.wm_state,
+                                data: &[WmState::Normal as u32, x::Window::none().resource_id()],
+                            }
+                        ));
+                    }
                 }
                 xcb::Event::X(x::Event::ConfigureNotify(e)) => {
                     server_state.reconfigure_window(e);
@@ -448,22 +452,24 @@ impl XState {
                         server_state.connection.focus_window(restore_to, None);
                     }
 
-                    unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
-                        &x::ChangeWindowAttributes {
-                            window: e.window(),
-                            value_list: &[x::Cw::EventMask(x::EventMask::empty())],
-                        }
-                    ));
+                    if !server_state.is_override_redirect(e.window()) {
+                        unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
+                            &x::ChangeWindowAttributes {
+                                window: e.window(),
+                                value_list: &[x::Cw::EventMask(x::EventMask::empty())],
+                            }
+                        ));
 
-                    unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
-                        &x::ChangeProperty {
-                            mode: x::PropMode::Replace,
-                            window: e.window(),
-                            property: self.atoms.wm_state,
-                            r#type: self.atoms.wm_state,
-                            data: &[WmState::Withdrawn as u32, x::Window::none().resource_id()],
-                        }
-                    ));
+                        unwrap_or_skip_bad_window_cont!(self.connection.send_and_check_request(
+                            &x::ChangeProperty {
+                                mode: x::PropMode::Replace,
+                                window: e.window(),
+                                property: self.atoms.wm_state,
+                                r#type: self.atoms.wm_state,
+                                data: &[WmState::Withdrawn as u32, x::Window::none().resource_id()],
+                            }
+                        ));
+                    }
                 }
                 xcb::Event::X(x::Event::DestroyNotify(e)) => {
                     debug!("destroying window {:?}", e.window());
@@ -552,17 +558,21 @@ impl XState {
 
                 trace!("_NET_WM_STATE ({action:?}) props: {prop1:?} {prop2:?}");
 
-                for prop in [prop1, prop2] {
-                    match prop {
-                        x if x == self.atoms.wm_fullscreen => {
-                            server_state.set_fullscreen(e.window(), action);
-                        }
-                        _ => {}
-                    }
+                let is_maximized = |atom: x::Atom| {
+                    atom == self.atoms.wm_maximized_vert || atom == self.atoms.wm_maximized_horz
+                };
+                if is_maximized(prop1) || is_maximized(prop2) {
+                    server_state.set_maximized(e.window(), action);
+                }
+                if prop1 == self.atoms.wm_fullscreen || prop2 == self.atoms.wm_fullscreen {
+                    server_state.set_fullscreen(e.window(), action);
                 }
             }
             x if x == self.atoms.active_win => {
-                server_state.activate_window(e.window());
+                let win = e.window();
+                if win != self.root && win != x::WINDOW_NONE {
+                    server_state.activate_window(win);
+                }
             }
             x if x == self.atoms.moveresize => {
                 let x::ClientMessageData::Data32(data) = e.data() else {
@@ -653,12 +663,32 @@ impl XState {
             server_state.set_win_hints(window, hints);
         }
 
+        if let Ok(Some(states)) = self.get_net_wm_state(window) {
+            if states.contains(&self.atoms.wm_maximized_vert)
+                || states.contains(&self.atoms.wm_maximized_horz)
+            {
+                server_state.set_win_maximized(window, true);
+            }
+            if states.contains(&self.atoms.wm_fullscreen) {
+                server_state.set_win_fullscreen(window, true);
+            }
+        }
+
         let transient_for = self.get_transient_for(window)?;
         let override_redirect = self.get_override_redirect(window)?;
 
         let window_types = self
             .get_net_wm_window_types(window)?
             .unwrap_or_else(Vec::new);
+
+        let is_menu = window_types.iter().any(|&atom| {
+            atom == self.window_atoms.dropdown_menu
+                || atom == self.window_atoms.popup_menu
+                || atom == self.window_atoms.menu
+                || atom == self.window_atoms.tooltip
+                || atom == self.window_atoms.combo
+        });
+        server_state.set_win_is_menu(window, is_menu);
 
         let heuristics = WindowRoleHeuristics {
             override_redirect,
@@ -756,6 +786,12 @@ impl XState {
 
     fn get_protocols(&self, window: x::Window) -> XResult<Option<Vec<x::Atom>>> {
         let cookie = self.get_property_cookie(window, self.atoms.wm_protocols, x::ATOM_ATOM, 10);
+        let resolver = |reply: x::GetPropertyReply| reply.value::<x::Atom>().to_vec();
+        PropertyCookieWrapper::new(&self.connection, cookie).resolve(resolver)
+    }
+
+    fn get_net_wm_state(&self, window: x::Window) -> XResult<Option<Vec<x::Atom>>> {
+        let cookie = self.get_property_cookie(window, self.atoms.net_wm_state, x::ATOM_ATOM, 1024);
         let resolver = |reply: x::GetPropertyReply| reply.value::<x::Atom>().to_vec();
         PropertyCookieWrapper::new(&self.connection, cookie).resolve(resolver)
     }
@@ -875,6 +911,15 @@ impl XState {
                     server_state.set_win_decorations(window, decorations);
                 }
             }
+            x if x == self.atoms.net_wm_state => {
+                if let Ok(Some(states)) = self.get_net_wm_state(window) {
+                    let maximized = states.contains(&self.atoms.wm_maximized_vert)
+                        || states.contains(&self.atoms.wm_maximized_horz);
+                    let fullscreen = states.contains(&self.atoms.wm_fullscreen);
+                    server_state.set_win_maximized(window, maximized);
+                    server_state.set_win_fullscreen(window, fullscreen);
+                }
+            }
             _ => {
                 if log::log_enabled!(log::Level::Debug) {
                     debug!(
@@ -905,6 +950,8 @@ xcb::atoms_struct! {
         wm_pid => b"_NET_WM_PID" only_if_exists = false,
         net_wm_state => b"_NET_WM_STATE" only_if_exists = false,
         wm_fullscreen => b"_NET_WM_STATE_FULLSCREEN" only_if_exists = false,
+        wm_maximized_vert => b"_NET_WM_STATE_MAXIMIZED_VERT" only_if_exists = false,
+        wm_maximized_horz => b"_NET_WM_STATE_MAXIMIZED_HORZ" only_if_exists = false,
         active_win => b"_NET_ACTIVE_WINDOW" only_if_exists = false,
         client_list => b"_NET_CLIENT_LIST" only_if_exists = false,
         supported => b"_NET_SUPPORTED" only_if_exists = false,
@@ -1192,6 +1239,13 @@ impl WindowRoleHeuristics {
             match ty {
                 x if x == window_atoms.normal => return WindowRole::Toplevel,
                 x if x == window_atoms.dialog => {
+                    let is_steam = self
+                        .wm_class
+                        .as_deref()
+                        .is_some_and(|c| c == "steam" || c == "steamwebhelper");
+                    if is_steam {
+                        return WindowRole::Toplevel;
+                    }
                     return WindowRole::new_basic(
                         self.has_transient_for && motif_no_decor && forced_size,
                     );
@@ -1242,6 +1296,16 @@ pub enum SetState {
     Remove,
     Add,
     Toggle,
+}
+
+impl SetState {
+    pub fn apply(self, current: bool) -> bool {
+        match self {
+            Self::Remove => false,
+            Self::Add => true,
+            Self::Toggle => !current,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, num_enum::TryFromPrimitive)]
@@ -1329,6 +1393,48 @@ impl RealConnection {
     fn root_window(&self) -> x::Window {
         self.connection.get_setup().roots().next().unwrap().root()
     }
+
+    fn get_net_wm_state(&self, window: x::Window) -> XResult<Option<Vec<x::Atom>>> {
+        let cookie = self.connection.send_request(&x::GetProperty {
+            delete: false,
+            window,
+            property: self.atoms.net_wm_state,
+            r#type: x::ATOM_ATOM,
+            long_offset: 0,
+            long_length: 1024,
+        });
+        let reply = self.connection.wait_for_reply(cookie)?;
+        Ok(Some(reply.value::<x::Atom>().to_vec()))
+    }
+
+    fn update_net_wm_state(&mut self, window: x::Window, add: &[x::Atom], remove: &[x::Atom]) {
+        let current_state = self
+            .get_net_wm_state(window)
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        let mut new_state: Vec<x::Atom> = current_state
+            .into_iter()
+            .filter(|atom| !remove.contains(atom))
+            .collect();
+        for atom in add {
+            if !new_state.contains(atom) {
+                new_state.push(*atom);
+            }
+        }
+        if let Err(e) = self
+            .connection
+            .send_and_check_request(&x::ChangeProperty::<x::Atom> {
+                mode: x::PropMode::Replace,
+                window,
+                property: self.atoms.net_wm_state,
+                r#type: x::ATOM_ATOM,
+                data: &new_state,
+            })
+        {
+            warn!("Failed to update _NET_WM_STATE on {window:?} ({e})");
+        }
+    }
 }
 
 impl XConnection for RealConnection {
@@ -1355,23 +1461,19 @@ impl XConnection for RealConnection {
     }
 
     fn set_fullscreen(&mut self, window: x::Window, fullscreen: bool) {
-        let data = if fullscreen {
-            std::slice::from_ref(&self.atoms.wm_fullscreen)
+        if fullscreen {
+            self.update_net_wm_state(window, &[self.atoms.wm_fullscreen], &[]);
         } else {
-            &[]
-        };
+            self.update_net_wm_state(window, &[], &[self.atoms.wm_fullscreen]);
+        }
+    }
 
-        if let Err(e) = self
-            .connection
-            .send_and_check_request(&x::ChangeProperty::<x::Atom> {
-                mode: x::PropMode::Replace,
-                window,
-                property: self.atoms.net_wm_state,
-                r#type: x::ATOM_ATOM,
-                data,
-            })
-        {
-            warn!("Failed to set fullscreen state on {window:?} ({e})");
+    fn set_maximized(&mut self, window: x::Window, maximized: bool) {
+        let max_atoms = [self.atoms.wm_maximized_vert, self.atoms.wm_maximized_horz];
+        if maximized {
+            self.update_net_wm_state(window, &max_atoms, &[]);
+        } else {
+            self.update_net_wm_state(window, &[], &max_atoms);
         }
     }
 
@@ -1394,14 +1496,16 @@ impl XConnection for RealConnection {
         }) {
             debug!("ChangeProperty failed ({window:?}: {e:?})");
         }
-        if let Err(e) = self.connection.send_and_check_request(&x::ChangeProperty {
-            mode: x::PropMode::Replace,
-            window,
-            property: self.atoms.wm_state,
-            r#type: self.atoms.wm_state,
-            data: &[WmState::Normal as u32, 0],
-        }) {
-            debug!("ChangeProperty failed ({window:?}: {e:?})");
+        if window != x::WINDOW_NONE {
+            if let Err(e) = self.connection.send_and_check_request(&x::ChangeProperty {
+                mode: x::PropMode::Replace,
+                window,
+                property: self.atoms.wm_state,
+                r#type: self.atoms.wm_state,
+                data: &[WmState::Normal as u32, 0],
+            }) {
+                debug!("ChangeProperty failed ({window:?}: {e:?})");
+            }
         }
 
         if let Some(name) = output_name {
@@ -1414,9 +1518,18 @@ impl XConnection for RealConnection {
                 return;
             }
 
+            let primary_window = if window != x::WINDOW_NONE {
+                window
+            } else {
+                self.root_window()
+            };
+
             if let Err(e) = self
                 .connection
-                .send_and_check_request(&xcb::randr::SetOutputPrimary { window, output })
+                .send_and_check_request(&xcb::randr::SetOutputPrimary {
+                    window: primary_window,
+                    output,
+                })
             {
                 warn!("Couldn't set output {name} as primary: {e:?}");
             } else {
@@ -1431,6 +1544,17 @@ impl XConnection for RealConnection {
                     output: Xid::none(),
                 });
             self.primary_output = Xid::none();
+        }
+    }
+
+    fn focus_popup(&mut self, window: x::Window) {
+        trace!("{window:?} (popup focus)");
+        if let Err(e) = self.connection.send_and_check_request(&x::SetInputFocus {
+            focus: window,
+            revert_to: x::InputFocus::None,
+            time: x::CURRENT_TIME,
+        }) {
+            debug!("SetInputFocus failed ({window:?}: {e:?})");
         }
     }
 

--- a/src/xstate/selection.rs
+++ b/src/xstate/selection.rs
@@ -1,12 +1,15 @@
 use super::{XState, get_atom_name};
-use crate::server::selection::{Clipboard, ForeignSelection, Primary, SelectionType};
+use crate::server::selection::{
+    Clipboard, ForeignSelection, MAX_CLIPBOARD_SIZE, Primary, SelectionType,
+};
 use crate::{RealServerState, X11Selection};
 use log::{debug, error, warn};
 use rustix::event::{PollFd, PollFlags, poll};
-use smithay_client_toolkit::data_device_manager::WritePipe;
+use smithay_client_toolkit::data_device_manager::{ReadPipe, WritePipe};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::io::{Error, ErrorKind, Result, Write};
+use std::os::fd::AsFd;
 use std::rc::Rc;
 use xcb::x;
 
@@ -224,12 +227,12 @@ impl Selection {
 }
 
 pub struct WaylandIncrInfo {
-    data: Vec<u8>,
-    start: usize,
-    property: x::Atom,
-    target_window: x::Window,
-    target_type: x::Atom,
-    max_req_bytes: usize,
+    pub(crate) data: Vec<u8>,
+    pub(crate) start: usize,
+    pub(crate) property: x::Atom,
+    pub(crate) target_window: x::Window,
+    pub(crate) target_type: x::Atom,
+    pub(crate) max_req_bytes: usize,
 }
 
 pub struct WaylandSelection<T: SelectionType> {
@@ -297,6 +300,24 @@ struct SelectionData<T: SelectionType> {
     current_selection: Option<CurrentSelection<T>>,
 }
 
+pub(super) enum RequestResult {
+    Success,
+    Refuse,
+    Async(ReadPipe),
+}
+
+pub(crate) struct PendingTransfer {
+    pub(crate) pipe: ReadPipe,
+    pub(crate) data: Vec<u8>,
+    pub(crate) requestor: x::Window,
+    pub(crate) property: x::Atom,
+    pub(crate) target: x::Atom,
+    pub(crate) selection: x::Atom,
+    pub(crate) time: x::Timestamp,
+    pub(crate) max_req_bytes: usize,
+    pub(crate) expires_at: std::time::Instant,
+}
+
 // This is a trait so that we can use &dyn
 trait SelectionDataImpl {
     fn set_owner(&self, connection: &xcb::Connection, wm_window: x::Window) -> bool;
@@ -323,11 +344,12 @@ trait SelectionDataImpl {
         connection: &xcb::Connection,
         atoms: &super::Atoms,
         request: &x::SelectionRequestEvent,
-        max_req_bytes: usize,
-        server_state: &mut RealServerState,
-    ) -> bool;
+        _max_req_bytes: usize,
+        _server_state: &mut RealServerState,
+    ) -> RequestResult;
     fn atom(&self) -> x::Atom;
     fn selection_clear(&mut self);
+    fn start_incr(&mut self, incr_info: WaylandIncrInfo);
 }
 
 impl<T: SelectionType> SelectionData<T> {
@@ -350,6 +372,11 @@ impl<T: SelectionType> SelectionData<T> {
 impl<T: SelectionType> SelectionDataImpl for SelectionData<T> {
     fn atom(&self) -> x::Atom {
         self.atom
+    }
+    fn start_incr(&mut self, incr_info: WaylandIncrInfo) {
+        if let Some(wayland_sel) = self.wayland_selection_mut() {
+            wayland_sel.incr_data = Some(incr_info);
+        }
     }
     fn set_owner(&self, connection: &xcb::Connection, wm_window: x::Window) -> bool {
         if let Err(e) = connection.send_and_check_request(&x::SetSelectionOwner {
@@ -526,17 +553,17 @@ impl<T: SelectionType> SelectionDataImpl for SelectionData<T> {
         connection: &xcb::Connection,
         atoms: &super::Atoms,
         request: &x::SelectionRequestEvent,
-        max_req_bytes: usize,
-        server_state: &mut RealServerState,
-    ) -> bool {
+        _max_req_bytes: usize,
+        _server_state: &mut RealServerState,
+    ) -> RequestResult {
         let Some(CurrentSelection::Wayland(WaylandSelection {
             mimes,
             inner,
-            incr_data,
+            incr_data: _,
         })) = &mut self.current_selection
         else {
             warn!("Got selection request, but we don't seem to be the selection owner");
-            return false;
+            return RequestResult::Refuse;
         };
 
         let req_target = request.target();
@@ -550,10 +577,10 @@ impl<T: SelectionType> SelectionDataImpl for SelectionData<T> {
                 r#type: x::ATOM_ATOM,
                 data: &atoms,
             }) {
-                Ok(_) => true,
+                Ok(_) => RequestResult::Success,
                 Err(e) => {
                     warn!("Failed to set targets for selection request: {e:?}");
-                    false
+                    RequestResult::Refuse
                 }
             }
         } else {
@@ -564,7 +591,7 @@ impl<T: SelectionType> SelectionDataImpl for SelectionData<T> {
                         "refusing selection request because given atom could not be found ({name})"
                     );
                 }
-                return false;
+                return RequestResult::Refuse;
             };
 
             let mime_name = target
@@ -572,51 +599,11 @@ impl<T: SelectionType> SelectionDataImpl for SelectionData<T> {
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| target.name.clone());
-            let data = inner.receive(mime_name, server_state);
-            if data.len() > max_req_bytes {
-                if let Err(e) = connection.send_and_check_request(&x::ChangeWindowAttributes {
-                    window: request.requestor(),
-                    value_list: &[x::Cw::EventMask(x::EventMask::PROPERTY_CHANGE)],
-                }) {
-                    warn!("Failed to set up property change notifications: {e:?}");
-                    return false;
-                }
-                if let Err(e) = connection.send_and_check_request(&x::ChangeProperty {
-                    mode: x::PropMode::Replace,
-                    window: request.requestor(),
-                    property: request.property(),
-                    r#type: atoms.incr,
-                    data: &[data.len() as u32],
-                }) {
-                    warn!("Failed to set incr property for large transfer: {e:?}");
-                    return false;
-                }
-                debug!(
-                    "beginning incr for {}",
-                    get_atom_name(connection, target.target)
-                );
-                *incr_data = Some(WaylandIncrInfo {
-                    data,
-                    start: 0,
-                    target_window: request.requestor(),
-                    property: request.property(),
-                    target_type: target.target,
-                    max_req_bytes,
-                });
-                true
-            } else {
-                match connection.send_and_check_request(&x::ChangeProperty {
-                    mode: x::PropMode::Replace,
-                    window: request.requestor(),
-                    property: request.property(),
-                    r#type: target.target,
-                    data: &data,
-                }) {
-                    Ok(_) => true,
-                    Err(e) => {
-                        warn!("Failed setting selection property: {e:?}");
-                        false
-                    }
+            match inner.receive_async(mime_name) {
+                Ok(pipe) => RequestResult::Async(pipe),
+                Err(e) => {
+                    warn!("Failed to receive selection from Wayland: {e:?}");
+                    RequestResult::Refuse
                 }
             }
         }
@@ -627,6 +614,7 @@ pub(super) struct SelectionState {
     clipboard: SelectionData<Clipboard>,
     primary: SelectionData<Primary>,
     target_window: x::Window,
+    pub(crate) pending_transfers: Vec<PendingTransfer>,
 }
 
 impl SelectionState {
@@ -652,6 +640,7 @@ impl SelectionState {
             target_window,
             clipboard: SelectionData::new(atoms.clipboard, atoms.clipboard_targets),
             primary: SelectionData::new(atoms.primary, atoms.primary_targets),
+            pending_transfers: Vec::new(),
         }
     }
 }
@@ -887,16 +876,36 @@ impl XState {
                     return true;
                 }
 
-                if data.handle_selection_request(
+                match data.handle_selection_request(
                     &self.connection,
                     &self.atoms,
                     e,
                     self.max_req_bytes,
                     server_state,
                 ) {
-                    success()
-                } else {
-                    refuse()
+                    RequestResult::Success => success(),
+                    RequestResult::Refuse => refuse(),
+                    RequestResult::Async(pipe) => {
+                        // New request supersedes any pending transfer for same target
+                        self.selection_state.pending_transfers.retain(|t| {
+                            !(t.requestor == e.requestor() && t.property == e.property())
+                        });
+
+                        self.selection_state
+                            .pending_transfers
+                            .push(PendingTransfer {
+                                pipe,
+                                data: Vec::new(),
+                                requestor: e.requestor(),
+                                property: e.property(),
+                                target: e.target(),
+                                selection: e.selection(),
+                                time: e.time(),
+                                max_req_bytes: self.max_req_bytes,
+                                expires_at: std::time::Instant::now()
+                                    + std::time::Duration::from_secs(2),
+                            });
+                    }
                 }
             }
 
@@ -969,5 +978,187 @@ impl XState {
         }
         inner(&self.connection, event, &mut self.selection_state.primary)
             || inner(&self.connection, event, &mut self.selection_state.clipboard)
+    }
+
+    fn send_selection_notify(
+        connection: &xcb::Connection,
+        transfer: &PendingTransfer,
+        property: x::Atom,
+    ) {
+        if let Err(e) = connection.send_and_check_request(&x::SendEvent {
+            propagate: false,
+            destination: x::SendEventDest::Window(transfer.requestor),
+            event_mask: x::EventMask::empty(),
+            event: &x::SelectionNotifyEvent::new(
+                transfer.time,
+                transfer.requestor,
+                transfer.selection,
+                transfer.target,
+                property,
+            ),
+        }) {
+            warn!("Failed to send selection request notify: {e:?}");
+        }
+    }
+
+    fn complete_transfer(&mut self, mut transfer: PendingTransfer) {
+        let data_len = transfer.data.len();
+        let data = std::mem::take(&mut transfer.data);
+
+        if data_len > transfer.max_req_bytes {
+            if let Err(e) = self
+                .connection
+                .send_and_check_request(&x::ChangeWindowAttributes {
+                    window: transfer.requestor,
+                    value_list: &[x::Cw::EventMask(x::EventMask::PROPERTY_CHANGE)],
+                })
+            {
+                warn!("Failed to set up property change notifications: {e:?}");
+                Self::send_selection_notify(&self.connection, &transfer, x::ATOM_NONE);
+            } else if let Err(e) = self.connection.send_and_check_request(&x::ChangeProperty {
+                mode: x::PropMode::Replace,
+                window: transfer.requestor,
+                property: transfer.property,
+                r#type: self.atoms.incr,
+                data: &[data_len as u32],
+            }) {
+                warn!("Failed to set incr property for large transfer: {e:?}");
+                Self::send_selection_notify(&self.connection, &transfer, x::ATOM_NONE);
+            } else {
+                debug!(
+                    "beginning incr for {}",
+                    get_atom_name(&self.connection, transfer.target)
+                );
+                let is_clipboard = transfer.selection == self.atoms.clipboard;
+                let sel_data = if is_clipboard {
+                    &mut self.selection_state.clipboard as &mut dyn SelectionDataImpl
+                } else {
+                    &mut self.selection_state.primary as &mut dyn SelectionDataImpl
+                };
+                sel_data.start_incr(WaylandIncrInfo {
+                    data,
+                    start: 0,
+                    target_window: transfer.requestor,
+                    property: transfer.property,
+                    target_type: transfer.target,
+                    max_req_bytes: transfer.max_req_bytes,
+                });
+                Self::send_selection_notify(&self.connection, &transfer, transfer.property);
+            }
+        } else {
+            match self.connection.send_and_check_request(&x::ChangeProperty {
+                mode: x::PropMode::Replace,
+                window: transfer.requestor,
+                property: transfer.property,
+                r#type: transfer.target,
+                data: &data,
+            }) {
+                Ok(_) => {
+                    Self::send_selection_notify(&self.connection, &transfer, transfer.property);
+                }
+                Err(e) => {
+                    warn!("Failed setting selection property: {e:?}");
+                    Self::send_selection_notify(&self.connection, &transfer, x::ATOM_NONE);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn process_pending_clipboard_transfers(&mut self, events: &[PollFlags]) {
+        let mut pending = std::mem::take(&mut self.selection_state.pending_transfers);
+        let pending_len = pending.len();
+        let mut i = 0;
+        let mut orig_i = 0;
+        let now = std::time::Instant::now();
+
+        while i < pending.len() {
+            let fd_idx = events.len() - pending_len + orig_i;
+            let expired = now > pending[i].expires_at;
+            let is_readable = fd_idx < events.len() && !events[fd_idx].is_empty();
+
+            if expired {
+                let transfer = pending.remove(i);
+                warn!("Clipboard transfer timed out");
+                Self::send_selection_notify(&self.connection, &transfer, x::ATOM_NONE);
+                orig_i += 1;
+                continue;
+            }
+
+            if is_readable {
+                use std::io::Read;
+                let mut buf = [0u8; 4096];
+                let mut done = false;
+                let mut err = false;
+                loop {
+                    match pending[i].pipe.read(&mut buf) {
+                        Ok(0) => {
+                            done = true;
+                            break;
+                        }
+                        Ok(n) => {
+                            pending[i].data.extend_from_slice(&buf[..n]);
+                            if pending[i].data.len() > MAX_CLIPBOARD_SIZE {
+                                warn!("Clipboard limit exceeded 16MB, aborting transfer");
+                                // Drop ReadPipe to close FD and signal EPIPE
+                                err = true;
+                                break;
+                            }
+                        }
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            break;
+                        }
+                        Err(e) => {
+                            warn!("Error reading clipboard pipe: {e:?}");
+                            err = true;
+                            break;
+                        }
+                    }
+                }
+
+                if done {
+                    let transfer = pending.remove(i);
+                    self.complete_transfer(transfer);
+                    orig_i += 1;
+                    continue;
+                } else if err {
+                    let transfer = pending.remove(i);
+                    Self::send_selection_notify(&self.connection, &transfer, x::ATOM_NONE);
+                    orig_i += 1;
+                    continue;
+                }
+            }
+
+            i += 1;
+            orig_i += 1;
+        }
+
+        self.selection_state.pending_transfers = pending;
+    }
+
+    pub(crate) fn has_pending_transfers(&self) -> bool {
+        !self.selection_state.pending_transfers.is_empty()
+    }
+
+    pub(crate) fn collect_poll_fds<'a>(&'a self, base: &mut Vec<PollFd<'a>>) {
+        for t in &self.selection_state.pending_transfers {
+            base.push(PollFd::from_borrowed_fd(t.pipe.as_fd(), PollFlags::IN));
+        }
+    }
+
+    pub(crate) fn poll_timeout(&self) -> Option<rustix::event::Timespec> {
+        let now = std::time::Instant::now();
+        let mut min_duration = None;
+        for t in &self.selection_state.pending_transfers {
+            let duration = t.expires_at.saturating_duration_since(now);
+            match min_duration {
+                None => min_duration = Some(duration),
+                Some(min) if duration < min => min_duration = Some(duration),
+                _ => {}
+            }
+        }
+        min_duration.map(|d| rustix::event::Timespec {
+            tv_sec: d.as_secs() as _,
+            tv_nsec: d.subsec_nanos() as _,
+        })
     }
 }

--- a/src/xstate/tests.rs
+++ b/src/xstate/tests.rs
@@ -530,4 +530,49 @@ mod window_role_heuristics {
         };
         assert_eq!(win.guess_window_role(&win_types), WindowRole::Splash);
     }
+
+    #[test]
+    fn steam_add_non_steam_game_dialog() {
+        let win_types = WindowTypes::new();
+        let win = WindowRoleHeuristics {
+            has_transient_for: true,
+            motif_wm_hints: Some(motif::Hints::from([0x2_u32, 0x1, 0, 0, 0].as_slice())),
+            window_types: vec![win_types.dialog],
+            wm_class: Some("steam".into()),
+            ..Default::default()
+        };
+        assert_eq!(win.guess_window_role(&win_types), WindowRole::Toplevel);
+    }
+
+    #[test]
+    fn steam_popup_menu() {
+        let win_types = WindowTypes::new();
+        let win = WindowRoleHeuristics {
+            override_redirect: true,
+            has_transient_for: true,
+            motif_wm_hints: Some(motif::Hints::from([0x2_u32, 0x1, 0, 0, 0].as_slice())),
+            window_types: vec![win_types.popup_menu],
+            wm_class: Some("steamwebhelper".into()),
+            ..Default::default()
+        };
+        assert_eq!(win.guess_window_role(&win_types), WindowRole::Popup);
+    }
+
+    #[test]
+    fn regular_dialog_resizable_remains_toplevel() {
+        let win_types = WindowTypes::new();
+        let wm_normal_hints = WmNormalHints::new()
+            .min_size(300, 200)
+            .max_size(800, 600);
+        let win = WindowRoleHeuristics {
+            has_transient_for: true,
+            motif_wm_hints: Some(motif::Hints::from([0x2_u32, 0x1, 0, 0, 0].as_slice())),
+            window_types: vec![win_types.dialog],
+            wm_class: Some("otherapp".into()),
+            wm_normal_hints: Some(wm_normal_hints.into()),
+            ..Default::default()
+        };
+        assert_eq!(win.guess_window_role(&win_types), WindowRole::Toplevel);
+    }
 }
+

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -864,6 +864,15 @@ impl Server {
         self.display.flush_clients().unwrap();
     }
 
+    pub fn move_pointer_on_current_surface(&mut self, x: f64, y: f64) {
+        let pointer = self.state.pointer.as_ref().expect("No pointer created");
+        pointer
+            .pointer
+            .motion(self.state.begin.elapsed().as_millis() as u32, x, y);
+        pointer.pointer.frame();
+        self.display.flush_clients().unwrap();
+    }
+
     pub fn new_output(&mut self) {
         self.state.last_output_global = Some(self.dh.create_global::<State, WlOutput, _>(4, ()));
         self.display.flush_clients().unwrap();

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -80,6 +80,7 @@ use wayland_server::{
         wl_keyboard::{self, WlKeyboard},
         wl_output::{self, WlOutput},
         wl_pointer::{self, WlPointer},
+        wl_region::WlRegion,
         wl_seat::{self, WlSeat},
         wl_shm::WlShm,
         wl_shm_pool::WlShmPool,
@@ -116,6 +117,12 @@ pub struct SurfaceData {
     pub viewport: Option<Viewport>,
     pub moving: bool,
     pub resizing: Option<xdg_toplevel::ResizeEdge>,
+    pub input_region: Option<Vec<(i32, i32, i32, i32)>>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RegionState {
+    pub rects: Vec<(i32, i32, i32, i32)>,
 }
 
 impl SurfaceData {
@@ -1574,7 +1581,9 @@ impl Dispatch<XdgToplevel, SurfaceId> for State {
                 let Some(SurfaceRole::Toplevel(toplevel)) = &mut data.role else {
                     unreachable!();
                 };
-                toplevel.states.push(xdg_toplevel::State::Fullscreen);
+                if !toplevel.states.contains(&xdg_toplevel::State::Fullscreen) {
+                    toplevel.states.push(xdg_toplevel::State::Fullscreen);
+                }
                 let states = toplevel.states.clone();
                 state.configure_toplevel(*surface_id, 100, 100, states);
             }
@@ -1588,6 +1597,34 @@ impl Dispatch<XdgToplevel, SurfaceId> for State {
                     .iter()
                     .copied()
                     .position(|p| p == xdg_toplevel::State::Fullscreen)
+                else {
+                    return;
+                };
+                toplevel.states.swap_remove(pos);
+                let states = toplevel.states.clone();
+                state.configure_toplevel(*surface_id, 100, 100, states);
+            }
+            xdg_toplevel::Request::SetMaximized => {
+                let data = state.surfaces.get_mut(surface_id).unwrap();
+                let Some(SurfaceRole::Toplevel(toplevel)) = &mut data.role else {
+                    unreachable!();
+                };
+                if !toplevel.states.contains(&xdg_toplevel::State::Maximized) {
+                    toplevel.states.push(xdg_toplevel::State::Maximized);
+                }
+                let states = toplevel.states.clone();
+                state.configure_toplevel(*surface_id, 100, 100, states);
+            }
+            xdg_toplevel::Request::UnsetMaximized => {
+                let data = state.surfaces.get_mut(surface_id).unwrap();
+                let Some(SurfaceRole::Toplevel(toplevel)) = &mut data.role else {
+                    unreachable!();
+                };
+                let Some(pos) = toplevel
+                    .states
+                    .iter()
+                    .copied()
+                    .position(|p| p == xdg_toplevel::State::Maximized)
                 else {
                     return;
                 };
@@ -1965,10 +2002,14 @@ impl Dispatch<WlCompositor, ()> for State {
                         viewport: None,
                         moving: false,
                         resizing: None,
+                        input_region: None,
                     },
                 );
                 state.last_surface_id = Some(SurfaceId(id));
                 state.created_surfaces.push(SurfaceId(id));
+            }
+            proto::wl_compositor::Request::CreateRegion { id } => {
+                data_init.init(id, Arc::new(Mutex::new(RegionState::default())));
             }
             _ => unreachable!(),
         }
@@ -2058,9 +2099,40 @@ impl Dispatch<WlSurface, ()> for State {
                 }
                 state.surfaces.remove(&id);
             }
-            SetInputRegion { .. } => {}
+            SetInputRegion { region } => {
+                data.input_region = region.map(|r| {
+                    let r_data = r.data::<Arc<Mutex<RegionState>>>().unwrap();
+                    r_data.lock().unwrap().rects.clone()
+                });
+            }
             SetBufferScale { .. } => {}
             other => todo!("unhandled request {other:?}"),
+        }
+    }
+}
+
+impl Dispatch<WlRegion, Arc<Mutex<RegionState>>> for State {
+    fn request(
+        _: &mut Self,
+        _: &Client,
+        _: &WlRegion,
+        request: <WlRegion as Resource>::Request,
+        data: &Arc<Mutex<RegionState>>,
+        _: &DisplayHandle,
+        _: &mut wayland_server::DataInit<'_, Self>,
+    ) {
+        match request {
+            proto::wl_region::Request::Add {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                data.lock().unwrap().rects.push((x, y, width, height));
+            }
+            proto::wl_region::Request::Subtract { .. } => {}
+            proto::wl_region::Request::Destroy => {}
+            _ => {}
         }
     }
 }

--- a/xwayland-satellite.man
+++ b/xwayland-satellite.man
@@ -40,6 +40,7 @@ Specify a file with authorization records. This flag can be passed a maximum of 
 and
 .BR Xsecurity (7)
 man pages.
+
 .TP
 \fB\-core\fR
 Cause Xwayland to generate a core dump on fatal errors. Note this does not generate a core dump on fatal
@@ -96,6 +97,12 @@ for more information on how to set this variable.
 .TP
 \fBWAYLAND_DISPLAY\fR
 Name of the Wayland server's display.
+.TP
+\fBXWAYLAND_SATELLITE_COMPOSITOR_SCALING\fR
+If set, enables compositor-side scaling.
+.TP
+\fBXWAYLAND_SATELLITE_BASE_SCALE\fR
+Overrides the base scale factor (1.0 to 8.0) when compositor-side scaling is enabled.
 .TP
 \fBXDG_RUNTIME_DIR\fR
 The directory used by \fBxwayland\-satellite\fR to both look for the Wayland socket to connect to and to create the Wayland socket \fBXwayland\fR will connect to.


### PR DESCRIPTION
### What

Adds optional compositor-side supersampling for mixed-DPI setups, implements missing EWMH window maximization, and fixes Wayland input region coordinate scaling for viewport-managed surfaces.

* **Compositor supersampling**: Renders X11 apps at the maximum output DPI and lets the Wayland compositor downscale them on lower-DPI monitors via `wp_viewport`. 2D monitor layout is resolved through a minimum spanning tree. Includes `XWAYLAND_SATELLITE_BASE_SCALE` (1.0–8.0) to override the scale on low-end systems.
* **Input region scaling**: Buffers and scales `wl_region` rectangles to match destination logical coordinates, eliminating click offsets and destroying replaced `wl_region` objects immediately.
* **EWMH maximization**: Adds `_NET_WM_STATE_MAXIMIZED_VERT` and `_NET_WM_STATE_MAXIMIZED_HORZ` with pre-mapping state caching so frameworks like Avalonia (SourceGit) map directly in the maximized state.
* **Non-blocking selection**: Converts clipboard transfers to `O_NONBLOCK` pipes with a 2-second timeout and a 16 MiB payload cap to prevent X11 event loop stalls.

### Why
On mixed-DPI setups (for example, a 2560x1600 1.75x internal laptop display paired with a 1080p 1.0x external monitor),  Xwayland forces a single global scale across outputs. Without compositor scaling, X11 apps like Steam end up blurry on the HiDPI screen or tiny on standard screens, with geometry gaps when crossing monitor boundaries.

Additionally:
* Apps like SourceGit start unmaximized because `_NET_WM_STATE` maximization atoms were unhandled.
* Clicks inside scaled windows registered at the wrong offsets because `wp_viewport` requires logical destination coordinates, while X11 passes buffer pixels.
* Slow or broken clipboard transfers could block the main poll loop.

### How

* **Compositor Scaling & Spanning Tree**:
  * Gated by `XWAYLAND_SATELLITE_COMPOSITOR_SCALING` (checked for non-empty, non-zero values).
  * Replaced 1D coordinate offsets with a 2D minimum spanning tree solver (Prim's algorithm in `recalculate_x11_output_positions`) rooted at the monitor closest to `(0, 0)`.
  * Delta offsets between adjacent monitors are scaled by the boundary edge scale factor (`dx * scale_x * global_scale`) to prevent gaps or overlaps on mixed-DPI and rotated setups.
  * Added `XWAYLAND_SATELLITE_BASE_SCALE` (clamped to `[1.0, 8.0]`): setting it to `1.0` keeps native resolution and saves VRAM without breaking multi-monitor positioning fixes.
  * Hardened MST offset lookups with `unwrap_or(0)` against incomplete output graphs during monitor hotplug.
  * Titlebar heights are dynamically calculated from font line metrics (`ascent - descent + line_gap + padding`) and cached via `OnceLock<i32>`.
* **Input Region Scaling**:
  * While X11 passes `SetInputRegion` rectangles in buffer pixels, `wp_viewport` expects logical destination coordinates.
  * Operations (`Add`/`Subtract`) are buffered in `RegionData.ops` (`Arc<Mutex<Vec<RegionOp>>>`) and scaled by `(scale_x, scale_y)` before issuing Wayland requests.
  * Stale `wl_region` objects are destroyed immediately on replacement (`old.destroy()`) and on surface destruction to avoid object leaks.
  * Applied aspect ratio correction for 90°-rotated fullscreen surfaces.
  * In `WlTouch::Up` and `WlTouch::Cancel`, `CurrentSurface` is cleanly removed to avoid stale touch tracking.
* **EWMH Maximization**:
  * Advertised `_NET_WM_STATE_MAXIMIZED_VERT` and `_NET_WM_STATE_MAXIMIZED_HORZ` in `_NET_SUPPORTED`.
  * `update_net_wm_state()` performs atomic read-modify-write on `_NET_WM_STATE` properties without clobbering existing flags like fullscreen.
  * Pre-mapping state buffering in `WindowAttributes` ensures windows that set state before `XMapWindow` (Avalonia/SourceGit) start already maximized.
  * Synced bidirectionally with `xdg_toplevel::Event::Configure`.
* **Clipboard & Selection Hardening**:
  * Switched pipe I/O to `O_NONBLOCK` with an explicit 2-second timeout (`PendingTransfer`).
  * Capped payload size at 16 MiB (`MAX_CLIPBOARD_SIZE`), returning `ATOM_NONE` on overflow to prevent memory exhaustion and hanging clients.
  * The main loop polls with stack-allocated `[PollFd; 5]` when idle, only heap-allocating `Vec<PollFd>` during active transfers.

### Related Issues

Closes #449
Closes #456
Related #180

### Testing

Tested on Arch Linux with Niri compositor on AMD Ryzen 7 780M (1.75x 2560x1600) + external 1080p (1.0x):
* `cargo test --all-targets` passes.
* Unit tests cover multi-scale MST layout, 90° rotated screens, monitor disconnect fallback, rapid maximization toggles, `BASE_SCALE` override, and scaled input region clipping.
* Verified sharp Steam rendering without upscale blur; window dragging across mixed-DPI screens transitions without visual gaps or jumping.
* Mouse and touch clicks register at exact pixel locations across all scale factors.
* Confirmed SourceGit starts maximized immediately on launch.

<img width="3856" height="1208" alt="original_horizontal" src="https://github.com/user-attachments/assets/a6144817-f6ae-491f-8be1-6af3395fb28a" />
<img width="3856" height="1208" alt="patched_horizontal" src="https://github.com/user-attachments/assets/fac80352-e2b6-41a6-b83d-5173d637a1fc" />
