### PR TITLE
add optional mode for mixed scaling factors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,11 @@ pub trait RunData {
     fn max_req_len_bytes(&self) -> Option<usize> {
         None
     }
+    /// Present X11 clients with the compositor's logical coordinate space
+    /// instead of device pixels. See `ServerState::logical_geometry`.
+    fn logical_geometry(&self) -> bool {
+        false
+    }
 }
 
 pub const fn timespec_from_millis(millis: u64) -> Timespec {
@@ -153,7 +158,15 @@ pub fn main(mut data: impl RunData) -> Option<()> {
         }
     };
 
-    let mut server_state = EarlyServerState::new(dh, data.server(), connection);
+    let logical_geometry = data
+        .logical_geometry();
+    let mut server_state = EarlyServerState::new(
+        dh,
+        data
+            .server(),
+        connection,
+        logical_geometry,
+    );
     server_state.run();
 
     // Remove the lifetimes on our fds to avoid borrowing issues, since we know they will exist for

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ struct RealData {
     display: Option<String>,
     listenfds: Vec<OwnedFd>,
     flags: Vec<String>,
+    logical_geometry: bool,
 }
 impl xwayland_satellite::RunData for RealData {
     fn display(&self) -> Option<&str> {
@@ -25,6 +26,10 @@ impl xwayland_satellite::RunData for RealData {
 
     fn flags(&self) -> &[String] {
         &self.flags
+    }
+
+    fn logical_geometry(&self) -> bool {
+        self.logical_geometry
     }
 }
 
@@ -179,6 +184,10 @@ fn parse_args() -> RealData {
                     "-glamor [gl|es|none]"
                 );
                 println!("{:<25} prints message with these options", "-help");
+                println!(
+                    "{:<25} present X11 clients with logical (scale-independent) output geometry; also enabled by XWLS_LOGICAL_GEOMETRY=1",
+                    "--logical-geometry"
+                );
                 println!("{:<25} listen on protocol", "-listen");
                 println!("{:<25} don't listen on protocol", "-nolisten");
                 println!("{:<25} add given fd as a listen socket", "-listenfd");
@@ -224,6 +233,9 @@ fn parse_args() -> RealData {
                 let fd = unsafe { OwnedFd::from_raw_fd(fd) };
                 data.listenfds.push(fd);
             }
+            "--logical-geometry" => {
+                data.logical_geometry = true;
+            }
             "--test-listenfd-support" => std::process::exit(0),
             "-verbose" => {
                 if let Some(v) = args.peek().and_then(|n| n.parse::<u32>().ok()) {
@@ -243,6 +255,14 @@ fn parse_args() -> RealData {
         }
     }
     data.flags = flags.to_vec();
+
+    // The environment variable is an alternative to --logical-geometry for
+    // setups where the satellite command line cannot be changed (e.g. a
+    // compositor spawning satellite with a fixed argument list).
+    if !data.logical_geometry {
+        data.logical_geometry = std::env::var("XWLS_LOGICAL_GEOMETRY")
+            .is_ok_and(|v| !v.is_empty() && v != "0");
+    }
 
     data
 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -1071,6 +1071,11 @@ pub(super) struct OutputDimensions {
     pub width: i32,
     pub height: i32,
     rotated_90: bool,
+    /// The host compositor's xdg_output logical size, used instead of the
+    /// device-pixel mode size in logical geometry mode.
+    logical: Option<(i32, i32)>,
+    /// Refresh of the current mode, for restating the mode at logical size.
+    refresh: i32,
 }
 
 impl Default for OutputDimensions {
@@ -1089,6 +1094,8 @@ impl Default for OutputDimensions {
             width: 0,
             height: 0,
             rotated_90: false,
+            logical: None,
+            refresh: 0,
         }
     }
 }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -102,6 +102,13 @@ impl Event for SurfaceEvents {
                         factor
                     );
 
+                    if state.logical_geometry {
+                        // Surfaces stay at scale 1 in logical geometry mode:
+                        // X11 windows are sized in logical pixels and the
+                        // compositor scales them at composite time.
+                        return;
+                    }
+
                     entity.get::<&mut SurfaceScaleFactor>().unwrap().0 = factor;
 
                     if let Some(OnOutput(output)) = entity.get::<&OnOutput>().as_deref().copied() {
@@ -1260,6 +1267,7 @@ impl OutputEvent {
                 model,
                 transform,
             } => {
+                let logical_geometry = state.logical_geometry;
                 update_output_offset(
                     target,
                     OutputDimensionsSource::Wl {
@@ -1307,10 +1315,36 @@ impl OutputEvent {
                     )
                 });
                 if let Some(xdg) = xdg {
-                    if dimensions.rotated_90 {
-                        xdg.logical_size(dimensions.height, dimensions.width);
-                    } else {
-                        xdg.logical_size(dimensions.width, dimensions.height);
+                    match dimensions.logical {
+                        // The host's logical size is already post-transform;
+                        // no rotation swap needed.
+                        Some(
+                            
+                            (
+                                width, 
+                                height,
+                            )
+                        ) if logical_geometry => {
+                            xdg
+                                .logical_size(
+                                    width, 
+                                    height,
+                                );
+                        }
+                        _ if dimensions.rotated_90 => {
+                            xdg
+                                .logical_size(
+                                    dimensions.height, 
+                                    dimensions.width,
+                                );
+                        }
+                        _ => {
+                            xdg
+                                .logical_size(
+                                    dimensions.width,
+                                    dimensions.height,
+                                );
+                        }
                     }
                 }
             }
@@ -1320,6 +1354,7 @@ impl OutputEvent {
                 height,
                 refresh,
             } => {
+                let logical_geometry = state.logical_geometry;
                 let Ok((output, dimensions)) = state
                     .world
                     .query_one_mut::<(&WlOutput, &mut OutputDimensions)>(target)
@@ -1333,15 +1368,47 @@ impl OutputEvent {
                 {
                     dimensions.width = width;
                     dimensions.height = height;
+                    dimensions.refresh = refresh;
                     debug!("{} dimensions: {width}x{height}", output.id());
                 }
-                output.mode(convert_wenum(flags), width, height, refresh);
+                // In logical geometry mode the mode is advertised at the
+                // output's logical size, so the X11 screen layout matches
+                // the compositor's logical coordinate space. Until
+                // xdg_output reports the logical size, the raw mode is
+                // forwarded and corrected once LogicalSize arrives.
+                let (
+                    mode_width, 
+                    mode_height,
+                ) = match dimensions.logical {
+                    Some(logical) if logical_geometry => logical,
+                    _ => (
+                        width, 
+                        height,
+                    ),
+                };
+                output
+                    .mode(
+                        convert_wenum(flags),
+                        mode_width, 
+                        mode_height, 
+                        refresh,
+                    );
             }
             Event::Scale { factor } => {
                 debug!(
                     "{} scale: {factor}",
                     state.world.get::<&WlOutput>(target).unwrap().id()
                 );
+                if state.logical_geometry {
+                    // The output keeps its default OutputScaleFactor of 1,
+                    // and X11 is explicitly told the world is unscaled.
+                    state.world.get::<&WlOutput>(
+                        target,
+                    )
+                        .unwrap()
+                        .scale(1);
+                    return;
+                }
                 if update_output_scale(
                     state.world.query_one(target).unwrap(),
                     OutputScaleFactor::Output(factor),
@@ -1391,14 +1458,52 @@ impl OutputEvent {
                         );
                 }
             }
-            Event::LogicalSize { .. } => {
-                let Ok((xdg, dimensions)) = state
+            Event::LogicalSize {
+                width, 
+                height,
+            } => {
+                let logical_geometry = state.logical_geometry;
+                let Ok(
+                    (
+                        xdg, 
+                        dimensions,
+                        output,
+                    )
+                ) = state
                     .world
-                    .query_one_mut::<(&XdgOutputServer, &OutputDimensions)>(target)
+                    .query_one_mut::<(
+                        &XdgOutputServer,
+                        &mut OutputDimensions,
+                        &WlOutput,
+                    )>(target)
                 else {
                     return;
                 };
-                if dimensions.rotated_90 {
+                if logical_geometry {
+                    // Pass the compositor's logical size straight through
+                    // (it is already post-transform), and restate the
+                    // current mode at the logical size so the X11 screen
+                    // layout agrees with it.
+                    dimensions.logical = Some(
+                        (
+                            width,
+                            height,
+                        )
+                    );
+                    xdg
+                        .logical_size(
+                            width,
+                            height,
+                        );
+                    if dimensions.refresh != 0 {
+                        output.mode(
+                            wayland_server::protocol::wl_output::Mode::Current,
+                            width,
+                            height,
+                            dimensions.refresh,
+                        );
+                    }
+                } else if dimensions.rotated_90 {
                     xdg.logical_size(dimensions.height, dimensions.width);
                 } else {
                     xdg.logical_size(dimensions.width, dimensions.height);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -483,6 +483,15 @@ pub struct InnerServerState<S: X11Selection> {
     global_offset_updated: bool,
     updated_outputs: Vec<Entity>,
     new_scale: Option<f64>,
+    /// Present X11 with the compositor's logical coordinate space instead of
+    /// device pixels: outputs advertise their xdg_output logical size as both
+    /// mode and logical size, output/surface scale factors stay pinned at 1,
+    /// and windows are sized in logical pixels. This keeps X11 window geometry
+    /// and pointer input consistent on mixed-scale multi-monitor layouts, at
+    /// the cost of upscale softness on outputs with scale > 1 (X11 has a
+    /// single coordinate space; it cannot be per-output crisp AND
+    /// geometrically consistent). Enabled by XWLS_LOGICAL_GEOMETRY=1.
+    logical_geometry: bool,
 }
 
 impl<S: X11Selection> ServerState<NoConnection<S>> {
@@ -591,9 +600,16 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
+            logical_geometry: std::env::var("XWLS_LOGICAL_GEOMETRY")
+                .is_ok_and(|v| !v.is_empty() && v != "0"),
             decoration_manager,
             world,
         };
+        if inner.logical_geometry {
+            log::info!(
+                "XWLS_LOGICAL_GEOMETRY set: presenting X11 with logical output geometry"
+            );
+        }
         Self {
             inner,
             connection: NoConnection {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -490,7 +490,8 @@ pub struct InnerServerState<S: X11Selection> {
     /// and pointer input consistent on mixed-scale multi-monitor layouts, at
     /// the cost of upscale softness on outputs with scale > 1 (X11 has a
     /// single coordinate space; it cannot be per-output crisp AND
-    /// geometrically consistent). Enabled by XWLS_LOGICAL_GEOMETRY=1.
+    /// geometrically consistent). Enabled by the --logical-geometry flag or
+    /// XWLS_LOGICAL_GEOMETRY=1.
     logical_geometry: bool,
 }
 
@@ -499,6 +500,7 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
         mut dh: DisplayHandle,
         server_connection: Option<UnixStream>,
         client: UnixStream,
+        logical_geometry: bool,
     ) -> Self {
         let connection = if let Some(stream) = server_connection {
             Connection::from_socket(stream).unwrap()
@@ -600,14 +602,14 @@ impl<S: X11Selection> ServerState<NoConnection<S>> {
             global_offset_updated: false,
             updated_outputs: Vec::new(),
             new_scale: None,
-            logical_geometry: std::env::var("XWLS_LOGICAL_GEOMETRY")
-                .is_ok_and(|v| !v.is_empty() && v != "0"),
+            logical_geometry,
             decoration_manager,
             world,
         };
         if inner.logical_geometry {
             log::info!(
-                "XWLS_LOGICAL_GEOMETRY set: presenting X11 with logical output geometry"
+                "logical geometry enabled:\
+                presenting X11 with logical output geometry"
             );
         }
         Self {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -374,7 +374,15 @@ impl EarlyTestFixture {
         });
 
         let (fake_client, xwls_server) = UnixStream::pair().unwrap();
-        let satellite = ServerState::new(display.handle(), Some(client_s), xwls_server);
+        let satellite = ServerState::new(
+            display
+                .handle(), 
+            Some(
+                client_s
+            ),
+            xwls_server, 
+            false,
+        );
         let testwl = thread.join().unwrap();
 
         let xwls_connection = Connection::from_socket(fake_client).unwrap();

--- a/xwayland-satellite.man
+++ b/xwayland-satellite.man
@@ -72,6 +72,13 @@ Prints a basic usage message and list of accepted flags and returns 0.
 \fB\-listen\fR
 Enable a transport mechanism. This option can be used multiple times to enable multiple transport mechanisms. This option overrides a previous \fB\-nolisten\fR sent with the same parameter.
 .TP
+\fB\-\-logical\-geometry\fR
+Present X11 clients with the compositor's logical coordinate space instead of device pixels: outputs are advertised at their logical size with scale 1, and X11 windows are sized in logical pixels. This keeps X11 window geometry and pointer input consistent on multi-monitor layouts with mixed output scales, at the cost of upscale softness on outputs with a scale greater than 1. This option is specific to
+.B xwayland\-satellite
+and is not forwarded to Xwayland. It can also be enabled by setting the
+.B XWLS_LOGICAL_GEOMETRY
+environment variable to a non-empty value other than 0, for setups where the command line cannot be changed.
+.TP
 \fB\-nolisten\fR
 Disable a transport mechanism. This option can be used multiple times to disable multiple transport mechanisms. This option overrides a previous \fB\-listen\fR sent with the same parameter.
 .TP


### PR DESCRIPTION
this is entirely opt in. when enabled, there's still a global scaling factor for x windows, but on monitors with larger scaling factors windows will be scaled up. obviously this is a bit blurry, but in some use cases may be preferred over windows just completely ignoring scaling.