### PR TITLE
Fix persistent cursor offset in Proton games on multi-monitor setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /result
+.worktrees/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub trait XConnection: Sized + 'static {
     fn close_window(&mut self, window: x::Window);
     fn unmap_window(&mut self, window: x::Window);
     fn raise_to_top(&mut self, window: x::Window);
+    fn update_desktop_properties(&self, _outputs: &[(i32, i32, i32, i32)]) {}
 }
 
 pub trait X11Selection {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -656,6 +656,8 @@ impl<C: XConnection> ServerState<C> {
                 .unwrap();
         }
 
+        let mut outputs_changed = false;
+
         if self.global_output_offset.x.owner.is_none()
             || self.global_output_offset.y.owner.is_none()
         {
@@ -663,6 +665,7 @@ impl<C: XConnection> ServerState<C> {
             self.global_offset_updated = true;
         }
         if self.global_offset_updated {
+            outputs_changed = true;
             debug!(
                 target: "output_offset",
                 "updated global output offset: {}x{}",
@@ -681,6 +684,7 @@ impl<C: XConnection> ServerState<C> {
         }
 
         if !self.updated_outputs.is_empty() {
+            outputs_changed = true;
             for output in std::mem::take(&mut self.updated_outputs).iter() {
                 let Ok(output_scale) = self.world.get::<&OutputScaleFactor>(*output) else {
                     continue;
@@ -732,6 +736,21 @@ impl<C: XConnection> ServerState<C> {
                 debug!("Using new scale {scale}");
                 self.new_scale = Some(scale);
             }
+        }
+
+        // Update _NET_DESKTOP_GEOMETRY and _NET_WORKAREA when outputs change
+        if outputs_changed {
+            let outputs: Vec<_> = self
+                .world
+                .query::<&OutputDimensions>()
+                .iter()
+                .map(|(_, d)| {
+                    let x = d.x - self.global_output_offset.x.value;
+                    let y = d.y - self.global_output_offset.y.value;
+                    (x, y, d.width, d.height)
+                })
+                .collect();
+            self.connection.update_desktop_properties(&outputs);
         }
 
         {

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -1465,28 +1465,22 @@ impl XConnection for RealConnection {
                 warn!("Couldn't find output {name}, primary output will be wrong");
                 return;
             };
-            if output == self.primary_output {
-                debug!("primary output is already {name}");
-                return;
+            // Set primary once on first focus, then leave it alone.
+            // Rotating the primary on every focus change shifts the Xinerama
+            // origin and breaks cursor coordinate translation in Wine/Proton.
+            if self.primary_output == Xid::none() {
+                if let Err(e) = self
+                    .connection
+                    .send_and_check_request(&xcb::randr::SetOutputPrimary { window, output })
+                {
+                    warn!("Couldn't set output {name} as primary: {e:?}");
+                } else {
+                    debug!("set initial primary output to {name}");
+                    self.primary_output = output;
+                }
+            } else if output != self.primary_output {
+                debug!("focused window on {name} (primary remains {:?})", self.primary_output);
             }
-
-            if let Err(e) = self
-                .connection
-                .send_and_check_request(&xcb::randr::SetOutputPrimary { window, output })
-            {
-                warn!("Couldn't set output {name} as primary: {e:?}");
-            } else {
-                debug!("set {name} as primary output");
-                self.primary_output = output;
-            }
-        } else {
-            let _ = self
-                .connection
-                .send_and_check_request(&xcb::randr::SetOutputPrimary {
-                    window,
-                    output: Xid::none(),
-                });
-            self.primary_output = Xid::none();
         }
     }
 

--- a/src/xstate/mod.rs
+++ b/src/xstate/mod.rs
@@ -293,6 +293,8 @@ impl XState {
                 self.atoms.net_wm_state,
                 self.atoms.wm_fullscreen,
                 self.atoms.moveresize,
+                self.atoms.net_desktop_geometry,
+                self.atoms.net_workarea,
             ],
         );
 
@@ -920,6 +922,8 @@ xcb::atoms_struct! {
         primary => b"PRIMARY" only_if_exists = false,
         primary_targets => b"_primary_targets" only_if_exists = false,
         moveresize => b"_NET_WM_MOVERESIZE" only_if_exists = false,
+        net_desktop_geometry => b"_NET_DESKTOP_GEOMETRY" only_if_exists = false,
+        net_workarea => b"_NET_WORKAREA" only_if_exists = false,
     }
 }
 
@@ -1328,6 +1332,63 @@ impl RealConnection {
 
 impl XConnection for RealConnection {
     type X11Selection = Selection;
+    fn update_desktop_properties(
+        &self,
+        outputs: &[(i32, i32, i32, i32)],
+    ) {
+        // Compute bounding box of all outputs
+        let mut min_x = 0i32;
+        let mut min_y = 0i32;
+        let mut max_x = 0i32;
+        let mut max_y = 0i32;
+        if let Some(first) = outputs.first() {
+            min_x = first.0;
+            min_y = first.1;
+            max_x = first.0 + first.2;
+            max_y = first.1 + first.3;
+            for &(x, y, w, h) in &outputs[1..] {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x + w);
+                max_y = max_y.max(y + h);
+            }
+        }
+        let width = (max_x - min_x) as u32;
+        let height = (max_y - min_y) as u32;
+
+        let root = self.root_window();
+
+        // _NET_DESKTOP_GEOMETRY: width, height
+        let _ = self.connection.send_and_check_request(&x::ChangeProperty::<u32> {
+            mode: x::PropMode::Replace,
+            window: root,
+            property: self.atoms.net_desktop_geometry,
+            r#type: x::ATOM_CARDINAL,
+            data: &[width, height],
+        });
+
+        // _NET_WORKAREA: x, y, width, height for each desktop area
+        // Report each output's full geometry as a work area
+        let mut workareas = Vec::with_capacity(outputs.len() * 4);
+        for &(x, y, w, h) in outputs {
+            workareas.push(x as u32);
+            workareas.push(y as u32);
+            workareas.push(w as u32);
+            workareas.push(h as u32);
+        }
+        let _ = self.connection.send_and_check_request(&x::ChangeProperty::<u32> {
+            mode: x::PropMode::Replace,
+            window: root,
+            property: self.atoms.net_workarea,
+            r#type: x::ATOM_CARDINAL,
+            data: &workareas,
+        });
+
+        debug!(
+            "desktop geometry: {width}x{height}, work areas: {outputs:?}"
+        );
+    }
+
     fn set_window_dims(
         &mut self,
         window: x::Window,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1547,10 +1547,13 @@ fn primary_output() {
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
     assert_eq!(reply.output(), output1);
 
+    // Primary should NOT change when focus moves to a different output.
+    // Rotating the primary on every focus change shifts the Xinerama origin
+    // and breaks cursor coordinate translation in Wine/Proton.
     f.testwl.focus_toplevel(surface2);
     std::thread::sleep(std::time::Duration::from_millis(10));
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
-    assert_eq!(reply.output(), output2);
+    assert_eq!(reply.output(), output1, "primary should remain stable after focus change");
 
     let wl_output3 = f.create_output(24, 46);
     f.testwl.move_surface_to_output(surface2, &wl_output3);
@@ -1565,7 +1568,10 @@ fn primary_output() {
         .find(|o| ![output1, output2].contains(o))
         .unwrap();
     let reply = conn.get_reply(&xcb::randr::GetOutputPrimary { window: conn.root });
-    assert_eq!(reply.output(), output3);
+    assert_eq!(
+        reply.output(), output1,
+        "primary should remain stable after output hotplug"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Two related fixes for Proton/Wine games losing cursor alignment when switching between monitors.

### 1. Set `_NET_DESKTOP_GEOMETRY` and `_NET_WORKAREA` on the root window

Wine queries these to determine monitor layout. When missing, it falls back to Xinerama with the warning:

```
warn:x11drv:get_work_area _NET_WORKAREA is not supported, Work areas may be incorrect.
```

The properties are now set at startup and updated when outputs or the global output offset change. Each output's full geometry is reported as a work area; `_NET_DESKTOP_GEOMETRY` is the bounding box of all outputs.

### 2. Keep the primary output stable

The root cause of the cursor offset: `SetOutputPrimary` was called on every focus change between monitors. This rotates the Xinerama coordinate origin — when a different monitor becomes primary, the entire X11 → Windows desktop coordinate mapping shifts by the monitor width. Proton games that cache their window position relative to the old origin compute cursor coordinates off by exactly one screen width.

With this fix, the primary output is set *once* on the first focus event, then never changed. The Xinerama coordinate system remains stable regardless of which monitor has focus.

**Test:** Updated `primary_output` integration test to verify the primary remains on the first-focused output after focus changes and output hotplug.

Fixes #339
Likely fixes #321, #66, #428, #385
Ref: #438