### PR TITLE
feat: syslog support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -20,8 +20,16 @@ body:
     id: problem
     attributes:
       label: Describe the issue.
-      value: |
-        **Please attach a log if applicable.**
+      description: |
+        Provide a debug log file.
+        If integrated with the compositor with `systemd` as the init system, logs can be retrieved by running 
+
+        `journalctl --grep=xwayland-sat --output=short-iso-precise -b > "$(date -Iseconds).log"`.
+
+        If integrated with a different init system, the logs will be collected by the configured `syslog` daemon.
+        See your distribution's/`syslog` daemon's documentation for where the logs are kept (likely somewhere in `/var/log`).
+
+        If run directly, the logs are output to the console.
     validations:
       required: true
   - type: textarea
@@ -30,7 +38,14 @@ body:
       label: Steps to reproduce
   - type: checkboxes
     attributes:
-      label: Please confirm you have reproduced this on the latest commit.
+      label: Confirm you have reproduced this on the latest commit and attached log files.
+      description: "
+        To test the latest commit, build it according to the directions in the README, then launch it manually with
+        ```
+        ./xwayland-satellite -- :12
+        DISPLAY=:12 your-application
+        ```
+        "
       options:
         - label: I have reproduced this on the latest commit
           required: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syslog"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019f1500a13379b7d051455df397c75770de6311a7a188a699499502704d9f10"
+dependencies = [
+ "hostname",
+ "libc",
+ "log",
+ "time",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,6 +1279,7 @@ dependencies = [
  "rustix",
  "sd-notify",
  "smithay-client-toolkit",
+ "syslog",
  "testwl",
  "tiny-skia",
  "vergen-gitcl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ xcb = { version = "1.7.0", features = ["composite", "randr", "res"] }
 wl_drm = { path = "wl_drm" }
 log = "0.4.21"
 pretty_env_logger = "0.5.0"
+syslog = "7.0.0"
 xcb-util-cursor = "0.4"
 smithay-client-toolkit = { version = "0.20.0", default-features = false }
 

--- a/README.md
+++ b/README.md
@@ -4,38 +4,41 @@ This is particularly useful for compositors that (understandably) do not want to
 
 Found a bug? [Open a bug report.](https://github.com/Supreeeme/xwayland-satellite/issues/new?template=bug_report.yaml)
 
-Need help troubleshooting, or have some other general question? [Ask on GitHub Discussions.](https://github.com/Supreeeme/xwayland-satellite/discussions)
+## Building
 
-## Dependencies
+xwayland-satellite has the following dependencies:
 - Xwayland >=23.1
 - xcb
 - xcb-util-cursor
+- cargo (building only)
 - clang (building only)
+- git (building only, optional)
 
-## Usage
-Run `xwayland-satellite`. You can specify an X display to use (i.e. `:12`). Be sure to set the same `DISPLAY` environment variable for any X11 clients.
-Because xwayland-satellite is a Wayland client (in addition to being a Wayland compositor), it will need to launch after your compositor launches, but obviously before any X11 applications.
-
-## Java applications
-Some (most?) Java applications may present themselves as a blank screen by default with satellite. To fix this, simply set the environment variable
-`_JAVA_AWT_WM_NONREPARENTING=1` before launching it to fix this. Unfortunately there is not a way for satellite to automatically do this.
-
-## Building
 ```
 # dev build
 cargo build
 # release build
 cargo build --release
-
-# run - will also build if not already built
-cargo run # --release
 ```
 
-## Systemd support
-xwayland-satellite can be built with systemd support - simply add `-F systemd` to your build command - i.e. `cargo build --release -F systemd`.
+In addition, xwayland-satellite also has the following optional features, which can be enabled by adding the `-F <feature>` flag to the `cargo build` command:
 
-With systemd support, satellite will send a state change notification when Xwayland has been initialized, allowing for having services dependent on satellite's startup.
+### `systemd`
+With the `systemd` feature enabled, xwayland-satellite will send a state change notification when Xwayland has been initialized, allowing for services to depend on satellite's startup. This feature can be enabled without systemd installed, though it does nothing.
 
+### `fontconfig`
+The `fontconfig` feature uses fontconfig to load Open Sans at runtime instead of compiling Open Sans directly into the binary. The Open Sans font and `fontconfig` are runtime depenedencies when this feature is enabled.
+
+## Running
+
+Because xwayland-satellite is a Wayland client (in addition to being a Wayland compositor), it will need to launch after your compositor launches, but obviously before any X11 applications.
+
+The `RUST_LOG` environment variable can be set to `debug` to output higher levels of logging.
+
+### Manually
+Run the `xwayland-satellite` binary, or use `cargo run` (with or without `--release`). You can specify an X display to use (i.e. `:12`). Be sure to set the same `DISPLAY` environment variable for any X11 clients. Setting the display allows you to choose which instance of `satellite` the X11 client communicates with, which can be useful for debugging crashes or bypassing automatically started instances (see below).
+
+### Systemd support
 An example service file is located in `resources/xwayland-satellite.service` - be sure to replace the `ExecStart` line with the proper location before using it.
 It can be placed in a systemd user unit directory (i.e. `$XDG_CONFIG_HOME/systemd/user` or `/etc/systemd/user`),
 and be launched and enabled with `systemctl --user enable --now xwayland-satellite`.
@@ -44,17 +47,17 @@ which is likely after your compositor is started if it supports systemd.
 
 Note that you *do not* need the systemd service if the compositor already integrates xwayland-satellite (see below).
 
-## Scaling/HiDPI
-For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
-the smallest monitor's DPI, meaning apps may have small text on other monitors.
+### Compositor integration
+Satellite supports passing through the `-listenfd` Xwayland argument. What this means is you can integrate satellite
+(and by extension Xwayland) into your compositor, and do things like on demand activation. Note that you *must* pass
+a display number to satellite as the first argument, and then the `-listenfd` argument.
 
-Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
-so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.
+You can view [Niri's implementation of this integration](https://github.com/YaLTeR/niri/pull/1728/files) for understanding
+how it should work.
 
-Satellite acts as an Xsettings manager for setting scaling related settings, but will get out of the way of other Xsettings managers.
-To manually set these settings, try [xsettingsd](https://codeberg.org/derat/xsettingsd) or another Xsettings manager.
+If `satellite` is integrated into your compositor, updating either `xwayland-satellite` or your compositor's satellite settings requires restarting the compositor. To test latest commit and/or patches without restarting the compositor, add a display when launching `xwayland-satellite` and use the same `DISPLAY` environment variables for applications you wish to test.
 
-## Wayland protocols used
+## Wayland protocols
 The host compositor **must** implement the following protocols/interfaces for satellite to function:
 - Core interfaces (wl_output, wl_surface, wl_compositor, etc)
 - xdg_shell (xdg_wm_base, xdg_surface, xdg_popup, xdg_toplevel)
@@ -63,15 +66,27 @@ The host compositor **must** implement the following protocols/interfaces for sa
 Additionally, satellite can *optionally* take advantage of the following protocols:
 - Linux dmabuf
 - XDG activation
+- XDG decoration
 - XDG foreign
 - Pointer constraints
+- Primary selection
 - Tablet input
 - Fractional scale
 
-## Compositor integration
-Satellite supports passing through the `-listenfd` Xwayland argument. What this means is you can integrate satellite
-(and by extension Xwayland) into your compositor, and do things like on demand activation. Note that you *must* pass
-a display number to satellite as the first argument, and then the `-listenfd` argument.
+## Troubleshooting
 
-You can view [Niri's implementation of this integration](https://github.com/YaLTeR/niri/pull/1728/files) for understanding
-how it should work.
+Need help troubleshooting, or have some other general question? [Ask on GitHub Discussions.](https://github.com/Supreeeme/xwayland-satellite/discussions)
+
+### Java applications
+Some Java applications may present themselves as a blank screen by default with satellite. To fix this, simply set the environment variable
+`_JAVA_AWT_WM_NONREPARENTING=1` before launching it to fix this. Although `satellite` cannot automatically do this, you can configure Java to do this by adding `set _JAVA_AWT_WM_NONREPARENTING=1` to `/etc/profile.d/jre.sh`.
+
+### Scaling/HiDPI
+For most GTK and Qt apps, xwayland-satellite should automatically scale them properly. Note that for mixed DPI monitor setups, satellite will choose
+the smallest monitor's DPI, meaning apps may have small text on other monitors.
+
+Other miscellaneous apps (such as Wine apps) may have small text on HiDPI displays. It is application dependent on getting apps to scale properly with satellite,
+so you will have to figure out what app specific config needs to be set. See [the Arch Wiki on HiDPI](https://wiki.archlinux.org/title/HiDPI) for a good place start.
+
+Satellite acts as an Xsettings manager for setting scaling related settings, but will get out of the way of other Xsettings managers.
+To manually set these settings, try [xsettingsd](https://codeberg.org/derat/xsettingsd) or another Xsettings manager.

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,17 @@ fn init_logger(integrated: bool) {
             Ok(syslog) => {
                 log::set_boxed_logger(Box::new(syslog::BasicLogger::new(syslog))).unwrap();
                 log::set_max_level(log::LevelFilter::Debug);
+                std::panic::set_hook(Box::new(|info| {
+                    let thread = std::thread::current();
+                    let name = thread.name().unwrap_or("<unnamed");
+                    let location = info.location().unwrap();
+                    log::error!("thread '{name}' panicked at {location}:");
+                    if let Some(s) = info.payload().downcast_ref::<&str>() {
+                        log::error!("{s}");
+                    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+                        log::error!("{s}");
+                    }
+                }));
                 return;
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
 fn main() {
-    pretty_env_logger::formatted_timed_builder()
-        .filter_level(log::LevelFilter::Info)
-        .parse_default_env()
-        .init();
-    xwayland_satellite::main(parse_args());
+    let arg_data = parse_args();
+    init_logger(!arg_data.listenfds.is_empty());
+    xwayland_satellite::main(arg_data);
 }
 
 #[derive(Default)]
@@ -245,4 +243,23 @@ fn parse_args() -> RealData {
     data.flags = flags.to_vec();
 
     data
+}
+
+fn init_logger(integrated: bool) {
+    if integrated {
+        match syslog::unix(syslog::Formatter3164::default()) {
+            Ok(syslog) => {
+                log::set_boxed_logger(Box::new(syslog::BasicLogger::new(syslog))).unwrap();
+                log::set_max_level(log::LevelFilter::Debug);
+                return;
+            }
+            Err(e) => {
+                eprintln!("failed to start syslog: {e:?}");
+            }
+        };
+    }
+    pretty_env_logger::formatted_timed_builder()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
+        .init();
 }


### PR DESCRIPTION
Here is the `syslog` version of #414. Haven't updated the documentation yet (I'm tired).

Yes, the panic hook is important. Unwinding is considered "normal" process termination and is not caught by `coredumpctl` or similar utilities (unlike, for example, segfaulting).

I'll probably ask users with `systemd-journald` something like:
`journalctl --grep=xwayland-sat --output=short-iso-precise -b > "$(date -Iseconds).log"`.
Users without `systemd` will have to figure out where in `/var/log` their syslog daemon outputs to, but that shouldn't be too hard to explain.