### PR TITLE
Stabilize re-anchoring when windows move across outputs 

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -277,11 +277,45 @@ impl SurfaceEvents {
                     return;
                 };
                 surface.leave(&output);
-                if data
+
+                if let Some(mut entered) = data.get::<&mut EnteredOutputs>() {
+                    entered.0.retain(|e| *e != output_entity);
+                }
+
+                let anchored_here = data
                     .get::<&OnOutput>()
-                    .is_some_and(|o| o.0 == output_entity)
-                {
-                    cmd.remove_one::<OnOutput>(target);
+                    .is_some_and(|o| o.0 == output_entity);
+                if anchored_here {
+                    // The anchor output is gone for real: re-anchor to the
+                    // most recently entered output the surface is still on.
+                    let next = data.get::<&EnteredOutputs>().and_then(|entered| {
+                        entered.0.iter().rev().copied().find(|e| {
+                            state
+                                .world
+                                .entity(*e)
+                                .is_ok_and(|en| en.has::<OutputDimensions>())
+                        })
+                    });
+                    match next {
+                        Some(next_output) => {
+                            let mut query = data.query::<(&x::Window, &mut WindowData)>();
+                            if let Some((window, win_data)) = query.get() {
+                                anchor_window_to_output(
+                                    &state.world,
+                                    *window,
+                                    win_data,
+                                    next_output,
+                                    &state.global_output_offset,
+                                    state.last_focused_toplevel,
+                                    connection,
+                                );
+                            }
+                            cmd.insert_one(target, OnOutput(next_output));
+                        }
+                        None => {
+                            cmd.remove_one::<OnOutput>(target);
+                        }
+                    }
                 }
             }
             Event::PreferredBufferScale { .. } => {}

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -206,27 +206,43 @@ impl SurfaceEvents {
                 };
 
                 surface.enter(&output);
-                let on_output = OnOutput(output_entity);
 
                 debug!("{} entered {}", surface.id(), output.id());
 
+                // Track every output the surface is on. The anchor
+                // (OnOutput) only changes when its output actually leaves:
+                // re-anchoring on every enter turns transient overlaps
+                // (bounding-box sweeps during animations, brief flickers on
+                // layout changes) into X11 repositioning feedback loops.
+                match data.get::<&mut EnteredOutputs>() {
+                    Some(mut entered) => {
+                        entered.0.retain(|e| *e != output_entity);
+                        entered.0.push(output_entity);
+                    }
+                    None => cmd.insert_one(target, EnteredOutputs(vec![output_entity])),
+                }
+
+                let anchor_is_valid = data.get::<&OnOutput>().is_some_and(|o| {
+                    state
+                        .world
+                        .entity(o.0)
+                        .is_ok_and(|e| e.has::<OutputDimensions>())
+                });
+
                 let mut query = data.query::<(&x::Window, &mut WindowData)>();
                 if let Some((window, win_data)) = query.get() {
-                    let Some(dimensions) = output_data.get::<&OutputDimensions>() else {
-                        return;
-                    };
-                    win_data.update_output_offset(
-                        *window,
-                        WindowOutputOffset {
-                            x: dimensions.x - state.global_output_offset.x.value,
-                            y: dimensions.y - state.global_output_offset.y.value,
-                        },
-                        connection,
-                    );
-                    if state.last_focused_toplevel == Some(*window) {
-                        let output = get_output_name(Some(&on_output), &state.world);
-                        debug!("focused window changed outputs - resetting primary output");
-                        connection.focus_window(*window, output);
+                    if !anchor_is_valid
+                        && anchor_window_to_output(
+                            &state.world,
+                            *window,
+                            win_data,
+                            output_entity,
+                            &state.global_output_offset,
+                            state.last_focused_toplevel,
+                            connection,
+                        )
+                    {
+                        cmd.insert_one(target, OnOutput(output_entity));
                     }
 
                     if state.fractional_scale.is_none() {
@@ -240,14 +256,20 @@ impl SurfaceEvents {
                     } else {
                         let scale = data.get::<&SurfaceScaleFactor>().unwrap();
                         if update_output_scale(
-                            state.world.query_one(on_output.0).unwrap(),
+                            state.world.query_one(output_entity).unwrap(),
                             OutputScaleFactor::Fractional(scale.0),
                         ) {
-                            state.updated_outputs.push(on_output.0);
+                            state.updated_outputs.push(output_entity);
                         }
                     }
+                } else {
+                    // No X11 window on this surface: either it has not been
+                    // associated with one yet (that happens later, when the
+                    // Xwayland serial handshake pairs them), or its window has
+                    // since been destroyed. Nothing has an X11 position to keep
+                    // stable, so just track the most recent output.
+                    cmd.insert_one(target, OnOutput(output_entity));
                 }
-                cmd.insert_one(target, on_output);
             }
             Event::Leave { output } => {
                 let output_entity = output.data().copied().unwrap();
@@ -1001,6 +1023,12 @@ impl Event for client::wl_touch::Event {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(super) struct OnOutput(pub Entity);
+
+/// Every output a surface is currently on, in enter order (most recent last).
+/// [`OnOutput`] is the surface's positioning anchor; this set decides where to
+/// re-anchor when the anchor output itself leaves.
+pub(super) struct EnteredOutputs(Vec<Entity>);
+
 struct OutputName(String);
 fn get_output_name(output: Option<&OnOutput>, world: &World) -> Option<String> {
     output.map(|o| world.get::<&OutputName>(o.0).unwrap().0.clone())
@@ -1084,6 +1112,37 @@ impl Default for OutputDimensions {
             rotated_90: false,
         }
     }
+}
+
+/// Point a window's X11 position at `output_entity`, resetting the X11
+/// primary output if the window is focused. Returns false if the output's
+/// dimensions aren't known yet (no anchoring possible).
+fn anchor_window_to_output<C: XConnection>(
+    world: &World,
+    window: x::Window,
+    win_data: &mut WindowData,
+    output_entity: Entity,
+    global_output_offset: &GlobalOutputOffset,
+    last_focused_toplevel: Option<x::Window>,
+    connection: &mut C,
+) -> bool {
+    let Ok(dimensions) = world.get::<&OutputDimensions>(output_entity) else {
+        return false;
+    };
+    win_data.update_output_offset(
+        window,
+        WindowOutputOffset {
+            x: dimensions.x - global_output_offset.x.value,
+            y: dimensions.y - global_output_offset.y.value,
+        },
+        connection,
+    );
+    if last_focused_toplevel == Some(window) {
+        debug!("focused window changed outputs - resetting primary output");
+        let name = get_output_name(Some(&OnOutput(output_entity)), world);
+        connection.focus_window(window, name);
+    }
+    true
 }
 
 fn update_output_offset(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1793,6 +1793,66 @@ fn popup_done() {
     assert_eq!(reply.map_state(), x::MapState::Unmapped);
 }
 
+/// A window that merely overlaps a second output must keep the anchor - and
+/// so the X11 position - it already had, and only re-anchor once it actually
+/// leaves the output it was anchored to.
+///
+/// Without this, every `wl_surface.enter` re-anchored the window and rewrote
+/// its X11 offset, so a transient overlap (a window straddling a boundary, a
+/// bounding box sweeping past during an animation) moved the window out from
+/// under the pointer: clicks land offset, and regions of the window stop
+/// responding.
+#[test]
+fn transient_output_overlap_keeps_anchor() {
+    let mut f = Fixture::new();
+    let output1 = f.create_output(0, 0);
+    let output2 = f.create_output(1000, 0);
+    let mut connection = Connection::new(&f.display);
+
+    let window = connection.new_window(connection.root, 0, 0, 200, 200, false);
+    let surface = f.map_as_toplevel(&mut connection, window);
+
+    let root_position = |connection: &Connection| {
+        let tree = connection.get_reply(&x::QueryTree { window });
+        let geo = connection.get_reply(&x::GetGeometry {
+            drawable: x::Drawable::Window(window),
+        });
+        let reply = connection.get_reply(&x::TranslateCoordinates {
+            src_window: tree.parent(),
+            dst_window: connection.root,
+            src_x: geo.x(),
+            src_y: geo.y(),
+        });
+        assert!(reply.same_screen());
+        (reply.dst_x(), reply.dst_y())
+    };
+
+    // Anchored to output1.
+    f.testwl.move_surface_to_output(surface, &output1);
+    f.wait_and_dispatch();
+    let anchored = root_position(&connection);
+
+    // Now also on output2, without leaving output1. The anchor is still
+    // valid, so nothing should move.
+    f.testwl.add_surface_to_output(surface, &output2);
+    f.wait_and_dispatch();
+    assert_eq!(
+        root_position(&connection),
+        anchored,
+        "window re-anchored to an output it had only transiently entered"
+    );
+
+    // Leaving output1 invalidates the anchor for real, so the window
+    // re-anchors to the output it is still on.
+    f.testwl.move_surface_to_output(surface, &output2);
+    f.wait_and_dispatch();
+    assert_eq!(
+        root_position(&connection),
+        (anchored.0 + 1000, anchored.1),
+        "window did not re-anchor after leaving the output it was anchored to"
+    );
+}
+
 #[test]
 fn negative_output_coordinates() {
     let mut f = Fixture::new();

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -923,6 +923,27 @@ impl Server {
         self.display.flush_clients().unwrap();
     }
 
+    /// Send `wl_surface.enter` for an additional output, leaving the surface
+    /// on every output it is already on.
+    ///
+    /// This models a surface straddling two outputs - a window overlapping a
+    /// boundary, or a bounding box sweeping across one during an animation.
+    /// [`Self::move_surface_to_output`] cannot express it, because it leaves
+    /// every other output by design.
+    pub fn add_surface_to_output(&mut self, surface: SurfaceId, output: &WlOutput) {
+        let data = self
+            .state
+            .surfaces
+            .get_mut(&surface)
+            .expect("No such surface");
+        if data.entered.iter().any(|o| o.id() == output.id()) {
+            return;
+        }
+        data.surface.enter(output);
+        data.entered.push(output.clone());
+        self.display.flush_clients().unwrap();
+    }
+
     pub fn remove_output(&mut self, output: WlOutput) {
         let output = self.state.outputs.remove(&output).unwrap();
         self.dh.remove_global::<State>(output.global_id.unwrap());

--- a/testwl/src/lib.rs
+++ b/testwl/src/lib.rs
@@ -116,6 +116,8 @@ pub struct SurfaceData {
     pub viewport: Option<Viewport>,
     pub moving: bool,
     pub resizing: Option<xdg_toplevel::ResizeEdge>,
+    /// Outputs the surface has been sent wl_surface.enter for.
+    pub entered: Vec<WlOutput>,
 }
 
 impl SurfaceData {
@@ -896,8 +898,28 @@ impl Server {
     }
 
     pub fn move_surface_to_output(&mut self, surface: SurfaceId, output: &WlOutput) {
-        let data = self.state.surfaces.get(&surface).expect("No such surface");
-        data.surface.enter(output);
+        let data = self
+            .state
+            .surfaces
+            .get_mut(&surface)
+            .expect("No such surface");
+        // Real compositors send wl_surface.leave for outputs a moved surface
+        // is no longer on; model that so output-anchoring logic in the
+        // client under test behaves as it would in production.
+        let previously_entered = std::mem::take(&mut data.entered);
+        // Leave every output except the target.
+        for old in &previously_entered {
+            if old.id() != output.id() {
+                data.surface.leave(old);
+            }
+        }
+        // Enter the target, unless the surface was already on it. This is
+        // independent of the leaves above: a surface moving off one output
+        // still gets an enter for the one it is moving to.
+        if !previously_entered.iter().any(|o| o.id() == output.id()) {
+            data.surface.enter(output);
+        }
+        data.entered.push(output.clone());
         self.display.flush_clients().unwrap();
     }
 
@@ -1965,6 +1987,7 @@ impl Dispatch<WlCompositor, ()> for State {
                         viewport: None,
                         moving: false,
                         resizing: None,
+                        entered: Vec::new(),
                     },
                 );
                 state.last_surface_id = Some(SurfaceId(id));


### PR DESCRIPTION
Stabilizes how windows are anchored to outputs, preventing X11 repositioning feedback loops that could occur during transient overlaps or layout changes.

-   Introduces a new component to track all outputs a surface is currently on.
-   Modifies the main anchoring component to be more stable, changing only when its output truly leaves or if the window isn't currently anchored to a valid output. This avoids excessive re-anchoring from transient overlaps.
-   Re-anchors windows to the most recently entered valid output when the current anchor output leaves.
-   Extracts the core window anchoring logic into a dedicated helper function, which handles X11 position updates and focused window primary output resets.
-   Ensures popups and other non-window surfaces continue to follow the most recently entered output, aligning with their short-lived nature and lack of X11 positions.
-   Updates the testing utility to accurately model surface leave events during output transitions, ensuring correct behavior when moving surfaces between outputs.