### PR TITLE
Drop parent copy of the Xwayland WM socket after spawn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@ pub fn main(mut data: impl RunData) -> Option<()> {
 
     // Now that Xwayland spawned and got the listenfds, we can close them here.
     drop(fds);
+    // Close our copy of the WM socket so Xwayland exiting produces EOF on xsock_wl.
+    drop(xsock_xwl);
 
     let xwl_pid = xwayland.id();
 


### PR DESCRIPTION
Refs #130.

## Problem

xwayland-satellite creates a socket pair for communication with
Xwayland. It passes `xsock_xwl` to Xwayland through `-wm`, but the
satellite process retains its own copy after spawning Xwayland.

A Unix socket reports EOF only after all references to 
the peer end are closed. If Xwayland exits, the retained 
copy prevents `xsock_wl` from reporting EOF.

If `satellite` is in a blocking xcb request when Xwayland exits, that request can hang indefinitely. `Satellite` then does not return to the main poll loop to read the Xwayland exit status. Its Wayland toplevels remain visible as frozen windows.

## Change

Drop `xsock_xwl` after spawning Xwayland, next to the
`drop(fds)` call.

## Verification

- `cargo fmt --check`
- `cargo build --all-targets --profile ci --locked`
- `cargo test --profile ci --locked -- --test-threads 1 --nocapture`
- `cargo clippy --all-targets --profile ci --locked --workspace`

All pass

## Notes

This change makes a dead Xwayland connection observable by libxcb.
Some dead-connection paths currently panic instead of shutting down cleanly, 
including `poll_for_event().unwrap()` in `handle_events`.

This issue is not addressed in this PR because it is a larger behavioral change.