### PR TITLE
Fix fullscreen toggle at non-integer scales

### DIFF
--- a/src/server/event.rs
+++ b/src/server/event.rs
@@ -303,12 +303,12 @@ impl SurfaceEvents {
             let x = (pending.x.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.x;
             let y = (pending.y.max(0) as f64 * scale_factor.0) as i32 + window_data.output_offset.y;
             let width = if pending.width > 0 {
-                (pending.width as f64 * scale_factor.0) as u16
+                (pending.width as f64 * scale_factor.0).round() as u16
             } else {
                 window_data.attrs.dims.width
             };
             let mut height = if pending.height > 0 {
-                (pending.height as f64 * scale_factor.0) as u16
+                (pending.height as f64 * scale_factor.0).round() as u16
             } else {
                 window_data.attrs.dims.height
             };
@@ -486,8 +486,8 @@ pub(super) fn update_surface_viewport(
     let dims = &window_data.attrs.dims;
     let size_hints = &window_data.attrs.size_hints;
 
-    let width = (dims.width as f64 / scale_factor.0).ceil() as i32;
-    let height = (dims.height as f64 / scale_factor.0).ceil() as i32;
+    let width = (dims.width as f64 / scale_factor.0).round() as i32;
+    let height = (dims.height as f64 / scale_factor.0).round() as i32;
     if width > 0 && height > 0 {
         viewport.set_destination(width, height);
     }
@@ -518,17 +518,17 @@ pub(super) fn update_surface_viewport(
         if let Some(min) = hints.min_size {
             debug!(
                 "updated min height: {}",
-                (min.height as f64 / scale_factor.0) as i32 + decorations_height
+                (min.height as f64 / scale_factor.0).round() as i32 + decorations_height
             );
             data.toplevel.set_min_size(
-                (min.width as f64 / scale_factor.0) as i32,
-                (min.height as f64 / scale_factor.0) as i32 + decorations_height,
+                (min.width as f64 / scale_factor.0).round() as i32,
+                (min.height as f64 / scale_factor.0).round() as i32 + decorations_height,
             );
         }
         if let Some(max) = hints.max_size {
             data.toplevel.set_max_size(
-                (max.width as f64 / scale_factor.0) as i32,
-                (max.height as f64 / scale_factor.0) as i32 + decorations_height,
+                (max.width as f64 / scale_factor.0).round() as i32,
+                (max.height as f64 / scale_factor.0).round() as i32 + decorations_height,
             );
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1003,16 +1003,16 @@ impl<S: X11Selection + 'static> InnerServerState<S> {
                 };
                 if let Some(min_size) = &hints.min_size {
                     data.toplevel.set_min_size(
-                        (min_size.width as f64 / scale_factor.0) as i32,
-                        (min_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        (min_size.width as f64 / scale_factor.0).round() as i32,
+                        (min_size.height as f64 / scale_factor.0).round() as i32 + decorations_height,
                     );
                 } else {
                     data.toplevel.set_min_size(0, 0);
                 }
                 if let Some(max_size) = &hints.max_size {
                     data.toplevel.set_max_size(
-                        (max_size.width as f64 / scale_factor.0) as i32,
-                        (max_size.height as f64 / scale_factor.0) as i32 + decorations_height,
+                        (max_size.width as f64 / scale_factor.0).round() as i32,
+                        (max_size.height as f64 / scale_factor.0).round() as i32 + decorations_height,
                     );
                 } else {
                     data.toplevel.set_max_size(0, 0);


### PR DESCRIPTION
At fractional scales (e.g. 1.3×), the dimension conversion between compositor logical space and X11 physical space used asymmetric rounding: truncation (`as u16`) on the way up, ceiling (`.ceil()`) on the way down. This created a 1-pixel drift:

```
Compositor configures: 1969 → trunc(1969 × 1.3) = 2559 (should be 2560)
X11 reports: 2559 → ceil(2559 / 1.3) = 1969 (compositor expected 1970)
```

The compositor sees a "fullscreen" surface 1 pixel narrower than the output, drops the fullscreen state, and the window collapses back to its previous size. Toggling fullscreen rapidly flickers on then off.

**Fix:** Use `.round()` consistently in all four dimension-scaling paths:

| Location | Direction | Before | After |
|----------|-----------|--------|-------|
| `xdg_event` (event.rs) | compositor → X11 width/height | `as u16` | `.round() as u16` |
| `update_surface_viewport` (event.rs) | X11 → viewport | `.ceil() as i32` | `.round() as i32` |
| `update_surface_viewport` hints (event.rs) | X11 → logical size hints | `as i32` | `.round() as i32` |
| `set_size_hints` (mod.rs) | X11 → logical size hints | `as i32` | `.round() as i32` |

`round()` is symmetric: `round(round(L × s) / s) = L` for any scale ≥ 1.0. The round-trip is exact at all DPI levels.

Ref: #438