### PR TITLE
fix: pair of clientside decoration bugs

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -291,13 +291,8 @@ impl SurfaceEvents {
         drop(xdg);
 
         if let Some(pending) = pending {
-            let mut query = data.query::<(
-                &SurfaceScaleFactor,
-                &x::Window,
-                &mut WindowData,
-                &mut SurfaceRole,
-            )>();
-            let (scale_factor, window, window_data, role) = query.get().unwrap();
+            let mut query = data.query::<(&SurfaceScaleFactor, &x::Window, &mut WindowData)>();
+            let (scale_factor, window, window_data) = query.get().unwrap();
 
             let window = *window;
             let x = (pending.x.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.x;
@@ -307,7 +302,7 @@ impl SurfaceEvents {
             } else {
                 window_data.attrs.dims.width
             };
-            let mut height = if pending.height > 0 {
+            let height = if pending.height > 0 {
                 (pending.height as f64 * scale_factor.0) as u16
             } else {
                 window_data.attrs.dims.height
@@ -316,20 +311,6 @@ impl SurfaceEvents {
                 "configuring {} ({window:?}): {x}x{y}, {width}x{height}",
                 data.get::<&WlSurface>().unwrap().id(),
             );
-
-            if let SurfaceRole::Toplevel(Some(toplevel)) = &*role {
-                if let Some(d) = &toplevel.decoration.satellite {
-                    let surface_width = (width as f64 / scale_factor.0) as i32;
-                    if d.will_draw_decorations(surface_width) {
-                        height = height
-                            .saturating_sub(
-                                (DecorationsDataSatellite::TITLEBAR_HEIGHT as f64 * scale_factor.0)
-                                    as u16,
-                            )
-                            .max(DecorationsDataSatellite::TITLEBAR_HEIGHT as u16);
-                    }
-                }
-            }
 
             window_data.attrs.dims = WindowDims {
                 x: x as i16,
@@ -487,7 +468,20 @@ pub(super) fn update_surface_viewport(
     let size_hints = &window_data.attrs.size_hints;
 
     let width = (dims.width as f64 / scale_factor.0).ceil() as i32;
-    let height = (dims.height as f64 / scale_factor.0).ceil() as i32;
+    let mut height = dims.height;
+    if let Some(SurfaceRole::Toplevel(Some(toplevel))) = role {
+        if let Some(d) = &toplevel.decoration.satellite {
+            let surface_width = (dims.width as f64 / scale_factor.0) as i32;
+            if d.will_draw_decorations(surface_width) {
+                height = height
+                    .saturating_sub(
+                        (DecorationsDataSatellite::TITLEBAR_HEIGHT as f64 * scale_factor.0) as u16,
+                    )
+                    .max(DecorationsDataSatellite::TITLEBAR_HEIGHT as u16);
+            }
+        }
+    }
+    let height = (height as f64 / scale_factor.0).ceil() as i32;
     if width > 0 && height > 0 {
         viewport.set_destination(width, height);
     }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -518,17 +518,17 @@ pub(super) fn update_surface_viewport(
         if let Some(min) = hints.min_size {
             debug!(
                 "updated min height: {}",
-                (min.height as f64 / scale_factor.0) as i32 + decorations_height
+                ((min.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height)
             );
             data.toplevel.set_min_size(
                 (min.width as f64 / scale_factor.0) as i32,
-                (min.height as f64 / scale_factor.0) as i32 + decorations_height,
+                ((min.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height),
             );
         }
         if let Some(max) = hints.max_size {
             data.toplevel.set_max_size(
                 (max.width as f64 / scale_factor.0) as i32,
-                (max.height as f64 / scale_factor.0) as i32 + decorations_height,
+                ((max.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height),
             );
         }
     }

--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -499,32 +499,33 @@ pub(super) fn update_surface_viewport(
     debug!("{} viewport: {width}x{height}", surface.id());
 
     if let Some(hints) = size_hints {
-        let Some(data) = toplevel_data else {
-            return;
+        if let Some(data) = toplevel_data {
+            update_size_hints(data, hints, scale_factor.0);
         };
+    }
+}
 
-        let decorations_height = if data.decoration.satellite.is_some() {
-            DecorationsDataSatellite::TITLEBAR_HEIGHT
-        } else {
-            0
-        };
-
-        if let Some(min) = hints.min_size {
-            debug!(
-                "updated min height: {}",
-                ((min.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height)
-            );
-            data.toplevel.set_min_size(
-                (min.width as f64 / scale_factor.0) as i32,
-                ((min.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height),
-            );
-        }
-        if let Some(max) = hints.max_size {
-            data.toplevel.set_max_size(
-                (max.width as f64 / scale_factor.0) as i32,
-                ((max.height as f64 / scale_factor.0) as i32).saturating_add(decorations_height),
-            );
-        }
+pub(super) fn update_size_hints(data: &ToplevelData, hints: &WmNormalHints, scale: f64) {
+    let decorations_height = if data.decoration.satellite.is_some() {
+        DecorationsDataSatellite::TITLEBAR_HEIGHT
+    } else {
+        0
+    };
+    if let Some(min_size) = &hints.min_size {
+        data.toplevel.set_min_size(
+            (min_size.width as f64 / scale) as i32,
+            ((min_size.height as f64 / scale) as i32).saturating_add(decorations_height),
+        );
+    } else {
+        data.toplevel.set_min_size(0, 0);
+    }
+    if let Some(max_size) = &hints.max_size {
+        data.toplevel.set_max_size(
+            (max_size.width as f64 / scale) as i32,
+            ((max_size.height as f64 / scale) as i32).saturating_add(decorations_height),
+        );
+    } else {
+        data.toplevel.set_max_size(0, 0);
     }
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -996,29 +996,7 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
             debug!("setting {window:?} hints {hints:?}");
             let mut query = data.query::<(&SurfaceRole, &SurfaceScaleFactor)>();
             if let Some((SurfaceRole::Toplevel(Some(data)), scale_factor)) = query.get() {
-                let decorations_height = if data.decoration.satellite.is_some() {
-                    DecorationsDataSatellite::TITLEBAR_HEIGHT
-                } else {
-                    0
-                };
-                if let Some(min_size) = &hints.min_size {
-                    data.toplevel.set_min_size(
-                        (min_size.width as f64 / scale_factor.0) as i32,
-                        ((min_size.height as f64 / scale_factor.0) as i32)
-                            .saturating_add(decorations_height),
-                    );
-                } else {
-                    data.toplevel.set_min_size(0, 0);
-                }
-                if let Some(max_size) = &hints.max_size {
-                    data.toplevel.set_max_size(
-                        (max_size.width as f64 / scale_factor.0) as i32,
-                        ((max_size.height as f64 / scale_factor.0) as i32)
-                            .saturating_add(decorations_height),
-                    );
-                } else {
-                    data.toplevel.set_max_size(0, 0);
-                }
+                event::update_size_hints(data, &hints, scale_factor.0);
             }
             win.attrs.size_hints = Some(hints);
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1004,7 +1004,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 if let Some(min_size) = &hints.min_size {
                     data.toplevel.set_min_size(
                         (min_size.width as f64 / scale_factor.0) as i32,
-                        (min_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        ((min_size.height as f64 / scale_factor.0) as i32)
+                            .saturating_add(decorations_height),
                     );
                 } else {
                     data.toplevel.set_min_size(0, 0);
@@ -1012,7 +1013,8 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 if let Some(max_size) = &hints.max_size {
                     data.toplevel.set_max_size(
                         (max_size.width as f64 / scale_factor.0) as i32,
-                        (max_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        ((max_size.height as f64 / scale_factor.0) as i32)
+                            .saturating_add(decorations_height),
                     );
                 } else {
                     data.toplevel.set_max_size(0, 0);

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3256,6 +3256,41 @@ fn decorations_with_title_on_thin_window() {
         .set_win_title(window, WmName::WmName("window".into()));
 }
 
+#[test]
+fn decorations_max_height_int_max() {
+    let (mut f, compositor) = TestFixture::new_with_compositor();
+    let window = Window::new(1);
+    let (_, id) = f.create_toplevel(&compositor, window);
+    f.testwl
+        .force_decoration_mode(id, zxdg_toplevel_decoration_v1::Mode::ClientSide);
+    f.testwl.configure_toplevel(id, 1, 100, vec![]);
+    f.run();
+
+    // When calculating the Wayland max size from the X size hints, the titlebar height is added to
+    // the height hint, but obviously this should not overflow the size hint.
+    f.satellite.set_size_hints(
+        window,
+        super::WmNormalHints {
+            min_size: None,
+            max_size: Some(WinSize {
+                width: i32::MAX,
+                height: i32::MAX,
+            }),
+        },
+    );
+    f.run();
+
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let toplevel = data.toplevel();
+    assert_eq!(
+        toplevel.max_size,
+        Some(testwl::Vec2 {
+            x: i32::MAX,
+            y: i32::MAX
+        })
+    );
+}
+
 /// See Pointer::handle_event for an explanation.
 #[test]
 fn popup_pointer_motion_workaround() {}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3079,16 +3079,11 @@ fn client_side_decorations() {
     f.testwl.configure_toplevel(id, 100, 100, vec![]);
     f.run();
 
-    let data = f.connection().window(window);
-    assert_eq!(
-        data.dims,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 75
-        }
-    );
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let viewport = data.viewport.as_ref().unwrap();
+    assert_eq!(viewport.width, 100);
+    assert_eq!(viewport.height, 75);
+
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
@@ -3103,16 +3098,11 @@ fn client_side_decorations() {
     f.testwl
         .configure_toplevel(id, 100, 100, vec![xdg_toplevel::State::Fullscreen]);
     f.run();
-    let data = f.connection().window(window);
-    assert_eq!(
-        data.dims,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 100
-        }
-    );
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let viewport = data.viewport.as_ref().unwrap();
+    assert_eq!(viewport.width, 100);
+    assert_eq!(viewport.height, 100);
+
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
     assert!(data.buffer.is_none());
 
@@ -3128,16 +3118,10 @@ fn client_side_decorations() {
     f.testwl.configure_toplevel(id, 100, 100, vec![]);
     f.run();
 
-    let data = f.connection().window(window);
-    assert_eq!(
-        data.dims,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 100
-        }
-    );
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let viewport = data.viewport.as_ref().unwrap();
+    assert_eq!(viewport.width, 100);
+    assert_eq!(viewport.height, 100);
     assert!(f.testwl.get_surface_data(subsurface_id).is_none());
     assert!(!subsurface.is_alive());
 }
@@ -3201,16 +3185,11 @@ fn resize_decorations_on_reconfigure() {
     f.testwl.configure_toplevel(id, 100, 100, vec![]);
     f.run();
 
-    let data = f.connection().window(window);
-    assert_eq!(
-        data.dims,
-        WindowDims {
-            x: 0,
-            y: 0,
-            width: 100,
-            height: 75
-        }
-    );
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let viewport = data.viewport.as_ref().unwrap();
+    assert_eq!(viewport.width, 100);
+    assert_eq!(viewport.height, 75);
+
     let subsurface_id = f.testwl.last_created_surface_id().unwrap();
     assert_ne!(subsurface_id, id);
     let data = f.testwl.get_surface_data(subsurface_id).unwrap();
@@ -3223,6 +3202,15 @@ fn resize_decorations_on_reconfigure() {
         "surface was not a subsurface: {:?}",
         data.role
     );
+
+    // Weston seems to do this when a window is deactivated. Since the stored window data's height
+    // is used as a fallback in this case, do not reapply the height reduction from the titlebar.
+    f.testwl.configure_toplevel(id, 0, 0, vec![]);
+    f.run();
+    let data = f.testwl.get_surface_data(id).unwrap();
+    let viewport = data.viewport.as_ref().unwrap();
+    assert_eq!(viewport.width, 100);
+    assert_eq!(viewport.height, 75);
 
     let dims = WindowDims {
         x: 0,


### PR DESCRIPTION
First is an overflow that occurs when adding the titlebar height to the min/max size hint.

Second is that bug where Weston shrinks its windows by the titlebar height whenever they lose focus. I found the source of this bug completely on accident lol.